### PR TITLE
feat: cloud LLM providers, Docker fixes, Helm chart improvements

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,7 +83,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            RUST_VERSION=1.85
+            RUST_VERSION=1.93
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             VCS_REF=${{ github.sha }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -147,7 +147,7 @@ jobs:
         id: inspect
         run: |
           tag=$(jq -r '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          digest=$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')
+          digest=$(docker buildx imagetools inspect "$tag" --raw | jq -r '.manifests[0].digest // .digest')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
   scan:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,23 +34,88 @@ env:
 
 jobs:
   build:
-    name: Build and Push
-    runs-on: ubuntu-latest
-    outputs:
-      digest: ${{ steps.build-push.outputs.digest }}
-      tags: ${{ steps.meta.outputs.tags }}
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          build-args: |
+            RUST_VERSION=1.93
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+            VCS_REF=${{ github.sha }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.runner }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge Manifests
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name != 'pull_request'
+    outputs:
+      digest: ${{ steps.inspect.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -71,39 +136,23 @@ jobs:
             type=sha,prefix=sha-
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 
-      - name: Build and push
-        id: build-push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            RUST_VERSION=1.93
-            BUILD_DATE=${{ github.event.head_commit.timestamp }}
-            VCS_REF=${{ github.sha }}
-
-      - name: Export digest
-        if: github.event_name != 'pull_request'
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
         run: |
-          mkdir -p /tmp/digests
-          echo "${{ steps.build-push.outputs.digest }}" > /tmp/digests/digest.txt
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
-      - name: Upload digest
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests
-          path: /tmp/digests
-          retention-days: 1
+      - name: Inspect image
+        id: inspect
+        run: |
+          tag=$(jq -r '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          digest=$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
   scan:
     name: Security Scan
-    needs: build
+    needs: merge
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     steps:
@@ -120,7 +169,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.merge.outputs.digest }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
@@ -134,7 +183,7 @@ jobs:
       - name: Run Trivy for summary
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.merge.outputs.digest }}
           format: 'table'
           severity: 'CRITICAL,HIGH,MEDIUM'
           vuln-type: 'os,library'
@@ -142,7 +191,7 @@ jobs:
 
   sign:
     name: Sign Image
-    needs: [build, scan]
+    needs: [merge, scan]
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')
     steps:
@@ -158,14 +207,14 @@ jobs:
 
       - name: Sign image with Cosign
         env:
-          DIGEST: ${{ needs.build.outputs.digest }}
+          DIGEST: ${{ needs.merge.outputs.digest }}
           COSIGN_EXPERIMENTAL: 1
         run: |
           cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}
 
       - name: Verify signature
         env:
-          DIGEST: ${{ needs.build.outputs.digest }}
+          DIGEST: ${{ needs.merge.outputs.digest }}
           COSIGN_EXPERIMENTAL: 1
         run: |
           cosign verify ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST} \
@@ -174,7 +223,7 @@ jobs:
 
   sbom:
     name: Generate SBOM
-    needs: build
+    needs: merge
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')
     steps:
@@ -188,7 +237,7 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.merge.outputs.digest }}
           artifact-name: sbom-aeterna.spdx.json
           output-file: ./sbom-aeterna.spdx.json
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,7 +83,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            RUST_VERSION=1.83
+            RUST_VERSION=1.85
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             VCS_REF=${{ github.sha }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker Build
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     tags:
       - 'v*'
     paths:
@@ -13,7 +13,7 @@ on:
       - 'Dockerfile'
       - '.github/workflows/docker.yml'
   pull_request:
-    branches: [main]
+    branches: [master]
     paths:
       - 'Cargo.toml'
       - 'Cargo.lock'
@@ -69,7 +69,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,prefix=sha-
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 
       - name: Build and push
         id: build-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.83
+ARG RUST_VERSION=1.85
 
 FROM rust:${RUST_VERSION}-bookworm AS chef
 RUN cargo install cargo-chef

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.85
+ARG RUST_VERSION=1.93
 
 FROM rust:${RUST_VERSION}-bookworm AS chef
 RUN cargo install cargo-chef

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,108 @@ The rest of this file remains focused on Code Search repository management deplo
 
 ---
 
+## Server-Side LLM Provider Deployment
+
+Aeterna can construct server-side LLM and embedding services at startup from deployment configuration. The runtime currently supports these provider values through `AETERNA_LLM_PROVIDER`:
+
+- `openai`
+- `google`
+- `bedrock`
+- `none`
+
+### Common Runtime Selection
+
+Set the provider explicitly:
+
+```bash
+export AETERNA_LLM_PROVIDER=openai
+```
+
+If you set `AETERNA_LLM_PROVIDER=none`, provider-dependent memory and reasoning operations fail closed instead of silently falling back.
+
+### OpenAI
+
+```bash
+export AETERNA_LLM_PROVIDER=openai
+export OPENAI_API_KEY=your-api-key
+export AETERNA_OPENAI_MODEL=gpt-4.1-mini
+export AETERNA_OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+```
+
+### Google Cloud (Vertex AI / Gemini)
+
+Required runtime settings:
+
+```bash
+export AETERNA_LLM_PROVIDER=google
+export AETERNA_GOOGLE_PROJECT_ID=my-gcp-project
+export AETERNA_GOOGLE_LOCATION=global
+export AETERNA_GOOGLE_MODEL=gemini-2.5-flash
+export AETERNA_GOOGLE_EMBEDDING_MODEL=text-embedding-005
+```
+
+Authentication is resolved in this order:
+
+1. `GOOGLE_ACCESS_TOKEN`
+2. Application Default Credentials via `GOOGLE_APPLICATION_CREDENTIALS`
+3. Ambient ADC in GCP runtimes such as GKE Workload Identity
+
+Example with a service-account key file:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/var/run/secrets/google/service-account.json
+```
+
+Operational notes:
+
+- the configured service account needs Vertex AI access in the configured project
+- the selected location and model identifiers must match enabled Vertex AI resources
+- missing project, location, or model configuration fails closed during provider construction
+
+### AWS Bedrock
+
+Required runtime settings:
+
+```bash
+export AETERNA_LLM_PROVIDER=bedrock
+export AETERNA_BEDROCK_REGION=eu-west-1
+export AETERNA_BEDROCK_MODEL=anthropic.claude-3-5-sonnet-20241022-v2:0
+export AETERNA_BEDROCK_EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
+```
+
+Authentication uses the normal AWS credential chain, including:
+
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+- `AWS_SESSION_TOKEN`
+- IAM roles for service accounts or instance profiles
+- shared AWS config/credential files
+
+Operational notes:
+
+- the runtime region must be a Bedrock-enabled region for the selected models
+- the workload identity must have permission to invoke the selected Bedrock models
+- missing region or model configuration fails closed during provider construction
+
+### Helm / Setup CLI Alignment
+
+The setup wizard and Helm chart emit the exact environment variables consumed by the runtime:
+
+- `AETERNA_LLM_PROVIDER`
+- `AETERNA_GOOGLE_PROJECT_ID`
+- `AETERNA_GOOGLE_LOCATION`
+- `AETERNA_GOOGLE_MODEL`
+- `AETERNA_GOOGLE_EMBEDDING_MODEL`
+- `AETERNA_BEDROCK_REGION`
+- `AETERNA_BEDROCK_MODEL`
+- `AETERNA_BEDROCK_EMBEDDING_MODEL`
+
+Use the chart examples for cloud deployments:
+
+- `charts/aeterna/examples/values-gke.yaml`
+- `charts/aeterna/examples/values-aws.yaml`
+
+---
+
 ## 🏗 System Architecture
 
 The Code Search Repository Management system follows a distributed, multi-tenant architecture designed for Kubernetes:

--- a/charts/aeterna/README.md
+++ b/charts/aeterna/README.md
@@ -184,7 +184,7 @@ cnpg:
 
 ```yaml
 llm:
-  provider: openai  # Options: openai, anthropic, ollama, none
+  provider: openai  # Options: openai, anthropic, ollama, google, bedrock, none
 
   openai:
     existingSecret: "openai-credentials"
@@ -201,6 +201,21 @@ llm:
     host: "http://ollama.default.svc:11434"
     model: "llama3.2"
     embeddingModel: "nomic-embed-text"
+
+  # Or Google Cloud Vertex AI / Gemini
+  google:
+    projectId: "my-gcp-project"
+    location: "us-central1"
+    model: "gemini-2.5-flash"
+    embeddingModel: "text-embedding-005"
+    # Optional: mount ADC credential JSON from an existing secret
+    existingSecret: "aeterna-google-llm"
+
+  # Or AWS Bedrock
+  bedrock:
+    region: "us-east-1"
+    model: "amazon.nova-micro-v1:0"
+    embeddingModel: "amazon.titan-embed-text-v2:0"
 ```
 
 ## OPAL Authorization Stack

--- a/charts/aeterna/ci/deployment-example-values.yaml
+++ b/charts/aeterna/ci/deployment-example-values.yaml
@@ -1,0 +1,105 @@
+# Example: Full deployment overlay
+#
+# Copy this file and fill in the placeholders for your environment.
+# Usage:
+#   cp deployment-example-values.yaml my-env-values.yaml
+#   # Edit my-env-values.yaml with your real values
+#   helm upgrade --install aeterna ./charts/aeterna -f my-env-values.yaml
+#
+# IMPORTANT: Never commit environment-specific values to the repository.
+# Add your file to .gitignore or keep it outside the repo.
+
+deploymentMode: local
+
+aeterna:
+  replicaCount: 1
+  image:
+    # tag: "latest"                       # Image tag to deploy
+    pullPolicy: Always
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: "${CLUSTER_ISSUER}"    # e.g. letsencrypt-prod
+      kubernetes.io/tls-acme: "true"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    hosts:
+      - host: "${INGRESS_HOST}"                              # e.g. aeterna.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: aeterna-tls
+        hosts:
+          - "${INGRESS_HOST}"
+  imagePullSecrets: []
+  # imagePullSecrets:
+  #   - name: ghcr-pull-secret
+
+cache:
+  type: valkey
+  dragonfly:
+    enabled: false
+  valkey:
+    enabled: true
+
+postgresql:
+  bundled: true
+  cloudnativepg:
+    enabled: true
+    instances: 1
+    storage:
+      size: 10Gi
+      storageClass: "${STORAGE_CLASS}"                       # e.g. gp3, standard, fast-ssd
+
+opal:
+  server:
+    replicaCount: 1
+
+observability:
+  serviceMonitor:
+    enabled: false
+
+networkPolicy:
+  enabled: false
+
+global:
+  storageClass: "${STORAGE_CLASS}"
+
+cnpg:
+  enabled: false
+
+dragonfly:
+  enabled: false
+
+valkey:
+  enabled: true
+  auth:
+    enabled: false
+  metrics:
+    enabled: false
+  dataStorage:
+    enabled: true
+    requestedSize: 10Gi
+    className: "${STORAGE_CLASS}"
+
+qdrant:
+  enabled: true
+  replicaCount: 1
+  persistence:
+    size: 10Gi
+    storageClass: "${STORAGE_CLASS}"
+
+# --- LLM Provider Configuration ---
+# Uncomment and configure the provider you want to use.
+llm:
+  provider: google                                           # google | bedrock | openai | anthropic | ollama | none
+  google:
+    projectId: "${GCP_PROJECT_ID}"                           # e.g. my-gcp-project
+    location: "${GCP_LOCATION}"                              # e.g. us-central1
+    model: "gemini-2.5-flash"
+    embeddingModel: "text-embedding-005"
+    existingSecret: "${GOOGLE_CREDENTIALS_SECRET}"           # K8s secret name holding credentials.json
+    secretKey: "credentials.json"
+    wifTokenAudience: "${WIF_AUDIENCE}"                      # //iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL/providers/PROVIDER
+    wifTokenFile: "/var/run/secrets/tokens/gcp-token"

--- a/charts/aeterna/ci/internal-registry-example-values.yaml
+++ b/charts/aeterna/ci/internal-registry-example-values.yaml
@@ -1,0 +1,70 @@
+# Example: Internal registry mirror overlay
+#
+# Use this when your cluster requires pulling images through
+# a corporate registry mirror / proxy (e.g. Artifactory, Nexus, Harbor).
+#
+# Usage:
+#   cp internal-registry-example-values.yaml my-registry-values.yaml
+#   # Edit with your registry URL
+#   helm upgrade --install aeterna ./charts/aeterna \
+#     -f deployment-example-values.yaml \
+#     -f my-registry-values.yaml
+
+global:
+  imageRegistry: "${INTERNAL_REGISTRY}"                      # e.g. registry.corp.example.com
+  imagePullSecrets: []
+
+aeterna:
+  image:
+    repository: ghcrio/kikokikok/aeterna
+
+codesearch:
+  image:
+    repository: "${INTERNAL_REGISTRY}/ghcrio/kikokikok/codesearch"
+
+opal:
+  server:
+    image:
+      repository: "${INTERNAL_REGISTRY}/dockerhub/permitio/opal-server"
+  cedarAgent:
+    image:
+      repository: "${INTERNAL_REGISTRY}/dockerhub/permitio/cedar-agent"
+  fetcher:
+    image:
+      repository: "${INTERNAL_REGISTRY}/dockerhub/permitio/opal-client"
+
+cache:
+  type: valkey
+  dragonfly:
+    enabled: false
+  valkey:
+    enabled: true
+
+cnpg:
+  image:
+    repository: "${INTERNAL_REGISTRY}/ghcrio/cloudnative-pg/cloudnative-pg"
+
+qdrant:
+  image:
+    repository: "${INTERNAL_REGISTRY}/dockerhub/qdrant/qdrant"
+
+valkey:
+  enabled: true
+  auth:
+    enabled: false
+  image:
+    registry: "${INTERNAL_REGISTRY}"
+    repository: dockerhub/valkey/valkey
+  metrics:
+    enabled: false
+
+weaviate:
+  enabled: false
+
+mongodb:
+  enabled: false
+
+backup:
+  enabled: false
+  verify:
+    enabled: false

--- a/charts/aeterna/examples/values-aws.yaml
+++ b/charts/aeterna/examples/values-aws.yaml
@@ -107,6 +107,13 @@ opal:
   server:
     replicaCount: 3
 
+llm:
+  provider: bedrock
+  bedrock:
+    region: "us-east-1"
+    model: "amazon.nova-micro-v1:0"
+    embeddingModel: "amazon.titan-embed-text-v2:0"
+
 # Observability
 observability:
   serviceMonitor:

--- a/charts/aeterna/examples/values-gke.yaml
+++ b/charts/aeterna/examples/values-gke.yaml
@@ -105,6 +105,14 @@ opal:
   server:
     replicaCount: 3
 
+llm:
+  provider: google
+  google:
+    projectId: "project-id"
+    location: "us-central1"
+    model: "gemini-2.5-flash"
+    embeddingModel: "text-embedding-005"
+
 # Observability
 observability:
   serviceMonitor:

--- a/charts/aeterna/templates/aeterna/configmap.yaml
+++ b/charts/aeterna/templates/aeterna/configmap.yaml
@@ -66,6 +66,17 @@ data:
   AETERNA_OLLAMA_MODEL: {{ .Values.llm.ollama.model | quote }}
   AETERNA_OLLAMA_EMBEDDING_MODEL: {{ .Values.llm.ollama.embeddingModel | quote }}
   {{- end }}
+  {{- if eq .Values.llm.provider "google" }}
+  AETERNA_GOOGLE_PROJECT_ID: {{ .Values.llm.google.projectId | quote }}
+  AETERNA_GOOGLE_LOCATION: {{ .Values.llm.google.location | quote }}
+  AETERNA_GOOGLE_MODEL: {{ .Values.llm.google.model | quote }}
+  AETERNA_GOOGLE_EMBEDDING_MODEL: {{ .Values.llm.google.embeddingModel | quote }}
+  {{- end }}
+  {{- if eq .Values.llm.provider "bedrock" }}
+  AETERNA_BEDROCK_REGION: {{ .Values.llm.bedrock.region | quote }}
+  AETERNA_BEDROCK_MODEL: {{ .Values.llm.bedrock.model | quote }}
+  AETERNA_BEDROCK_EMBEDDING_MODEL: {{ .Values.llm.bedrock.embeddingModel | quote }}
+  {{- end }}
   {{- end }}
   {{- if .Values.observability.tracing.enabled }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.observability.tracing.endpoint | quote }}

--- a/charts/aeterna/templates/aeterna/deployment.yaml
+++ b/charts/aeterna/templates/aeterna/deployment.yaml
@@ -126,6 +126,10 @@ spec:
                   name: {{ .Values.llm.anthropic.existingSecret | default (printf "%s-anthropic" (include "aeterna.fullname" .)) }}
                   key: api-key
             {{- end }}
+            {{- if and (eq .Values.llm.provider "google") .Values.llm.google.existingSecret }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/run/aeterna/google/{{ .Values.llm.google.secretKey }}
+            {{- end }}
             {{- if and (eq .Values.vectorBackend.type "pinecone") }}
             - name: AETERNA_PINECONE_API_KEY
               valueFrom:
@@ -168,6 +172,11 @@ spec:
               mountPath: /tmp
             - name: cache
               mountPath: /home/aeterna/.cache
+            {{- if and (eq .Values.llm.provider "google") .Values.llm.google.existingSecret }}
+            - name: google-application-credentials
+              mountPath: /var/run/aeterna/google
+              readOnly: true
+            {{- end }}
         {{- if .Values.codesearch.enabled }}
         - name: codesearch
           image: {{ .Values.codesearch.image.repository }}:{{ .Values.codesearch.image.tag }}
@@ -231,6 +240,11 @@ spec:
           emptyDir: {}
         - name: cache
           emptyDir: {}
+        {{- if and (eq .Values.llm.provider "google") .Values.llm.google.existingSecret }}
+        - name: google-application-credentials
+          secret:
+            secretName: {{ .Values.llm.google.existingSecret }}
+        {{- end }}
         {{- if .Values.codesearch.enabled }}
         - name: codesearch-config
           configMap:

--- a/charts/aeterna/templates/aeterna/deployment.yaml
+++ b/charts/aeterna/templates/aeterna/deployment.yaml
@@ -130,6 +130,10 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/run/aeterna/google/{{ .Values.llm.google.secretKey }}
             {{- end }}
+            {{- if and (eq .Values.llm.provider "google") .Values.llm.google.wifTokenAudience }}
+            - name: GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES
+              value: "0"
+            {{- end }}
             {{- if and (eq .Values.vectorBackend.type "pinecone") }}
             - name: AETERNA_PINECONE_API_KEY
               valueFrom:
@@ -175,6 +179,11 @@ spec:
             {{- if and (eq .Values.llm.provider "google") .Values.llm.google.existingSecret }}
             - name: google-application-credentials
               mountPath: /var/run/aeterna/google
+              readOnly: true
+            {{- end }}
+            {{- if and (eq .Values.llm.provider "google") .Values.llm.google.wifTokenAudience }}
+            - name: google-external-account-token
+              mountPath: {{ dir .Values.llm.google.wifTokenFile }}
               readOnly: true
             {{- end }}
         {{- if .Values.codesearch.enabled }}
@@ -244,6 +253,15 @@ spec:
         - name: google-application-credentials
           secret:
             secretName: {{ .Values.llm.google.existingSecret }}
+        {{- end }}
+        {{- if and (eq .Values.llm.provider "google") .Values.llm.google.wifTokenAudience }}
+        - name: google-external-account-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: {{ base .Values.llm.google.wifTokenFile }}
+                  expirationSeconds: 3600
+                  audience: {{ .Values.llm.google.wifTokenAudience | quote }}
         {{- end }}
         {{- if .Values.codesearch.enabled }}
         - name: codesearch-config

--- a/charts/aeterna/templates/validation/_validation.tpl
+++ b/charts/aeterna/templates/validation/_validation.tpl
@@ -49,6 +49,33 @@ Validate PostgreSQL configuration.
 {{- end -}}
 
 {{/*
+Validate LLM provider configuration.
+*/}}
+{{- define "aeterna.validate.llm" -}}
+{{- if and (eq .Values.llm.provider "google") (not .Values.llm.google.projectId) -}}
+{{- fail "Invalid configuration: llm.provider=google requires llm.google.projectId to be set." -}}
+{{- end -}}
+{{- if and (eq .Values.llm.provider "google") (not .Values.llm.google.location) -}}
+{{- fail "Invalid configuration: llm.provider=google requires llm.google.location to be set." -}}
+{{- end -}}
+{{- if and (eq .Values.llm.provider "google") (not .Values.llm.google.model) -}}
+{{- fail "Invalid configuration: llm.provider=google requires llm.google.model to be set." -}}
+{{- end -}}
+{{- if and (eq .Values.llm.provider "google") (not .Values.llm.google.embeddingModel) -}}
+{{- fail "Invalid configuration: llm.provider=google requires llm.google.embeddingModel to be set." -}}
+{{- end -}}
+{{- if and (eq .Values.llm.provider "bedrock") (not .Values.llm.bedrock.region) -}}
+{{- fail "Invalid configuration: llm.provider=bedrock requires llm.bedrock.region to be set." -}}
+{{- end -}}
+{{- if and (eq .Values.llm.provider "bedrock") (not .Values.llm.bedrock.model) -}}
+{{- fail "Invalid configuration: llm.provider=bedrock requires llm.bedrock.model to be set." -}}
+{{- end -}}
+{{- if and (eq .Values.llm.provider "bedrock") (not .Values.llm.bedrock.embeddingModel) -}}
+{{- fail "Invalid configuration: llm.provider=bedrock requires llm.bedrock.embeddingModel to be set." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Validate Code Search image support.
 The default repository is not built by this repo's image workflow, so operators
 must supply an explicit published mirror/repository when enabling the sidecar.
@@ -106,6 +133,7 @@ Run all validations. Include this once in a rendered resource.
 {{- include "aeterna.validate.deploymentMode" . -}}
 {{- include "aeterna.validate.vectorBackend" . -}}
 {{- include "aeterna.validate.postgresql" . -}}
+{{- include "aeterna.validate.llm" . -}}
 {{- include "aeterna.validate.codesearch" . -}}
 {{- include "aeterna.validate.secrets" . -}}
 {{- include "aeterna.validate.okta" . -}}

--- a/charts/aeterna/values.schema.json
+++ b/charts/aeterna/values.schema.json
@@ -394,7 +394,7 @@
       "type": "object",
       "description": "LLM provider configuration",
       "properties": {
-        "provider": { "type": "string", "enum": ["openai", "anthropic", "ollama", "none"], "default": "none" },
+        "provider": { "type": "string", "enum": ["openai", "anthropic", "ollama", "google", "bedrock", "none"], "default": "none" },
         "openai": {
           "type": "object",
           "properties": {
@@ -418,6 +418,25 @@
             "host": { "type": "string", "default": "http://localhost:11434" },
             "model": { "type": "string", "default": "llama3.2" },
             "embeddingModel": { "type": "string", "default": "nomic-embed-text" }
+          }
+        },
+        "google": {
+          "type": "object",
+          "properties": {
+            "projectId": { "type": "string", "default": "" },
+            "location": { "type": "string", "default": "us-central1" },
+            "model": { "type": "string", "default": "gemini-2.5-flash" },
+            "embeddingModel": { "type": "string", "default": "text-embedding-005" },
+            "existingSecret": { "type": "string", "default": "" },
+            "secretKey": { "type": "string", "default": "credentials.json" }
+          }
+        },
+        "bedrock": {
+          "type": "object",
+          "properties": {
+            "region": { "type": "string", "default": "us-east-1" },
+            "model": { "type": "string", "default": "amazon.nova-micro-v1:0" },
+            "embeddingModel": { "type": "string", "default": "amazon.titan-embed-text-v2:0" }
           }
         }
       }

--- a/charts/aeterna/values.yaml
+++ b/charts/aeterna/values.yaml
@@ -634,6 +634,10 @@ llm:
     existingSecret: ""
     ## @param llm.google.secretKey Secret key containing the credential file payload
     secretKey: "credentials.json"
+    ## @param llm.google.wifTokenAudience Audience for projected Kubernetes service account token used by external WIF ADC
+    wifTokenAudience: ""
+    ## @param llm.google.wifTokenFile Path for projected Kubernetes service account token used by external WIF ADC
+    wifTokenFile: "/var/run/secrets/tokens/gcp-token"
 
   ## AWS Bedrock configuration
   bedrock:

--- a/charts/aeterna/values.yaml
+++ b/charts/aeterna/values.yaml
@@ -588,7 +588,7 @@ okta:
 
 ## LLM provider configuration
 llm:
-  ## @param llm.provider LLM provider: openai, anthropic, ollama, none
+  ## @param llm.provider LLM provider: openai, anthropic, ollama, google, bedrock, none
   provider: none
 
   ## OpenAI configuration
@@ -619,6 +619,30 @@ llm:
     model: "llama3.2"
     ## @param llm.ollama.embeddingModel Embedding model name
     embeddingModel: "nomic-embed-text"
+
+  ## Google Cloud Vertex AI / Gemini configuration
+  google:
+    ## @param llm.google.projectId Google Cloud project ID
+    projectId: ""
+    ## @param llm.google.location Vertex AI location
+    location: "us-central1"
+    ## @param llm.google.model Google generation model
+    model: "gemini-2.5-flash"
+    ## @param llm.google.embeddingModel Google embedding model
+    embeddingModel: "text-embedding-005"
+    ## @param llm.google.existingSecret Existing secret containing ADC credential file
+    existingSecret: ""
+    ## @param llm.google.secretKey Secret key containing the credential file payload
+    secretKey: "credentials.json"
+
+  ## AWS Bedrock configuration
+  bedrock:
+    ## @param llm.bedrock.region AWS region
+    region: "us-east-1"
+    ## @param llm.bedrock.model Bedrock generation model ID
+    model: "amazon.nova-micro-v1:0"
+    ## @param llm.bedrock.embeddingModel Bedrock embedding model ID
+    embeddingModel: "amazon.titan-embed-text-v2:0"
 
 ## Observability configuration
 observability:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,7 @@ context.workspace = true
 config.workspace = true
 errors.workspace = true
 storage.workspace = true
+memory = { workspace = true, features = ["llm-integration", "embedding-integration", "google-provider", "bedrock-provider"] }
 
 clap = { version = "4.5", features = ["derive", "env", "wrap_help"] }
 clap_complete = "4.5"
@@ -42,5 +43,6 @@ regex = "1.11"
 
 [dev-dependencies]
 tempfile.workspace = true
+serial_test.workspace = true
 assert_cmd = "2.0"
 predicates = "3.1"

--- a/cli/src/commands/serve.rs
+++ b/cli/src/commands/serve.rs
@@ -1,4 +1,10 @@
 use clap::Args;
+use std::sync::Arc;
+
+use memory::embedding::create_embedding_service_from_env;
+use memory::llm::create_llm_service_from_env;
+use memory::manager::MemoryManager;
+use memory::reasoning::{DefaultReflectiveReasoner, ReflectiveReasoner};
 
 #[derive(Args)]
 pub struct ServeArgs {
@@ -20,7 +26,36 @@ pub struct ServeArgs {
 
     /// Log level (trace, debug, info, warn, error)
     #[arg(long, default_value = "info")]
-    pub log_level: String
+    pub log_level: String,
+}
+
+struct RuntimeProviderServices {
+    memory_manager: Arc<MemoryManager>,
+    reasoner: Option<Arc<dyn ReflectiveReasoner>>,
+}
+
+fn bootstrap_runtime_provider_services() -> anyhow::Result<RuntimeProviderServices> {
+    let mut manager = MemoryManager::new();
+
+    if let Some(embedding_service) = create_embedding_service_from_env()? {
+        manager = manager.with_embedding_service(embedding_service);
+    }
+
+    let reasoner = if let Some(llm_service) = create_llm_service_from_env()? {
+        let reasoner: Arc<dyn ReflectiveReasoner> =
+            Arc::new(DefaultReflectiveReasoner::new(llm_service.clone()));
+        manager = manager
+            .with_llm_service(llm_service)
+            .with_reasoner(reasoner.clone());
+        Some(reasoner)
+    } else {
+        None
+    };
+
+    Ok(RuntimeProviderServices {
+        memory_manager: Arc::new(manager),
+        reasoner,
+    })
 }
 
 pub fn run(args: ServeArgs) -> anyhow::Result<()> {
@@ -69,7 +104,19 @@ pub fn run(args: ServeArgs) -> anyhow::Result<()> {
     // will be wired in when the server crate is integrated.
     let addr = format!("{}:{}", args.bind, args.port);
     tracing::info!("Aeterna API server starting on http://{}", addr);
-    tracing::info!("Metrics endpoint on http://{}:{}/metrics", args.bind, args.metrics_port);
+    tracing::info!(
+        "Metrics endpoint on http://{}:{}/metrics",
+        args.bind,
+        args.metrics_port
+    );
+
+    let runtime = bootstrap_runtime_provider_services()?;
+    tracing::info!(
+        llm_enabled = runtime.reasoner.is_some(),
+        provider_backed_memory_manager = true,
+        "Runtime provider services initialized"
+    );
+    let _ = runtime.memory_manager;
 
     // Runtime is already provided by the #[tokio::main] in main.rs.
     // This function is synchronous; the actual async server loop will be
@@ -87,6 +134,29 @@ pub fn run(args: ServeArgs) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    fn set_base_runtime_env() {
+        unsafe {
+            std::env::set_var("AETERNA_POSTGRESQL_HOST", "localhost");
+            std::env::set_var("AETERNA_POSTGRESQL_DATABASE", "aeterna");
+            std::env::set_var("AETERNA_LLM_PROVIDER", "none");
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("AETERNA_OPENAI_MODEL");
+            std::env::remove_var("AETERNA_OPENAI_EMBEDDING_MODEL");
+        }
+    }
+
+    fn clear_runtime_env() {
+        unsafe {
+            std::env::remove_var("AETERNA_POSTGRESQL_HOST");
+            std::env::remove_var("AETERNA_POSTGRESQL_DATABASE");
+            std::env::remove_var("AETERNA_LLM_PROVIDER");
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("AETERNA_OPENAI_MODEL");
+            std::env::remove_var("AETERNA_OPENAI_EMBEDDING_MODEL");
+        }
+    }
 
     #[test]
     fn test_serve_args_defaults() {
@@ -95,7 +165,7 @@ mod tests {
             port: 8080,
             metrics_port: 9090,
             config: None,
-            log_level: "info".to_string()
+            log_level: "info".to_string(),
         };
         assert_eq!(args.bind, "0.0.0.0");
         assert_eq!(args.port, 8080);
@@ -111,7 +181,7 @@ mod tests {
             port: 3000,
             metrics_port: 3001,
             config: Some(std::path::PathBuf::from("/etc/aeterna")),
-            log_level: "debug".to_string()
+            log_level: "debug".to_string(),
         };
         assert_eq!(args.port, 3000);
         assert_eq!(args.metrics_port, 3001);
@@ -126,8 +196,10 @@ mod tests {
             bind: "0.0.0.0".to_string(),
             port: 8080,
             metrics_port: 9090,
-            config: Some(std::path::PathBuf::from("/nonexistent/path/that/does/not/exist")),
-            log_level: "info".to_string()
+            config: Some(std::path::PathBuf::from(
+                "/nonexistent/path/that/does/not/exist",
+            )),
+            log_level: "info".to_string(),
         };
         let result = run(args);
         assert!(result.is_err());
@@ -139,6 +211,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_serve_missing_env_vars_with_existing_config_path() {
         // Use a path that exists ("/tmp") so we pass the config check and hit
         // the environment variable check.
@@ -147,6 +220,8 @@ mod tests {
         unsafe {
             std::env::remove_var("AETERNA_POSTGRESQL_HOST");
             std::env::remove_var("AETERNA_POSTGRESQL_DATABASE");
+            std::env::set_var("AETERNA_LLM_PROVIDER", "none");
+            std::env::remove_var("OPENAI_API_KEY");
         }
 
         let args = ServeArgs {
@@ -154,7 +229,7 @@ mod tests {
             port: 8080,
             metrics_port: 9090,
             config: Some(std::path::PathBuf::from("/tmp")),
-            log_level: "info".to_string()
+            log_level: "info".to_string(),
         };
         let result = run(args);
         assert!(result.is_err());
@@ -164,5 +239,60 @@ mod tests {
             msg.contains("AETERNA_POSTGRESQL") || msg.contains("not yet integrated"),
             "Expected AETERNA_POSTGRESQL or not-yet-integrated error, got: {msg}"
         );
+
+        clear_runtime_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_bootstrap_runtime_provider_services_allows_none_provider() {
+        set_base_runtime_env();
+
+        let services = bootstrap_runtime_provider_services().expect("bootstrap should succeed");
+        assert!(services.reasoner.is_none());
+
+        clear_runtime_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_bootstrap_runtime_provider_services_requires_openai_key() {
+        set_base_runtime_env();
+        unsafe {
+            std::env::set_var("AETERNA_LLM_PROVIDER", "openai");
+        }
+
+        let err = match bootstrap_runtime_provider_services() {
+            Ok(_) => panic!("expected openai provider bootstrap to fail without key"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("OPENAI_API_KEY"));
+
+        clear_runtime_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_serve_surfaces_provider_bootstrap_failure_before_not_integrated() {
+        unsafe {
+            std::env::set_var("AETERNA_POSTGRESQL_HOST", "localhost");
+            std::env::set_var("AETERNA_POSTGRESQL_DATABASE", "aeterna");
+            std::env::set_var("AETERNA_LLM_PROVIDER", "openai");
+            std::env::remove_var("OPENAI_API_KEY");
+        }
+
+        let args = ServeArgs {
+            bind: "0.0.0.0".to_string(),
+            port: 8080,
+            metrics_port: 9090,
+            config: Some(std::path::PathBuf::from("/tmp")),
+            log_level: "info".to_string(),
+        };
+        let result = run(args);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("OPENAI_API_KEY"), "unexpected error: {msg}");
+
+        clear_runtime_env();
     }
 }

--- a/cli/src/commands/setup/generators.rs
+++ b/cli/src/commands/setup/generators.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 
 use super::types::*;
 
@@ -145,6 +145,23 @@ pub fn generate_config_toml(config: &SetupConfig) -> String {
     content.push_str(&format!("provider = \"{:?}\"\n", config.llm_provider).to_lowercase());
     if let Some(host) = &config.ollama_host {
         content.push_str(&format!("ollama_host = \"{}\"\n", host));
+    }
+    if let Some(google) = &config.google_llm {
+        content.push_str(&format!("google_project_id = \"{}\"\n", google.project_id));
+        content.push_str(&format!("google_location = \"{}\"\n", google.location));
+        content.push_str(&format!("google_model = \"{}\"\n", google.model));
+        content.push_str(&format!(
+            "google_embedding_model = \"{}\"\n",
+            google.embedding_model
+        ));
+    }
+    if let Some(bedrock) = &config.bedrock_llm {
+        content.push_str(&format!("bedrock_region = \"{}\"\n", bedrock.region));
+        content.push_str(&format!("bedrock_model = \"{}\"\n", bedrock.model));
+        content.push_str(&format!(
+            "bedrock_embedding_model = \"{}\"\n",
+            bedrock.embedding_model
+        ));
     }
     content.push('\n');
 
@@ -396,6 +413,25 @@ pub fn generate_helm_values(config: &SetupConfig) -> String {
 
     content.push_str("llm:\n");
     content.push_str(&format!("  provider: {:?}\n", config.llm_provider).to_lowercase());
+    if let Some(google) = &config.google_llm {
+        content.push_str("  google:\n");
+        content.push_str(&format!("    projectId: \"{}\"\n", google.project_id));
+        content.push_str(&format!("    location: \"{}\"\n", google.location));
+        content.push_str(&format!("    model: \"{}\"\n", google.model));
+        content.push_str(&format!(
+            "    embeddingModel: \"{}\"\n",
+            google.embedding_model
+        ));
+    }
+    if let Some(bedrock) = &config.bedrock_llm {
+        content.push_str("  bedrock:\n");
+        content.push_str(&format!("    region: \"{}\"\n", bedrock.region));
+        content.push_str(&format!("    model: \"{}\"\n", bedrock.model));
+        content.push_str(&format!(
+            "    embeddingModel: \"{}\"\n",
+            bedrock.embedding_model
+        ));
+    }
     content.push('\n');
 
     content.push_str("ingress:\n");

--- a/cli/src/commands/setup/mod.rs
+++ b/cli/src/commands/setup/mod.rs
@@ -98,6 +98,47 @@ pub struct SetupArgs {
     )]
     pub ollama_host: String,
 
+    #[arg(long, help = "Google Cloud project ID for Vertex AI")]
+    pub google_project_id: Option<String>,
+
+    #[arg(
+        long,
+        default_value = "us-central1",
+        help = "Google Cloud location for Vertex AI"
+    )]
+    pub google_location: String,
+
+    #[arg(
+        long,
+        default_value = "gemini-2.5-flash",
+        help = "Google generation model"
+    )]
+    pub google_model: String,
+
+    #[arg(
+        long,
+        default_value = "text-embedding-005",
+        help = "Google embedding model"
+    )]
+    pub google_embedding_model: String,
+
+    #[arg(long, help = "AWS Bedrock region")]
+    pub bedrock_region: Option<String>,
+
+    #[arg(
+        long,
+        default_value = "amazon.nova-micro-v1:0",
+        help = "AWS Bedrock generation model"
+    )]
+    pub bedrock_model: String,
+
+    #[arg(
+        long,
+        default_value = "amazon.titan-embed-text-v2:0",
+        help = "AWS Bedrock embedding model"
+    )]
+    pub bedrock_embedding_model: String,
+
     #[arg(long, help = "Enable OpenCode integration")]
     pub opencode: Option<bool>,
 
@@ -292,6 +333,29 @@ fn run_non_interactive(args: &SetupArgs) -> Result<SetupConfig> {
         openai_api_key: args.openai_api_key.clone(),
         anthropic_api_key: args.anthropic_api_key.clone(),
         ollama_host: Some(args.ollama_host.clone()),
+        google_llm: if matches!(args.llm, Some(LlmProvider::Google)) {
+            Some(GoogleLlmConfig {
+                project_id: args.google_project_id.clone().ok_or_else(|| {
+                    anyhow::anyhow!("--google-project-id is required when --llm google")
+                })?,
+                location: args.google_location.clone(),
+                model: args.google_model.clone(),
+                embedding_model: args.google_embedding_model.clone(),
+            })
+        } else {
+            None
+        },
+        bedrock_llm: if matches!(args.llm, Some(LlmProvider::Bedrock)) {
+            Some(BedrockLlmConfig {
+                region: args.bedrock_region.clone().ok_or_else(|| {
+                    anyhow::anyhow!("--bedrock-region is required when --llm bedrock")
+                })?,
+                model: args.bedrock_model.clone(),
+                embedding_model: args.bedrock_embedding_model.clone(),
+            })
+        } else {
+            None
+        },
         opencode_enabled: args.opencode.unwrap_or(false),
         ingress_enabled: args.ingress.unwrap_or(false),
         ingress_host: args.ingress_host.clone(),
@@ -353,6 +417,11 @@ mod tests {
                 assert!(args.opal.is_none());
                 assert!(args.llm.is_none());
                 assert_eq!(args.ollama_host, "http://localhost:11434");
+                assert_eq!(args.google_location, "us-central1");
+                assert_eq!(args.google_model, "gemini-2.5-flash");
+                assert_eq!(args.google_embedding_model, "text-embedding-005");
+                assert_eq!(args.bedrock_model, "amazon.nova-micro-v1:0");
+                assert_eq!(args.bedrock_embedding_model, "amazon.titan-embed-text-v2:0");
             }
             _ => panic!("expected Setup command"),
         }
@@ -556,6 +625,13 @@ mod tests {
             openai_api_key: None,
             anthropic_api_key: None,
             ollama_host: "http://localhost:11434".to_string(),
+            google_project_id: None,
+            google_location: "us-central1".to_string(),
+            google_model: "gemini-2.5-flash".to_string(),
+            google_embedding_model: "text-embedding-005".to_string(),
+            bedrock_region: None,
+            bedrock_model: "amazon.nova-micro-v1:0".to_string(),
+            bedrock_embedding_model: "amazon.titan-embed-text-v2:0".to_string(),
             opencode: None,
             ingress: None,
             ingress_host: None,
@@ -597,6 +673,13 @@ mod tests {
             openai_api_key: None,
             anthropic_api_key: None,
             ollama_host: "http://localhost:11434".to_string(),
+            google_project_id: None,
+            google_location: "us-central1".to_string(),
+            google_model: "gemini-2.5-flash".to_string(),
+            google_embedding_model: "text-embedding-005".to_string(),
+            bedrock_region: None,
+            bedrock_model: "amazon.nova-micro-v1:0".to_string(),
+            bedrock_embedding_model: "amazon.titan-embed-text-v2:0".to_string(),
             opencode: None,
             ingress: None,
             ingress_host: None,
@@ -641,6 +724,13 @@ mod tests {
             openai_api_key: None,
             anthropic_api_key: None,
             ollama_host: "http://localhost:11434".to_string(),
+            google_project_id: None,
+            google_location: "us-central1".to_string(),
+            google_model: "gemini-2.5-flash".to_string(),
+            google_embedding_model: "text-embedding-005".to_string(),
+            bedrock_region: None,
+            bedrock_model: "amazon.nova-micro-v1:0".to_string(),
+            bedrock_embedding_model: "amazon.titan-embed-text-v2:0".to_string(),
             opencode: None,
             ingress: None,
             ingress_host: None,
@@ -674,5 +764,102 @@ normal = "visible"
         assert!(!masked.contains("tok-abc"));
         assert!(!masked.contains("s3cret"));
         assert!(masked.contains("visible"));
+    }
+
+    #[test]
+    fn test_run_non_interactive_google_requires_project() {
+        let args = SetupArgs {
+            non_interactive: true,
+            reconfigure: false,
+            validate: false,
+            show: false,
+            output: std::path::PathBuf::from("."),
+            target: Some(DeploymentTarget::DockerCompose),
+            mode: Some(DeploymentMode::Local),
+            central_url: None,
+            central_auth: None,
+            api_key: None,
+            vector_backend: None,
+            cache: None,
+            redis_host: None,
+            redis_port: 6379,
+            postgresql: None,
+            pg_host: None,
+            pg_port: 5432,
+            pg_database: "aeterna".to_string(),
+            opal: None,
+            llm: Some(LlmProvider::Google),
+            openai_api_key: None,
+            anthropic_api_key: None,
+            ollama_host: "http://localhost:11434".to_string(),
+            google_project_id: None,
+            google_location: "us-central1".to_string(),
+            google_model: "gemini-2.5-flash".to_string(),
+            google_embedding_model: "text-embedding-005".to_string(),
+            bedrock_region: None,
+            bedrock_model: "amazon.nova-micro-v1:0".to_string(),
+            bedrock_embedding_model: "amazon.titan-embed-text-v2:0".to_string(),
+            opencode: None,
+            ingress: None,
+            ingress_host: None,
+            service_monitor: None,
+            network_policy: None,
+            hpa: None,
+            pdb: None,
+        };
+        let result = run_non_interactive(&args);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("--google-project-id")
+        );
+    }
+
+    #[test]
+    fn test_run_non_interactive_bedrock_requires_region() {
+        let args = SetupArgs {
+            non_interactive: true,
+            reconfigure: false,
+            validate: false,
+            show: false,
+            output: std::path::PathBuf::from("."),
+            target: Some(DeploymentTarget::DockerCompose),
+            mode: Some(DeploymentMode::Local),
+            central_url: None,
+            central_auth: None,
+            api_key: None,
+            vector_backend: None,
+            cache: None,
+            redis_host: None,
+            redis_port: 6379,
+            postgresql: None,
+            pg_host: None,
+            pg_port: 5432,
+            pg_database: "aeterna".to_string(),
+            opal: None,
+            llm: Some(LlmProvider::Bedrock),
+            openai_api_key: None,
+            anthropic_api_key: None,
+            ollama_host: "http://localhost:11434".to_string(),
+            google_project_id: None,
+            google_location: "us-central1".to_string(),
+            google_model: "gemini-2.5-flash".to_string(),
+            google_embedding_model: "text-embedding-005".to_string(),
+            bedrock_region: None,
+            bedrock_model: "amazon.nova-micro-v1:0".to_string(),
+            bedrock_embedding_model: "amazon.titan-embed-text-v2:0".to_string(),
+            opencode: None,
+            ingress: None,
+            ingress_host: None,
+            service_monitor: None,
+            network_policy: None,
+            hpa: None,
+            pdb: None,
+        };
+        let result = run_non_interactive(&args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("--bedrock-region"));
     }
 }

--- a/cli/src/commands/setup/types.rs
+++ b/cli/src/commands/setup/types.rs
@@ -51,6 +51,8 @@ pub enum LlmProvider {
     Openai,
     Anthropic,
     Ollama,
+    Google,
+    Bedrock,
     None,
 }
 
@@ -103,6 +105,21 @@ pub struct DatabricksConfig {
     pub catalog: String,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GoogleLlmConfig {
+    pub project_id: String,
+    pub location: String,
+    pub model: String,
+    pub embedding_model: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BedrockLlmConfig {
+    pub region: String,
+    pub model: String,
+    pub embedding_model: String,
+}
+
 /// Hybrid mode: `local_cache_size_mb` is in MB, `sync_interval_secs` is in seconds.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HybridConfig {
@@ -152,6 +169,8 @@ pub struct SetupConfig {
     pub openai_api_key: Option<String>,
     pub anthropic_api_key: Option<String>,
     pub ollama_host: Option<String>,
+    pub google_llm: Option<GoogleLlmConfig>,
+    pub bedrock_llm: Option<BedrockLlmConfig>,
 
     pub opencode_enabled: bool,
 
@@ -187,6 +206,8 @@ impl Default for SetupConfig {
             openai_api_key: None,
             anthropic_api_key: None,
             ollama_host: None,
+            google_llm: None,
+            bedrock_llm: None,
             opencode_enabled: false,
             ingress_enabled: false,
             ingress_host: None,
@@ -311,6 +332,29 @@ mod tests {
             catalog: "main".into(),
         };
         assert_eq!(dc.catalog, "main");
+    }
+
+    #[test]
+    fn test_google_llm_config() {
+        let gc = GoogleLlmConfig {
+            project_id: "my-project".into(),
+            location: "us-central1".into(),
+            model: "gemini-2.5-flash".into(),
+            embedding_model: "text-embedding-005".into(),
+        };
+        assert_eq!(gc.project_id, "my-project");
+        assert_eq!(gc.location, "us-central1");
+    }
+
+    #[test]
+    fn test_bedrock_llm_config() {
+        let bc = BedrockLlmConfig {
+            region: "us-east-1".into(),
+            model: "amazon.nova-micro-v1:0".into(),
+            embedding_model: "amazon.titan-embed-text-v2:0".into(),
+        };
+        assert_eq!(bc.region, "us-east-1");
+        assert_eq!(bc.model, "amazon.nova-micro-v1:0");
     }
 
     #[test]
@@ -460,6 +504,17 @@ mod tests {
                 token: "dapi-tok".into(),
                 catalog: "main".into(),
             }),
+            google_llm: Some(GoogleLlmConfig {
+                project_id: "proj".into(),
+                location: "us-central1".into(),
+                model: "gemini-2.5-flash".into(),
+                embedding_model: "text-embedding-005".into(),
+            }),
+            bedrock_llm: Some(BedrockLlmConfig {
+                region: "us-east-1".into(),
+                model: "amazon.nova-micro-v1:0".into(),
+                embedding_model: "amazon.titan-embed-text-v2:0".into(),
+            }),
             ..SetupConfig::default()
         };
         let json = serde_json::to_string(&cfg).expect("serialize");
@@ -469,5 +524,7 @@ mod tests {
         assert!(d.mongodb.is_some());
         assert!(d.vertex_ai.is_some());
         assert!(d.databricks.is_some());
+        assert!(d.google_llm.is_some());
+        assert!(d.bedrock_llm.is_some());
     }
 }

--- a/cli/src/commands/setup/validators.rs
+++ b/cli/src/commands/setup/validators.rs
@@ -2,6 +2,8 @@ use std::path::Path;
 
 use anyhow::Result;
 
+use super::types::{LlmProvider, SetupConfig};
+
 pub struct ValidationResult {
     pub is_valid: bool,
     pub issues: Vec<String>,
@@ -37,6 +39,53 @@ pub fn validate_generated_values(yaml: &str) -> std::result::Result<(), Vec<Stri
     }
 }
 
+pub fn validate_setup_config(config: &SetupConfig) -> std::result::Result<(), Vec<String>> {
+    let mut issues = Vec::new();
+
+    match config.llm_provider {
+        LlmProvider::Google => {
+            let google = config.google_llm.as_ref();
+            if google.is_none() {
+                issues.push("google provider requires google_llm configuration".to_string());
+            }
+            if google.is_none_or(|g| g.project_id.trim().is_empty()) {
+                issues.push("google provider requires a non-empty project_id".to_string());
+            }
+            if google.is_none_or(|g| g.location.trim().is_empty()) {
+                issues.push("google provider requires a non-empty location".to_string());
+            }
+            if google.is_none_or(|g| g.model.trim().is_empty()) {
+                issues.push("google provider requires a non-empty model".to_string());
+            }
+            if google.is_none_or(|g| g.embedding_model.trim().is_empty()) {
+                issues.push("google provider requires a non-empty embedding_model".to_string());
+            }
+        }
+        LlmProvider::Bedrock => {
+            let bedrock = config.bedrock_llm.as_ref();
+            if bedrock.is_none() {
+                issues.push("bedrock provider requires bedrock_llm configuration".to_string());
+            }
+            if bedrock.is_none_or(|b| b.region.trim().is_empty()) {
+                issues.push("bedrock provider requires a non-empty region".to_string());
+            }
+            if bedrock.is_none_or(|b| b.model.trim().is_empty()) {
+                issues.push("bedrock provider requires a non-empty model".to_string());
+            }
+            if bedrock.is_none_or(|b| b.embedding_model.trim().is_empty()) {
+                issues.push("bedrock provider requires a non-empty embedding_model".to_string());
+            }
+        }
+        _ => {}
+    }
+
+    if issues.is_empty() {
+        Ok(())
+    } else {
+        Err(issues)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -63,5 +112,34 @@ mod tests {
             validate_config(Path::new("/tmp/nonexistent_aeterna_test_config.toml")).unwrap();
         assert!(!result.is_valid);
         assert!(result.issues[0].contains("does not exist"));
+    }
+
+    #[test]
+    fn test_validate_setup_config_google_requires_project_id() {
+        let mut config = SetupConfig::default();
+        config.llm_provider = LlmProvider::Google;
+        config.google_llm = Some(super::super::types::GoogleLlmConfig {
+            project_id: String::new(),
+            location: "us-central1".into(),
+            model: "gemini-2.5-flash".into(),
+            embedding_model: "text-embedding-005".into(),
+        });
+
+        let errors = validate_setup_config(&config).unwrap_err();
+        assert!(errors.iter().any(|error| error.contains("project_id")));
+    }
+
+    #[test]
+    fn test_validate_setup_config_bedrock_requires_region() {
+        let mut config = SetupConfig::default();
+        config.llm_provider = LlmProvider::Bedrock;
+        config.bedrock_llm = Some(super::super::types::BedrockLlmConfig {
+            region: String::new(),
+            model: "amazon.nova-micro-v1:0".into(),
+            embedding_model: "amazon.titan-embed-text-v2:0".into(),
+        });
+
+        let errors = validate_setup_config(&config).unwrap_err();
+        assert!(errors.iter().any(|error| error.contains("region")));
     }
 }

--- a/cli/src/commands/setup/wizard.rs
+++ b/cli/src/commands/setup/wizard.rs
@@ -525,6 +525,8 @@ impl SetupWizard {
             "OpenAI (text-embedding-3-small, gpt-4o)",
             "Anthropic (claude-3-haiku)",
             "Ollama (local, no API key)",
+            "Google Cloud Vertex AI / Gemini",
+            "AWS Bedrock",
             "Skip (configure later)",
         ];
 
@@ -538,7 +540,9 @@ impl SetupWizard {
             0 => LlmProvider::Openai,
             1 => LlmProvider::Anthropic,
             2 => LlmProvider::Ollama,
-            3 => LlmProvider::None,
+            3 => LlmProvider::Google,
+            4 => LlmProvider::Bedrock,
+            5 => LlmProvider::None,
             _ => unreachable!(),
         };
 
@@ -572,8 +576,77 @@ impl SetupWizard {
                     .interact_text()?;
                 self.config.ollama_host = Some(host);
             }
+            LlmProvider::Google => self.configure_google_llm()?,
+            LlmProvider::Bedrock => self.configure_bedrock_llm()?,
             LlmProvider::None => {}
         }
+
+        Ok(())
+    }
+
+    fn configure_google_llm(&mut self) -> Result<()> {
+        let project_id: String = Input::with_theme(&self.theme)
+            .with_prompt("Google Cloud project ID")
+            .interact_text()?;
+
+        let location: String = Input::with_theme(&self.theme)
+            .with_prompt("Vertex AI location")
+            .default("us-central1".to_string())
+            .interact_text()?;
+
+        let model: String = Input::with_theme(&self.theme)
+            .with_prompt("Google generation model")
+            .default("gemini-2.5-flash".to_string())
+            .interact_text()?;
+
+        let embedding_model: String = Input::with_theme(&self.theme)
+            .with_prompt("Google embedding model")
+            .default("text-embedding-005".to_string())
+            .interact_text()?;
+
+        println!(
+            "{}",
+            "Authentication uses GOOGLE_ACCESS_TOKEN or ADC / GOOGLE_APPLICATION_CREDENTIALS at runtime."
+                .dimmed()
+        );
+
+        self.config.google_llm = Some(GoogleLlmConfig {
+            project_id,
+            location,
+            model,
+            embedding_model,
+        });
+
+        Ok(())
+    }
+
+    fn configure_bedrock_llm(&mut self) -> Result<()> {
+        let region: String = Input::with_theme(&self.theme)
+            .with_prompt("AWS Bedrock region")
+            .default("us-east-1".to_string())
+            .interact_text()?;
+
+        let model: String = Input::with_theme(&self.theme)
+            .with_prompt("Bedrock generation model")
+            .default("amazon.nova-micro-v1:0".to_string())
+            .interact_text()?;
+
+        let embedding_model: String = Input::with_theme(&self.theme)
+            .with_prompt("Bedrock embedding model")
+            .default("amazon.titan-embed-text-v2:0".to_string())
+            .interact_text()?;
+
+        println!(
+            "{}",
+            "Authentication uses the standard AWS credential chain (IRSA, instance profile, profile, or env vars)."
+                .dimmed()
+        );
+
+        self.config.bedrock_llm = Some(BedrockLlmConfig {
+            region,
+            model,
+            embedding_model,
+        });
 
         Ok(())
     }

--- a/context/src/migration.rs
+++ b/context/src/migration.rs
@@ -509,3 +509,291 @@ pub enum MigrationError {
     #[error("Validation error: {0}")]
     ValidationError(String)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    // ---------------------------------------------------------------------------
+    // MigrationConfig — Default values
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_migration_config_default_values() {
+        let cfg = MigrationConfig::default();
+        assert!(!cfg.parallel_resolution_enabled);
+        assert!(cfg.comparison_logging_enabled);
+        assert_eq!(cfg.primary_mode, ResolutionMode::Heuristic);
+        assert!(cfg.audit_mode);
+        assert_eq!(cfg.circuit_breaker_threshold, 5);
+        assert!(cfg.fallback_enabled);
+    }
+
+    // ---------------------------------------------------------------------------
+    // MigrationConfig — from_env (reads env vars, falls back to defaults when absent)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_migration_config_from_env_defaults_when_no_env() {
+        // Make sure none of the env vars are set in this test
+        std::env::remove_var("AETERNA_PARALLEL_RESOLUTION");
+        std::env::remove_var("AETERNA_COMPARISON_LOGGING");
+        std::env::remove_var("AETERNA_PRIMARY_MODE");
+        std::env::remove_var("AETERNA_CEDAR_AUDIT_MODE");
+        std::env::remove_var("AETERNA_CIRCUIT_BREAKER_THRESHOLD");
+        std::env::remove_var("AETERNA_CEDAR_FALLBACK");
+
+        let cfg = MigrationConfig::from_env();
+        assert!(!cfg.parallel_resolution_enabled);
+        assert!(cfg.comparison_logging_enabled);
+        assert_eq!(cfg.primary_mode, ResolutionMode::Heuristic);
+        assert!(cfg.audit_mode);
+        assert_eq!(cfg.circuit_breaker_threshold, 5);
+        assert!(cfg.fallback_enabled);
+    }
+
+    #[test]
+    fn test_migration_config_from_env_parallel_resolution_true() {
+        std::env::set_var("AETERNA_PARALLEL_RESOLUTION", "true");
+        let cfg = MigrationConfig::from_env();
+        assert!(cfg.parallel_resolution_enabled);
+        std::env::remove_var("AETERNA_PARALLEL_RESOLUTION");
+    }
+
+    #[test]
+    fn test_migration_config_from_env_comparison_logging_false() {
+        std::env::set_var("AETERNA_COMPARISON_LOGGING", "false");
+        let cfg = MigrationConfig::from_env();
+        assert!(!cfg.comparison_logging_enabled);
+        std::env::remove_var("AETERNA_COMPARISON_LOGGING");
+    }
+
+    #[test]
+    fn test_migration_config_from_env_primary_mode_cedar() {
+        std::env::set_var("AETERNA_PRIMARY_MODE", "cedar");
+        let cfg = MigrationConfig::from_env();
+        assert_eq!(cfg.primary_mode, ResolutionMode::Cedar);
+        std::env::remove_var("AETERNA_PRIMARY_MODE");
+    }
+
+    #[test]
+    fn test_migration_config_from_env_primary_mode_parallel() {
+        std::env::set_var("AETERNA_PRIMARY_MODE", "parallel");
+        let cfg = MigrationConfig::from_env();
+        assert_eq!(cfg.primary_mode, ResolutionMode::Parallel);
+        std::env::remove_var("AETERNA_PRIMARY_MODE");
+    }
+
+    #[test]
+    fn test_migration_config_from_env_primary_mode_unknown_falls_back_to_heuristic() {
+        std::env::set_var("AETERNA_PRIMARY_MODE", "something_weird");
+        let cfg = MigrationConfig::from_env();
+        assert_eq!(cfg.primary_mode, ResolutionMode::Heuristic);
+        std::env::remove_var("AETERNA_PRIMARY_MODE");
+    }
+
+    #[test]
+    fn test_migration_config_from_env_circuit_breaker_threshold() {
+        std::env::set_var("AETERNA_CIRCUIT_BREAKER_THRESHOLD", "10");
+        let cfg = MigrationConfig::from_env();
+        assert_eq!(cfg.circuit_breaker_threshold, 10);
+        std::env::remove_var("AETERNA_CIRCUIT_BREAKER_THRESHOLD");
+    }
+
+    #[test]
+    fn test_migration_config_from_env_circuit_breaker_invalid_falls_back_to_5() {
+        std::env::set_var("AETERNA_CIRCUIT_BREAKER_THRESHOLD", "not-a-number");
+        let cfg = MigrationConfig::from_env();
+        assert_eq!(cfg.circuit_breaker_threshold, 5);
+        std::env::remove_var("AETERNA_CIRCUIT_BREAKER_THRESHOLD");
+    }
+
+    #[test]
+    fn test_migration_config_from_env_audit_mode_false() {
+        std::env::set_var("AETERNA_CEDAR_AUDIT_MODE", "false");
+        let cfg = MigrationConfig::from_env();
+        assert!(!cfg.audit_mode);
+        std::env::remove_var("AETERNA_CEDAR_AUDIT_MODE");
+    }
+
+    #[test]
+    fn test_migration_config_from_env_fallback_disabled() {
+        std::env::set_var("AETERNA_CEDAR_FALLBACK", "false");
+        let cfg = MigrationConfig::from_env();
+        assert!(!cfg.fallback_enabled);
+        std::env::remove_var("AETERNA_CEDAR_FALLBACK");
+    }
+
+    // ---------------------------------------------------------------------------
+    // MigrationConfig — serde round-trip
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_migration_config_serde_round_trip() {
+        let cfg = MigrationConfig {
+            parallel_resolution_enabled: true,
+            comparison_logging_enabled: false,
+            primary_mode: ResolutionMode::Cedar,
+            audit_mode: false,
+            circuit_breaker_threshold: 3,
+            fallback_enabled: false,
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: MigrationConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.primary_mode, ResolutionMode::Cedar);
+        assert!(!back.audit_mode);
+        assert_eq!(back.circuit_breaker_threshold, 3);
+    }
+
+    // ---------------------------------------------------------------------------
+    // ResolutionMode
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_resolution_mode_equality() {
+        assert_eq!(ResolutionMode::Heuristic, ResolutionMode::Heuristic);
+        assert_ne!(ResolutionMode::Heuristic, ResolutionMode::Cedar);
+        assert_ne!(ResolutionMode::Cedar, ResolutionMode::Parallel);
+    }
+
+    #[test]
+    fn test_resolution_mode_serde_round_trip() {
+        for mode in [ResolutionMode::Heuristic, ResolutionMode::Cedar, ResolutionMode::Parallel] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let back: ResolutionMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, mode);
+        }
+    }
+
+    #[test]
+    fn test_resolution_mode_copy() {
+        let m = ResolutionMode::Parallel;
+        let m2 = m; // Copy
+        assert_eq!(m, m2);
+    }
+
+    // ---------------------------------------------------------------------------
+    // MatchStatus
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_match_status_serde_round_trip() {
+        for status in [
+            MatchStatus::Match,
+            MatchStatus::Mismatch,
+            MatchStatus::Partial,
+            MatchStatus::BothFailed,
+        ] {
+            let json = serde_json::to_string(&status).unwrap();
+            let back: MatchStatus = serde_json::from_str(&json).unwrap();
+            // Verify they serialise to the expected variant name strings
+            let s = format!("{:?}", back);
+            let orig = format!("{:?}", status);
+            assert_eq!(s, orig);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // AuditDecision
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_audit_decision_serde() {
+        let allow_json = serde_json::to_string(&AuditDecision::Allow).unwrap();
+        let deny_json = serde_json::to_string(&AuditDecision::Deny).unwrap();
+        assert!(allow_json.contains("Allow"), "Expected 'Allow' in JSON: {allow_json}");
+        assert!(deny_json.contains("Deny"), "Expected 'Deny' in JSON: {deny_json}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // ContextError — Display
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_context_error_display_heuristic() {
+        let e = ContextError::HeuristicError("resolver failed".to_string());
+        assert!(e.to_string().contains("resolver failed"));
+    }
+
+    #[test]
+    fn test_context_error_display_cedar() {
+        let e = ContextError::CedarError("connection refused".to_string());
+        assert!(e.to_string().contains("connection refused"));
+    }
+
+    #[test]
+    fn test_context_error_display_parallel() {
+        let e = ContextError::ParallelError("both failed".to_string());
+        assert!(e.to_string().contains("both failed"));
+    }
+
+    #[test]
+    fn test_context_error_display_config() {
+        let e = ContextError::ConfigError("bad config".to_string());
+        assert!(e.to_string().contains("bad config"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // MigrationError — Display
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_migration_error_display_database() {
+        let e = MigrationError::DatabaseError("conn refused".to_string());
+        assert!(e.to_string().contains("conn refused"));
+    }
+
+    #[test]
+    fn test_migration_error_display_validation() {
+        let e = MigrationError::ValidationError("integrity check failed".to_string());
+        assert!(e.to_string().contains("integrity check failed"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // MigrationReport / ValidationReport — construction & serde
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_migration_report_serde() {
+        let report = MigrationReport {
+            timestamp: Utc::now(),
+            companies_migrated: 2,
+            orgs_migrated: 5,
+            teams_migrated: 10,
+            projects_migrated: 20,
+            users_migrated: 300,
+            agents_migrated: 0,
+            errors: vec!["skipped orphan".to_string()],
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        let back: MigrationReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.companies_migrated, 2);
+        assert_eq!(back.users_migrated, 300);
+        assert_eq!(back.errors.len(), 1);
+    }
+
+    #[test]
+    fn test_validation_report_serde() {
+        let report = ValidationReport {
+            timestamp: Utc::now(),
+            valid: false,
+            issues: vec!["missing tenant link".to_string()],
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        let back: ValidationReport = serde_json::from_str(&json).unwrap();
+        assert!(!back.valid);
+        assert_eq!(back.issues[0], "missing tenant link");
+    }
+
+    #[test]
+    fn test_validation_report_valid() {
+        let report = ValidationReport {
+            timestamp: Utc::now(),
+            valid: true,
+            issues: vec![],
+        };
+        assert!(report.valid);
+        assert!(report.issues.is_empty());
+    }
+}

--- a/docs/guides/provider-adapters.md
+++ b/docs/guides/provider-adapters.md
@@ -6,6 +6,93 @@ Aeterna uses a **pluggable backend architecture** built around the `VectorBacken
 
 This guide explains how the adapter system works and how to add a new provider.
 
+## Runtime Model Provider Adapters
+
+Vector backends are only one side of the provider story. Aeterna also supports runtime-selected server-side model providers for:
+
+- text generation via `mk_core::traits::LlmService`
+- embeddings via `mk_core::traits::EmbeddingService`
+
+These services are constructed through dedicated runtime factories:
+
+- `memory/src/llm/factory.rs`
+- `memory/src/embedding/factory.rs`
+
+The server startup path wires those factories from deployment configuration in `cli/src/commands/serve.rs`.
+
+### Supported Runtime LLM Providers
+
+`AETERNA_LLM_PROVIDER` currently supports:
+
+- `openai`
+- `google`
+- `bedrock`
+- `none`
+
+Provider construction is fail-closed. Unsupported providers or incomplete provider-specific configuration return an error instead of falling back implicitly.
+
+### OpenAI Runtime Configuration
+
+```bash
+export AETERNA_LLM_PROVIDER=openai
+export OPENAI_API_KEY=your-api-key
+export AETERNA_OPENAI_MODEL=gpt-4.1-mini
+export AETERNA_OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+```
+
+### Google Cloud Runtime Configuration
+
+```bash
+export AETERNA_LLM_PROVIDER=google
+export AETERNA_GOOGLE_PROJECT_ID=my-project
+export AETERNA_GOOGLE_LOCATION=global
+export AETERNA_GOOGLE_MODEL=gemini-2.5-flash
+export AETERNA_GOOGLE_EMBEDDING_MODEL=text-embedding-005
+```
+
+Authentication behavior:
+
+1. Use `GOOGLE_ACCESS_TOKEN` when explicitly provided
+2. Otherwise use ADC via `GOOGLE_APPLICATION_CREDENTIALS`
+3. Otherwise use ambient ADC available in Google Cloud runtimes
+
+The Google adapters target Vertex AI / Gemini server-side APIs, not browser-user federation.
+
+### AWS Bedrock Runtime Configuration
+
+```bash
+export AETERNA_LLM_PROVIDER=bedrock
+export AETERNA_BEDROCK_REGION=us-east-1
+export AETERNA_BEDROCK_MODEL=anthropic.claude-3-5-sonnet-20241022-v2:0
+export AETERNA_BEDROCK_EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
+```
+
+Authentication uses the AWS SDK credential chain. In Kubernetes this normally means IAM roles for service accounts or another workload identity path rather than long-lived static credentials.
+
+### Adapter Design Notes
+
+- provider-specific request and response shapes stay inside adapter modules
+- factories normalize provider selection and missing-config validation
+- `MemoryManager` continues using injected trait implementations rather than provider-specific logic
+- `none` is an explicit mode for deployments that do not want server-side provider construction
+
+### Testing Expectations for Runtime Providers
+
+Provider adapters should include:
+
+- factory tests for provider parsing and fail-closed validation
+- request/response adaptation tests for each provider module
+- setup/deployment validation for emitted runtime environment
+
+The current Google and Bedrock implementations are covered in:
+
+- `memory/src/llm/google.rs`
+- `memory/src/embedding/google.rs`
+- `memory/src/llm/bedrock.rs`
+- `memory/src/embedding/bedrock.rs`
+- `cli/src/commands/setup/`
+- `charts/aeterna/`
+
 ## Architecture
 
 ```

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -23,6 +23,9 @@ aisdk = { version = "0.4.0", features = ["openai"], optional = true }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "json"], optional = true }
 mongodb = { version = "3.2", optional = true }
 reqwest = { version = "0.12", features = ["json"], optional = true }
+aws-config = { version = "1.8", optional = true }
+aws-sdk-bedrockruntime = { version = "1.128.0", optional = true }
+gcp_auth = { version = "0.12", optional = true }
 urlencoding = "2.1"
 uuid = { version = "1.0", features = ["v4", "v5", "serde"] }
 metrics-util.workspace = true
@@ -40,11 +43,15 @@ redis.workspace = true
 testing.workspace = true
 tempfile = "3.10"
 proptest = "1.4"
+wiremock.workspace = true
+rustls = { version = "0.23", features = ["aws_lc_rs"] }
 
 [features]
 default = []
 llm-integration = ["dep:async-openai", "dep:aisdk"]
 embedding-integration = ["dep:async-openai"]
+google-provider = ["dep:reqwest", "dep:gcp_auth"]
+bedrock-provider = ["dep:aws-config", "dep:aws-sdk-bedrockruntime"]
 pinecone = ["dep:reqwest"]
 pgvector = ["dep:sqlx"]
 vertex-ai = ["dep:reqwest"]

--- a/memory/src/embedding/bedrock.rs
+++ b/memory/src/embedding/bedrock.rs
@@ -1,0 +1,155 @@
+#![cfg(feature = "bedrock-provider")]
+
+use async_trait::async_trait;
+use aws_config::BehaviorVersion;
+use aws_sdk_bedrockruntime::Client;
+use aws_sdk_bedrockruntime::config::Region;
+use aws_sdk_bedrockruntime::primitives::Blob;
+use mk_core::traits::EmbeddingService;
+use tokio::sync::OnceCell;
+
+pub struct BedrockEmbeddingService {
+    region: String,
+    model_id: String,
+    dimension: usize,
+    client: OnceCell<Client>,
+}
+
+impl BedrockEmbeddingService {
+    pub fn new(region: String, model_id: String) -> Self {
+        let dimension = match model_id.as_str() {
+            "amazon.titan-embed-text-v2:0" => 1024,
+            "cohere.embed-english-v3" | "cohere.embed-multilingual-v3" => 1024,
+            _ => 1024,
+        };
+
+        Self {
+            region,
+            model_id,
+            dimension,
+            client: OnceCell::new(),
+        }
+    }
+
+    async fn client(&self) -> anyhow::Result<&Client> {
+        self.client
+            .get_or_try_init(|| async {
+                let config = aws_config::defaults(BehaviorVersion::latest())
+                    .region(Region::new(self.region.clone()))
+                    .load()
+                    .await;
+                Ok::<Client, anyhow::Error>(Client::new(&config))
+            })
+            .await
+    }
+
+    fn request_body(&self, text: &str) -> anyhow::Result<Vec<u8>> {
+        if self.model_id.starts_with("amazon.titan-embed") {
+            Ok(serde_json::to_vec(&serde_json::json!({
+                "inputText": text,
+                "dimensions": self.dimension,
+                "normalize": true,
+            }))?)
+        } else if self.model_id.starts_with("cohere.embed-") {
+            Ok(serde_json::to_vec(&serde_json::json!({
+                "texts": [text],
+                "input_type": "search_document",
+                "embedding_types": ["float"],
+            }))?)
+        } else {
+            anyhow::bail!("Unsupported Bedrock embedding model: {}", self.model_id)
+        }
+    }
+
+    fn extract_embedding(&self, payload: &serde_json::Value) -> anyhow::Result<Vec<f32>> {
+        if self.model_id.starts_with("amazon.titan-embed") {
+            serde_json::from_value(
+                payload.get("embedding").cloned().ok_or_else(|| {
+                    anyhow::anyhow!("Bedrock embedding response missing 'embedding'")
+                })?,
+            )
+            .map_err(Into::into)
+        } else if self.model_id.starts_with("cohere.embed-") {
+            let embeddings = payload
+                .get("embeddings")
+                .and_then(|value| value.as_array())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Bedrock embedding response missing 'embeddings'")
+                })?;
+
+            serde_json::from_value(
+                embeddings.first().cloned().ok_or_else(|| {
+                    anyhow::anyhow!("Bedrock embedding response returned no vectors")
+                })?,
+            )
+            .map_err(Into::into)
+        } else {
+            anyhow::bail!("Unsupported Bedrock embedding model: {}", self.model_id)
+        }
+    }
+}
+
+#[async_trait]
+impl EmbeddingService for BedrockEmbeddingService {
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, Self::Error> {
+        let body = self
+            .request_body(text)
+            .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as Self::Error)?;
+
+        let response = self
+            .client()
+            .await
+            .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as Self::Error)?
+            .invoke_model()
+            .model_id(&self.model_id)
+            .content_type("application/json")
+            .accept("application/json")
+            .body(Blob::new(body))
+            .send()
+            .await
+            .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as Self::Error)?;
+
+        let payload: serde_json::Value = serde_json::from_slice(response.body().as_ref())
+            .map_err(|e| Box::new(e) as Self::Error)?;
+
+        self.extract_embedding(&payload)
+            .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as Self::Error)
+    }
+
+    fn dimension(&self) -> usize {
+        self.dimension
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn titan_request_shape_is_generated() {
+        let service =
+            BedrockEmbeddingService::new("us-east-1".into(), "amazon.titan-embed-text-v2:0".into());
+
+        let body: serde_json::Value =
+            serde_json::from_slice(&service.request_body("hello").unwrap()).unwrap();
+        assert_eq!(body["inputText"], "hello");
+        assert_eq!(body["dimensions"], 1024);
+        assert_eq!(body["normalize"], true);
+    }
+
+    #[test]
+    fn cohere_response_shape_is_adapted() {
+        let service =
+            BedrockEmbeddingService::new("us-east-1".into(), "cohere.embed-english-v3".into());
+
+        let embedding = service
+            .extract_embedding(&serde_json::json!({
+                "embeddings": [[0.1, 0.2, 0.3]]
+            }))
+            .unwrap();
+
+        assert_eq!(embedding, vec![0.1, 0.2, 0.3]);
+    }
+}

--- a/memory/src/embedding/factory.rs
+++ b/memory/src/embedding/factory.rs
@@ -1,0 +1,311 @@
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use mk_core::traits::EmbeddingService;
+
+#[derive(Debug, thiserror::Error)]
+pub enum EmbeddingFactoryError {
+    #[error("Embedding provider configuration error: {0}")]
+    Configuration(String),
+    #[error("Embedding provider unavailable in this build: {0}")]
+    Unavailable(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum EmbeddingProviderType {
+    Openai,
+    Google,
+    Bedrock,
+    #[default]
+    None,
+}
+
+impl std::fmt::Display for EmbeddingProviderType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EmbeddingProviderType::Openai => write!(f, "openai"),
+            EmbeddingProviderType::Google => write!(f, "google"),
+            EmbeddingProviderType::Bedrock => write!(f, "bedrock"),
+            EmbeddingProviderType::None => write!(f, "none"),
+        }
+    }
+}
+
+impl std::str::FromStr for EmbeddingProviderType {
+    type Err = EmbeddingFactoryError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "openai" => Ok(EmbeddingProviderType::Openai),
+            "google" | "vertex" | "vertex_ai" | "vertexai" | "gemini" => {
+                Ok(EmbeddingProviderType::Google)
+            }
+            "bedrock" | "aws_bedrock" | "aws-bedrock" => Ok(EmbeddingProviderType::Bedrock),
+            "none" => Ok(EmbeddingProviderType::None),
+            _ => Err(EmbeddingFactoryError::Configuration(format!(
+                "Unknown embedding provider: {s}. Valid options: openai, google, bedrock, none"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct OpenAiEmbeddingConfig {
+    pub model: String,
+    pub api_key: String,
+}
+
+impl OpenAiEmbeddingConfig {
+    pub fn from_env() -> Result<Self, EmbeddingFactoryError> {
+        Ok(Self {
+            model: std::env::var("AETERNA_OPENAI_EMBEDDING_MODEL")
+                .unwrap_or_else(|_| "text-embedding-3-small".to_string()),
+            api_key: std::env::var("OPENAI_API_KEY").map_err(|_| {
+                EmbeddingFactoryError::Configuration("OPENAI_API_KEY not set".into())
+            })?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct GoogleEmbeddingConfig {
+    pub project_id: String,
+    pub location: String,
+    pub model: String,
+}
+
+impl GoogleEmbeddingConfig {
+    pub fn from_env() -> Result<Self, EmbeddingFactoryError> {
+        Ok(Self {
+            project_id: std::env::var("AETERNA_GOOGLE_PROJECT_ID").map_err(|_| {
+                EmbeddingFactoryError::Configuration("AETERNA_GOOGLE_PROJECT_ID not set".into())
+            })?,
+            location: std::env::var("AETERNA_GOOGLE_LOCATION").map_err(|_| {
+                EmbeddingFactoryError::Configuration("AETERNA_GOOGLE_LOCATION not set".into())
+            })?,
+            model: std::env::var("AETERNA_GOOGLE_EMBEDDING_MODEL").map_err(|_| {
+                EmbeddingFactoryError::Configuration(
+                    "AETERNA_GOOGLE_EMBEDDING_MODEL not set".into(),
+                )
+            })?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct BedrockEmbeddingConfig {
+    pub region: String,
+    pub model_id: String,
+}
+
+impl BedrockEmbeddingConfig {
+    pub fn from_env() -> Result<Self, EmbeddingFactoryError> {
+        Ok(Self {
+            region: std::env::var("AETERNA_BEDROCK_REGION").map_err(|_| {
+                EmbeddingFactoryError::Configuration("AETERNA_BEDROCK_REGION not set".into())
+            })?,
+            model_id: std::env::var("AETERNA_BEDROCK_EMBEDDING_MODEL").map_err(|_| {
+                EmbeddingFactoryError::Configuration(
+                    "AETERNA_BEDROCK_EMBEDDING_MODEL not set".into(),
+                )
+            })?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct EmbeddingProviderConfig {
+    pub provider_type: EmbeddingProviderType,
+    pub openai: Option<OpenAiEmbeddingConfig>,
+    pub google: Option<GoogleEmbeddingConfig>,
+    pub bedrock: Option<BedrockEmbeddingConfig>,
+}
+
+impl EmbeddingProviderConfig {
+    pub fn from_env() -> Result<Self, EmbeddingFactoryError> {
+        let provider_type = std::env::var("AETERNA_LLM_PROVIDER")
+            .unwrap_or_else(|_| "none".to_string())
+            .parse()?;
+
+        Ok(Self {
+            provider_type,
+            openai: matches!(provider_type, EmbeddingProviderType::Openai)
+                .then(OpenAiEmbeddingConfig::from_env)
+                .transpose()?,
+            google: matches!(provider_type, EmbeddingProviderType::Google)
+                .then(GoogleEmbeddingConfig::from_env)
+                .transpose()?,
+            bedrock: matches!(provider_type, EmbeddingProviderType::Bedrock)
+                .then(BedrockEmbeddingConfig::from_env)
+                .transpose()?,
+        })
+    }
+}
+
+pub fn create_embedding_service_from_env() -> Result<
+    Option<
+        Arc<dyn EmbeddingService<Error = Box<dyn std::error::Error + Send + Sync>> + Send + Sync>,
+    >,
+    EmbeddingFactoryError,
+> {
+    let config = EmbeddingProviderConfig::from_env()?;
+    create_embedding_service(config)
+}
+
+pub fn create_embedding_service(
+    config: EmbeddingProviderConfig,
+) -> Result<
+    Option<
+        Arc<dyn EmbeddingService<Error = Box<dyn std::error::Error + Send + Sync>> + Send + Sync>,
+    >,
+    EmbeddingFactoryError,
+> {
+    match config.provider_type {
+        EmbeddingProviderType::None => Ok(None),
+        EmbeddingProviderType::Openai => {
+            #[allow(unused_variables)]
+            let openai = config.openai.ok_or_else(|| {
+                EmbeddingFactoryError::Configuration("OpenAI embedding config missing".into())
+            })?;
+
+            #[cfg(feature = "embedding-integration")]
+            {
+                let service =
+                    super::openai::OpenAIEmbeddingService::new(openai.api_key, &openai.model);
+                return Ok(Some(Arc::new(service)));
+            }
+
+            #[cfg(not(feature = "embedding-integration"))]
+            {
+                return Err(EmbeddingFactoryError::Unavailable(
+                    "openai embeddings require the embedding-integration feature".into(),
+                ));
+            }
+        }
+        EmbeddingProviderType::Google => {
+            let google = config.google.ok_or_else(|| {
+                EmbeddingFactoryError::Configuration("Google embedding config missing".into())
+            })?;
+
+            #[cfg(feature = "google-provider")]
+            {
+                let service = super::google::GoogleEmbeddingService::new(
+                    google.project_id,
+                    google.location,
+                    google.model,
+                );
+                return Ok(Some(Arc::new(service)));
+            }
+
+            #[cfg(not(feature = "google-provider"))]
+            {
+                let _ = google;
+                return Err(EmbeddingFactoryError::Unavailable(
+                    "google support requires the google-provider feature".into(),
+                ));
+            }
+        }
+        EmbeddingProviderType::Bedrock => {
+            let bedrock = config.bedrock.ok_or_else(|| {
+                EmbeddingFactoryError::Configuration("Bedrock embedding config missing".into())
+            })?;
+
+            #[cfg(feature = "bedrock-provider")]
+            {
+                let service =
+                    super::bedrock::BedrockEmbeddingService::new(bedrock.region, bedrock.model_id);
+                return Ok(Some(Arc::new(service)));
+            }
+
+            #[cfg(not(feature = "bedrock-provider"))]
+            {
+                let _ = bedrock;
+                return Err(EmbeddingFactoryError::Unavailable(
+                    "bedrock support requires the bedrock-provider feature".into(),
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_provider_aliases() {
+        assert_eq!(
+            "openai".parse::<EmbeddingProviderType>().unwrap(),
+            EmbeddingProviderType::Openai
+        );
+        assert_eq!(
+            "vertexai".parse::<EmbeddingProviderType>().unwrap(),
+            EmbeddingProviderType::Google
+        );
+        assert_eq!(
+            "bedrock".parse::<EmbeddingProviderType>().unwrap(),
+            EmbeddingProviderType::Bedrock
+        );
+        assert_eq!(
+            "none".parse::<EmbeddingProviderType>().unwrap(),
+            EmbeddingProviderType::None
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_provider() {
+        let err = "wat".parse::<EmbeddingProviderType>().unwrap_err();
+        assert!(err.to_string().contains("Unknown embedding provider"));
+    }
+
+    #[test]
+    fn none_provider_returns_no_service() {
+        let config = EmbeddingProviderConfig {
+            provider_type: EmbeddingProviderType::None,
+            openai: None,
+            google: None,
+            bedrock: None,
+        };
+
+        let service = create_embedding_service(config).unwrap();
+        assert!(service.is_none());
+    }
+
+    #[test]
+    #[cfg(not(feature = "bedrock-provider"))]
+    fn bedrock_provider_is_explicitly_unavailable() {
+        let config = EmbeddingProviderConfig {
+            provider_type: EmbeddingProviderType::Bedrock,
+            openai: None,
+            google: None,
+            bedrock: Some(BedrockEmbeddingConfig {
+                region: "eu-west-1".into(),
+                model_id: "amazon.titan-embed-text-v2:0".into(),
+            }),
+        };
+
+        let err = match create_embedding_service(config) {
+            Ok(_) => panic!("expected bedrock provider to be unavailable"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("bedrock"));
+    }
+
+    #[test]
+    #[cfg(feature = "bedrock-provider")]
+    fn bedrock_provider_is_constructed_when_feature_enabled() {
+        let config = EmbeddingProviderConfig {
+            provider_type: EmbeddingProviderType::Bedrock,
+            openai: None,
+            google: None,
+            bedrock: Some(BedrockEmbeddingConfig {
+                region: "us-east-1".into(),
+                model_id: "amazon.titan-embed-text-v2:0".into(),
+            }),
+        };
+
+        let service = create_embedding_service(config).unwrap();
+        assert!(service.is_some());
+    }
+}

--- a/memory/src/embedding/google.rs
+++ b/memory/src/embedding/google.rs
@@ -1,0 +1,255 @@
+#![cfg(feature = "google-provider")]
+
+use async_trait::async_trait;
+use gcp_auth::TokenProvider;
+use mk_core::traits::EmbeddingService;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Debug, Serialize)]
+struct EmbedContentRequest {
+    content: GoogleContent,
+    task_type: String,
+}
+
+#[derive(Debug, Serialize)]
+struct GoogleContent {
+    role: String,
+    parts: Vec<GooglePart>,
+}
+
+#[derive(Debug, Serialize)]
+struct GooglePart {
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct EmbedContentResponse {
+    embedding: Option<GoogleEmbedding>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleEmbedding {
+    #[serde(default)]
+    values: Vec<f32>,
+}
+
+struct CachedToken {
+    token: String,
+    expires_at: std::time::Instant,
+}
+
+type GoogleTokenProvider = Arc<dyn TokenProvider>;
+
+pub struct GoogleEmbeddingService {
+    client: Client,
+    project_id: String,
+    location: String,
+    model: String,
+    base_url: String,
+    dimension: usize,
+    access_token: Arc<RwLock<Option<CachedToken>>>,
+    token_provider: Arc<tokio::sync::OnceCell<GoogleTokenProvider>>,
+}
+
+impl GoogleEmbeddingService {
+    pub fn new(project_id: String, location: String, model: String) -> Self {
+        let dimension = match model.as_str() {
+            "text-embedding-005" | "text-multilingual-embedding-002" => 768,
+            _ => 768,
+        };
+
+        Self {
+            client: Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("Google embedding HTTP client should build"),
+            project_id,
+            location,
+            model,
+            base_url: "https://aiplatform.googleapis.com".to_string(),
+            dimension,
+            access_token: Arc::new(RwLock::new(None)),
+            token_provider: Arc::new(tokio::sync::OnceCell::new()),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url = base_url;
+        self
+    }
+
+    #[cfg(test)]
+    fn with_cached_access_token(mut self, token: impl Into<String>) -> Self {
+        self.access_token = Arc::new(RwLock::new(Some(CachedToken {
+            token: token.into(),
+            expires_at: std::time::Instant::now() + std::time::Duration::from_secs(3600),
+        })));
+        self
+    }
+
+    fn endpoint(&self) -> String {
+        format!(
+            "{}/v1/projects/{}/locations/{}/publishers/google/models/{}:embedContent",
+            self.base_url, self.project_id, self.location, self.model
+        )
+    }
+
+    async fn access_token(&self) -> anyhow::Result<String> {
+        {
+            let cached = self.access_token.read().await;
+            if let Some(token) = cached.as_ref()
+                && token.expires_at > std::time::Instant::now()
+            {
+                return Ok(token.token.clone());
+            }
+        }
+
+        let token = if let Ok(token) = std::env::var("GOOGLE_ACCESS_TOKEN") {
+            token
+        } else {
+            self.fetch_adc_token().await?
+        };
+
+        {
+            let mut cached = self.access_token.write().await;
+            *cached = Some(CachedToken {
+                token: token.clone(),
+                expires_at: std::time::Instant::now() + std::time::Duration::from_secs(3500),
+            });
+        }
+
+        Ok(token)
+    }
+
+    async fn token_provider(&self) -> anyhow::Result<&GoogleTokenProvider> {
+        self.token_provider
+            .get_or_try_init(|| async {
+                let provider = gcp_auth::provider().await.map_err(|e| {
+                    anyhow::anyhow!("failed to initialize Google ADC token provider: {e}")
+                })?;
+                Ok::<GoogleTokenProvider, anyhow::Error>(provider)
+            })
+            .await
+    }
+
+    async fn fetch_adc_token(&self) -> anyhow::Result<String> {
+        let provider = self.token_provider().await?;
+        let token = provider
+            .token(&["https://www.googleapis.com/auth/cloud-platform"])
+            .await
+            .map_err(|e| anyhow::anyhow!("Google access token not available from ADC: {e}"))?;
+        Ok(token.as_str().to_string())
+    }
+}
+
+#[async_trait]
+impl EmbeddingService for GoogleEmbeddingService {
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, Self::Error> {
+        let token = self
+            .access_token()
+            .await
+            .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as Self::Error)?;
+
+        let response = self
+            .client
+            .post(self.endpoint())
+            .bearer_auth(token)
+            .json(&EmbedContentRequest {
+                content: GoogleContent {
+                    role: "user".to_string(),
+                    parts: vec![GooglePart {
+                        text: text.to_string(),
+                    }],
+                },
+                task_type: "RETRIEVAL_DOCUMENT".to_string(),
+            })
+            .send()
+            .await
+            .map_err(|e| Box::new(e) as Self::Error)?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(Box::new(std::io::Error::other(format!(
+                "Google embedContent failed with {status}: {body}"
+            ))));
+        }
+
+        let payload: EmbedContentResponse = response
+            .json()
+            .await
+            .map_err(|e| Box::new(e) as Self::Error)?;
+        payload
+            .embedding
+            .map(|embedding| embedding.values)
+            .ok_or_else(|| {
+                Box::new(std::io::Error::other(
+                    "Google embedContent returned no embedding",
+                )) as Self::Error
+            })
+    }
+
+    fn dimension(&self) -> usize {
+        self.dimension
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustls::crypto::aws_lc_rs;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn install_crypto_provider() {
+        let _ = aws_lc_rs::default_provider().install_default();
+    }
+
+    #[tokio::test]
+    async fn prefers_explicit_google_access_token() {
+        install_crypto_provider();
+        let service = GoogleEmbeddingService::new(
+            "proj".into(),
+            "global".into(),
+            "text-embedding-005".into(),
+        )
+        .with_cached_access_token("test-token");
+
+        let token = service.access_token().await.unwrap();
+        assert_eq!(token, "test-token");
+    }
+
+    #[tokio::test]
+    async fn adapts_embed_content_response() {
+        install_crypto_provider();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/locations/global/publishers/google/models/text-embedding-005:embedContent"))
+            .and(header("authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "embedding": {
+                    "values": [0.1, 0.2, 0.3]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let service = GoogleEmbeddingService::new(
+            "proj".into(),
+            "global".into(),
+            "text-embedding-005".into(),
+        )
+        .with_base_url(server.uri())
+        .with_cached_access_token("test-token");
+
+        let vector = service.embed("hello").await.unwrap();
+        assert_eq!(vector, vec![0.1, 0.2, 0.3]);
+        assert_eq!(service.dimension(), 768);
+    }
+}

--- a/memory/src/embedding/mod.rs
+++ b/memory/src/embedding/mod.rs
@@ -1,7 +1,20 @@
+#[cfg(feature = "bedrock-provider")]
+pub mod bedrock;
+pub mod factory;
+#[cfg(feature = "google-provider")]
+pub mod google;
 pub mod mock;
 #[cfg(feature = "embedding-integration")]
 pub mod openai;
 
+#[cfg(feature = "bedrock-provider")]
+pub use bedrock::BedrockEmbeddingService;
+pub use factory::{
+    EmbeddingFactoryError, EmbeddingProviderConfig, EmbeddingProviderType,
+    create_embedding_service_from_env,
+};
+#[cfg(feature = "google-provider")]
+pub use google::GoogleEmbeddingService;
 pub use mock::MockEmbeddingService;
 #[cfg(feature = "embedding-integration")]
 pub use openai::OpenAIEmbeddingService;

--- a/memory/src/llm/bedrock.rs
+++ b/memory/src/llm/bedrock.rs
@@ -1,0 +1,128 @@
+#![cfg(feature = "bedrock-provider")]
+
+use async_trait::async_trait;
+use aws_config::BehaviorVersion;
+use aws_sdk_bedrockruntime::Client;
+use aws_sdk_bedrockruntime::config::Region;
+use aws_sdk_bedrockruntime::types::{ContentBlock, ConversationRole, Message};
+use mk_core::traits::LlmService;
+use mk_core::types::{Policy, ValidationResult};
+use tokio::sync::OnceCell;
+
+pub struct BedrockLlmService {
+    region: String,
+    model_id: String,
+    client: OnceCell<Client>,
+}
+
+impl BedrockLlmService {
+    pub fn new(region: String, model_id: String) -> Self {
+        Self {
+            region,
+            model_id,
+            client: OnceCell::new(),
+        }
+    }
+
+    async fn client(&self) -> anyhow::Result<&Client> {
+        self.client
+            .get_or_try_init(|| async {
+                let config = aws_config::defaults(BehaviorVersion::latest())
+                    .region(Region::new(self.region.clone()))
+                    .load()
+                    .await;
+                Ok::<Client, anyhow::Error>(Client::new(&config))
+            })
+            .await
+    }
+
+    async fn generate_text(&self, prompt: &str) -> anyhow::Result<String> {
+        let message = Message::builder()
+            .role(ConversationRole::User)
+            .content(ContentBlock::Text(prompt.to_string()))
+            .build()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+        let response = self
+            .client()
+            .await?
+            .converse()
+            .model_id(&self.model_id)
+            .messages(message)
+            .send()
+            .await?;
+
+        let output = response
+            .output()
+            .ok_or_else(|| anyhow::anyhow!("Bedrock returned no output"))?;
+        let message = output
+            .as_message()
+            .map_err(|_| anyhow::anyhow!("Bedrock converse output was not a message"))?;
+
+        let text = message
+            .content()
+            .iter()
+            .find_map(|block| block.as_text().ok())
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| anyhow::anyhow!("Bedrock converse returned no text content"))?;
+
+        Ok(text)
+    }
+}
+
+#[async_trait]
+impl LlmService for BedrockLlmService {
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    async fn generate(&self, prompt: &str) -> Result<String, Self::Error> {
+        self.generate_text(prompt)
+            .await
+            .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as Self::Error)
+    }
+
+    async fn analyze_drift(
+        &self,
+        content: &str,
+        policies: &[Policy],
+    ) -> Result<ValidationResult, Self::Error> {
+        let policies_json =
+            serde_json::to_string_pretty(policies).map_err(|e| Box::new(e) as Self::Error)?;
+        let prompt = format!(
+            "Analyze the following content against the provided governance policies.\nReturn a JSON object with 'isValid' (boolean) and 'violations' (array of PolicyViolation objects).\n\nContent:\n{}\n\nPolicies:\n{}",
+            content, policies_json
+        );
+
+        let text = self
+            .generate_text(&prompt)
+            .await
+            .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as Self::Error)?;
+
+        let result_json = if let Some(start) = text.find('{') {
+            if let Some(end) = text.rfind('}') {
+                &text[start..=end]
+            } else {
+                &text
+            }
+        } else {
+            &text
+        };
+
+        serde_json::from_str(result_json).map_err(|e| Box::new(e) as Self::Error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constructor_preserves_region_and_model() {
+        let service = BedrockLlmService::new(
+            "us-east-1".into(),
+            "anthropic.claude-3-5-haiku-20241022-v1:0".into(),
+        );
+
+        assert_eq!(service.region, "us-east-1");
+        assert_eq!(service.model_id, "anthropic.claude-3-5-haiku-20241022-v1:0");
+    }
+}

--- a/memory/src/llm/factory.rs
+++ b/memory/src/llm/factory.rs
@@ -1,0 +1,375 @@
+#[cfg(feature = "embedding-integration")]
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use mk_core::traits::LlmService;
+
+#[cfg(feature = "embedding-integration")]
+struct AnyhowLlmAdapter<T> {
+    inner: T,
+}
+
+#[cfg(feature = "embedding-integration")]
+#[async_trait]
+impl<T> LlmService for AnyhowLlmAdapter<T>
+where
+    T: LlmService<Error = anyhow::Error> + Send + Sync,
+{
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    async fn generate(&self, prompt: &str) -> Result<String, Self::Error> {
+        self.inner
+            .generate(prompt)
+            .await
+            .map_err(|e| -> Self::Error { Box::new(std::io::Error::other(e.to_string())) })
+    }
+
+    async fn analyze_drift(
+        &self,
+        content: &str,
+        policies: &[mk_core::types::Policy],
+    ) -> Result<mk_core::types::ValidationResult, Self::Error> {
+        self.inner
+            .analyze_drift(content, policies)
+            .await
+            .map_err(|e| -> Self::Error { Box::new(std::io::Error::other(e.to_string())) })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LlmFactoryError {
+    #[error("LLM provider configuration error: {0}")]
+    Configuration(String),
+    #[error("LLM provider unavailable in this build: {0}")]
+    Unavailable(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmProviderType {
+    Openai,
+    Google,
+    Bedrock,
+    #[default]
+    None,
+}
+
+impl std::fmt::Display for LlmProviderType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LlmProviderType::Openai => write!(f, "openai"),
+            LlmProviderType::Google => write!(f, "google"),
+            LlmProviderType::Bedrock => write!(f, "bedrock"),
+            LlmProviderType::None => write!(f, "none"),
+        }
+    }
+}
+
+impl std::str::FromStr for LlmProviderType {
+    type Err = LlmFactoryError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "openai" => Ok(LlmProviderType::Openai),
+            "google" | "vertex" | "vertex_ai" | "vertexai" | "gemini" => {
+                Ok(LlmProviderType::Google)
+            }
+            "bedrock" | "aws_bedrock" | "aws-bedrock" => Ok(LlmProviderType::Bedrock),
+            "none" => Ok(LlmProviderType::None),
+            _ => Err(LlmFactoryError::Configuration(format!(
+                "Unknown LLM provider: {s}. Valid options: openai, google, bedrock, none"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct OpenAiLlmConfig {
+    pub model: String,
+    pub api_key: String,
+}
+
+impl OpenAiLlmConfig {
+    pub fn from_env() -> Result<Self, LlmFactoryError> {
+        Ok(Self {
+            model: std::env::var("AETERNA_OPENAI_MODEL").unwrap_or_else(|_| "gpt-4o".to_string()),
+            api_key: std::env::var("OPENAI_API_KEY")
+                .map_err(|_| LlmFactoryError::Configuration("OPENAI_API_KEY not set".into()))?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct GoogleLlmConfig {
+    pub project_id: String,
+    pub location: String,
+    pub model: String,
+}
+
+impl GoogleLlmConfig {
+    pub fn from_env() -> Result<Self, LlmFactoryError> {
+        Ok(Self {
+            project_id: std::env::var("AETERNA_GOOGLE_PROJECT_ID").map_err(|_| {
+                LlmFactoryError::Configuration("AETERNA_GOOGLE_PROJECT_ID not set".into())
+            })?,
+            location: std::env::var("AETERNA_GOOGLE_LOCATION").map_err(|_| {
+                LlmFactoryError::Configuration("AETERNA_GOOGLE_LOCATION not set".into())
+            })?,
+            model: std::env::var("AETERNA_GOOGLE_MODEL").map_err(|_| {
+                LlmFactoryError::Configuration("AETERNA_GOOGLE_MODEL not set".into())
+            })?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct BedrockLlmConfig {
+    pub region: String,
+    pub model_id: String,
+}
+
+impl BedrockLlmConfig {
+    pub fn from_env() -> Result<Self, LlmFactoryError> {
+        Ok(Self {
+            region: std::env::var("AETERNA_BEDROCK_REGION").map_err(|_| {
+                LlmFactoryError::Configuration("AETERNA_BEDROCK_REGION not set".into())
+            })?,
+            model_id: std::env::var("AETERNA_BEDROCK_MODEL").map_err(|_| {
+                LlmFactoryError::Configuration("AETERNA_BEDROCK_MODEL not set".into())
+            })?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LlmProviderConfig {
+    pub provider_type: LlmProviderType,
+    pub openai: Option<OpenAiLlmConfig>,
+    pub google: Option<GoogleLlmConfig>,
+    pub bedrock: Option<BedrockLlmConfig>,
+}
+
+impl LlmProviderConfig {
+    pub fn from_env() -> Result<Self, LlmFactoryError> {
+        let provider_type = std::env::var("AETERNA_LLM_PROVIDER")
+            .unwrap_or_else(|_| "none".to_string())
+            .parse()?;
+
+        Ok(Self {
+            provider_type,
+            openai: matches!(provider_type, LlmProviderType::Openai)
+                .then(OpenAiLlmConfig::from_env)
+                .transpose()?,
+            google: matches!(provider_type, LlmProviderType::Google)
+                .then(GoogleLlmConfig::from_env)
+                .transpose()?,
+            bedrock: matches!(provider_type, LlmProviderType::Bedrock)
+                .then(BedrockLlmConfig::from_env)
+                .transpose()?,
+        })
+    }
+}
+
+pub fn create_llm_service_from_env() -> Result<
+    Option<Arc<dyn LlmService<Error = Box<dyn std::error::Error + Send + Sync>> + Send + Sync>>,
+    LlmFactoryError,
+> {
+    let config = LlmProviderConfig::from_env()?;
+    create_llm_service(config)
+}
+
+pub fn create_llm_service(
+    config: LlmProviderConfig,
+) -> Result<
+    Option<Arc<dyn LlmService<Error = Box<dyn std::error::Error + Send + Sync>> + Send + Sync>>,
+    LlmFactoryError,
+> {
+    match config.provider_type {
+        LlmProviderType::None => Ok(None),
+        LlmProviderType::Openai => {
+            #[allow(unused_variables)]
+            let openai = config.openai.ok_or_else(|| {
+                LlmFactoryError::Configuration("OpenAI LLM config missing".into())
+            })?;
+
+            #[cfg(feature = "embedding-integration")]
+            {
+                let service = AnyhowLlmAdapter {
+                    inner: super::openai::OpenAILlmService::new(openai.api_key, openai.model),
+                };
+                return Ok(Some(Arc::new(service)));
+            }
+
+            #[cfg(not(feature = "embedding-integration"))]
+            {
+                return Err(LlmFactoryError::Unavailable(
+                    "openai support requires the embedding-integration feature".into(),
+                ));
+            }
+        }
+        LlmProviderType::Google => {
+            let google = config.google.ok_or_else(|| {
+                LlmFactoryError::Configuration("Google LLM config missing".into())
+            })?;
+
+            #[cfg(feature = "google-provider")]
+            {
+                let service = super::google::GoogleLlmService::new(
+                    google.project_id,
+                    google.location,
+                    google.model,
+                );
+                return Ok(Some(Arc::new(service)));
+            }
+
+            #[cfg(not(feature = "google-provider"))]
+            {
+                let _ = google;
+                return Err(LlmFactoryError::Unavailable(
+                    "google support requires the google-provider feature".into(),
+                ));
+            }
+        }
+        LlmProviderType::Bedrock => {
+            let bedrock = config.bedrock.ok_or_else(|| {
+                LlmFactoryError::Configuration("Bedrock LLM config missing".into())
+            })?;
+
+            #[cfg(feature = "bedrock-provider")]
+            {
+                let service =
+                    super::bedrock::BedrockLlmService::new(bedrock.region, bedrock.model_id);
+                return Ok(Some(Arc::new(service)));
+            }
+
+            #[cfg(not(feature = "bedrock-provider"))]
+            {
+                let _ = bedrock;
+                return Err(LlmFactoryError::Unavailable(
+                    "bedrock support requires the bedrock-provider feature".into(),
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_provider_aliases() {
+        assert_eq!(
+            "openai".parse::<LlmProviderType>().unwrap(),
+            LlmProviderType::Openai
+        );
+        assert_eq!(
+            "gemini".parse::<LlmProviderType>().unwrap(),
+            LlmProviderType::Google
+        );
+        assert_eq!(
+            "aws-bedrock".parse::<LlmProviderType>().unwrap(),
+            LlmProviderType::Bedrock
+        );
+        assert_eq!(
+            "none".parse::<LlmProviderType>().unwrap(),
+            LlmProviderType::None
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_provider() {
+        let err = "wat".parse::<LlmProviderType>().unwrap_err();
+        assert!(err.to_string().contains("Unknown LLM provider"));
+    }
+
+    #[test]
+    fn none_provider_returns_no_service() {
+        let config = LlmProviderConfig {
+            provider_type: LlmProviderType::None,
+            openai: None,
+            google: None,
+            bedrock: None,
+        };
+
+        let service = create_llm_service(config).unwrap();
+        assert!(service.is_none());
+    }
+
+    #[test]
+    #[cfg(not(feature = "google-provider"))]
+    fn google_provider_is_explicitly_unavailable() {
+        let config = LlmProviderConfig {
+            provider_type: LlmProviderType::Google,
+            openai: None,
+            google: Some(GoogleLlmConfig {
+                project_id: "p".into(),
+                location: "global".into(),
+                model: "gemini-2.5-flash".into(),
+            }),
+            bedrock: None,
+        };
+
+        let err = match create_llm_service(config) {
+            Ok(_) => panic!("expected google provider to be unavailable"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("google"));
+    }
+
+    #[test]
+    #[cfg(feature = "google-provider")]
+    fn google_provider_is_constructed_when_feature_enabled() {
+        let config = LlmProviderConfig {
+            provider_type: LlmProviderType::Google,
+            openai: None,
+            google: Some(GoogleLlmConfig {
+                project_id: "p".into(),
+                location: "global".into(),
+                model: "gemini-2.5-flash".into(),
+            }),
+            bedrock: None,
+        };
+
+        let service = create_llm_service(config).unwrap();
+        assert!(service.is_some());
+    }
+
+    #[test]
+    #[cfg(not(feature = "bedrock-provider"))]
+    fn bedrock_provider_is_explicitly_unavailable_without_feature() {
+        let config = LlmProviderConfig {
+            provider_type: LlmProviderType::Bedrock,
+            openai: None,
+            google: None,
+            bedrock: Some(BedrockLlmConfig {
+                region: "us-east-1".into(),
+                model_id: "anthropic.claude-3-5-haiku-20241022-v1:0".into(),
+            }),
+        };
+
+        let err = match create_llm_service(config) {
+            Ok(_) => panic!("expected bedrock provider to be unavailable"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("bedrock"));
+    }
+
+    #[test]
+    #[cfg(feature = "bedrock-provider")]
+    fn bedrock_provider_is_constructed_when_feature_enabled() {
+        let config = LlmProviderConfig {
+            provider_type: LlmProviderType::Bedrock,
+            openai: None,
+            google: None,
+            bedrock: Some(BedrockLlmConfig {
+                region: "us-east-1".into(),
+                model_id: "anthropic.claude-3-5-haiku-20241022-v1:0".into(),
+            }),
+        };
+
+        let service = create_llm_service(config).unwrap();
+        assert!(service.is_some());
+    }
+}

--- a/memory/src/llm/google.rs
+++ b/memory/src/llm/google.rs
@@ -1,0 +1,276 @@
+#![cfg(feature = "google-provider")]
+
+use async_trait::async_trait;
+use gcp_auth::TokenProvider;
+use mk_core::traits::LlmService;
+use mk_core::types::{Policy, ValidationResult};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Debug, Serialize)]
+struct GenerateContentRequest {
+    contents: Vec<GoogleContent>,
+}
+
+#[derive(Debug, Serialize)]
+struct GoogleContent {
+    role: String,
+    parts: Vec<GooglePart>,
+}
+
+#[derive(Debug, Serialize)]
+struct GooglePart {
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenerateContentResponse {
+    #[serde(default)]
+    candidates: Vec<GoogleCandidate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleCandidate {
+    content: Option<GoogleResponseContent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleResponseContent {
+    #[serde(default)]
+    parts: Vec<GoogleResponsePart>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleResponsePart {
+    text: Option<String>,
+}
+
+struct CachedToken {
+    token: String,
+    expires_at: std::time::Instant,
+}
+
+type GoogleTokenProvider = Arc<dyn TokenProvider>;
+
+pub struct GoogleLlmService {
+    client: Client,
+    project_id: String,
+    location: String,
+    model: String,
+    base_url: String,
+    access_token: Arc<RwLock<Option<CachedToken>>>,
+    token_provider: Arc<tokio::sync::OnceCell<GoogleTokenProvider>>,
+}
+
+impl GoogleLlmService {
+    pub fn new(project_id: String, location: String, model: String) -> Self {
+        Self {
+            client: Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("Google LLM HTTP client should build"),
+            project_id,
+            location,
+            model,
+            base_url: "https://aiplatform.googleapis.com".to_string(),
+            access_token: Arc::new(RwLock::new(None)),
+            token_provider: Arc::new(tokio::sync::OnceCell::new()),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url = base_url;
+        self
+    }
+
+    #[cfg(test)]
+    fn with_cached_access_token(mut self, token: impl Into<String>) -> Self {
+        self.access_token = Arc::new(RwLock::new(Some(CachedToken {
+            token: token.into(),
+            expires_at: std::time::Instant::now() + std::time::Duration::from_secs(3600),
+        })));
+        self
+    }
+
+    fn endpoint(&self) -> String {
+        format!(
+            "{}/v1/projects/{}/locations/{}/publishers/google/models/{}:generateContent",
+            self.base_url, self.project_id, self.location, self.model
+        )
+    }
+
+    async fn access_token(&self) -> anyhow::Result<String> {
+        {
+            let cached = self.access_token.read().await;
+            if let Some(token) = cached.as_ref()
+                && token.expires_at > std::time::Instant::now()
+            {
+                return Ok(token.token.clone());
+            }
+        }
+
+        let token = if let Ok(token) = std::env::var("GOOGLE_ACCESS_TOKEN") {
+            token
+        } else {
+            self.fetch_adc_token().await?
+        };
+
+        {
+            let mut cached = self.access_token.write().await;
+            *cached = Some(CachedToken {
+                token: token.clone(),
+                expires_at: std::time::Instant::now() + std::time::Duration::from_secs(3500),
+            });
+        }
+
+        Ok(token)
+    }
+
+    async fn token_provider(&self) -> anyhow::Result<&GoogleTokenProvider> {
+        self.token_provider
+            .get_or_try_init(|| async {
+                let provider = gcp_auth::provider().await.map_err(|e| {
+                    anyhow::anyhow!("failed to initialize Google ADC token provider: {e}")
+                })?;
+                Ok::<GoogleTokenProvider, anyhow::Error>(provider)
+            })
+            .await
+    }
+
+    async fn fetch_adc_token(&self) -> anyhow::Result<String> {
+        let provider = self.token_provider().await?;
+        let token = provider
+            .token(&["https://www.googleapis.com/auth/cloud-platform"])
+            .await
+            .map_err(|e| anyhow::anyhow!("Google access token not available from ADC: {e}"))?;
+        Ok(token.as_str().to_string())
+    }
+
+    async fn generate_text(&self, prompt: &str) -> anyhow::Result<String> {
+        let token = self.access_token().await?;
+        let response = self
+            .client
+            .post(self.endpoint())
+            .bearer_auth(token)
+            .json(&GenerateContentRequest {
+                contents: vec![GoogleContent {
+                    role: "user".to_string(),
+                    parts: vec![GooglePart {
+                        text: prompt.to_string(),
+                    }],
+                }],
+            })
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Google generateContent failed with {status}: {body}")
+        }
+
+        let payload: GenerateContentResponse = response.json().await?;
+        let text = payload
+            .candidates
+            .first()
+            .and_then(|candidate| candidate.content.as_ref())
+            .and_then(|content| content.parts.first())
+            .and_then(|part| part.text.clone())
+            .ok_or_else(|| anyhow::anyhow!("Google generateContent returned no text"))?;
+
+        Ok(text)
+    }
+}
+
+#[async_trait]
+impl LlmService for GoogleLlmService {
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    async fn generate(&self, prompt: &str) -> Result<String, Self::Error> {
+        self.generate_text(prompt)
+            .await
+            .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as Self::Error)
+    }
+
+    async fn analyze_drift(
+        &self,
+        content: &str,
+        policies: &[Policy],
+    ) -> Result<ValidationResult, Self::Error> {
+        let policies_json =
+            serde_json::to_string_pretty(policies).map_err(|e| Box::new(e) as Self::Error)?;
+        let prompt = format!(
+            "Analyze the following content against the provided governance policies.\nReturn a JSON object with 'isValid' (boolean) and 'violations' (array of PolicyViolation objects).\n\nContent:\n{}\n\nPolicies:\n{}",
+            content, policies_json
+        );
+
+        let text = self
+            .generate_text(&prompt)
+            .await
+            .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as Self::Error)?;
+
+        let result_json = if let Some(start) = text.find('{') {
+            if let Some(end) = text.rfind('}') {
+                &text[start..=end]
+            } else {
+                &text
+            }
+        } else {
+            &text
+        };
+
+        serde_json::from_str(result_json).map_err(|e| Box::new(e) as Self::Error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustls::crypto::aws_lc_rs;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn install_crypto_provider() {
+        let _ = aws_lc_rs::default_provider().install_default();
+    }
+
+    #[tokio::test]
+    async fn prefers_explicit_google_access_token() {
+        install_crypto_provider();
+        let service =
+            GoogleLlmService::new("proj".into(), "global".into(), "gemini-2.5-flash".into())
+                .with_cached_access_token("test-token");
+
+        let token = service.access_token().await.unwrap();
+        assert_eq!(token, "test-token");
+    }
+
+    #[tokio::test]
+    async fn adapts_generate_content_response() {
+        install_crypto_provider();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/locations/global/publishers/google/models/gemini-2.5-flash:generateContent"))
+            .and(header("authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "text": "hello from google" }]
+                    }
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let service =
+            GoogleLlmService::new("proj".into(), "global".into(), "gemini-2.5-flash".into())
+                .with_base_url(server.uri())
+                .with_cached_access_token("test-token");
+
+        let text = service.generate("hi").await.unwrap();
+        assert_eq!(text, "hello from google");
+    }
+}

--- a/memory/src/llm/mod.rs
+++ b/memory/src/llm/mod.rs
@@ -5,14 +5,26 @@ pub mod mock;
 
 #[cfg(feature = "llm-integration")]
 pub mod aisdk;
+#[cfg(feature = "bedrock-provider")]
+pub mod bedrock;
 #[cfg(feature = "llm-integration")]
 pub mod extractor;
+pub mod factory;
+#[cfg(feature = "google-provider")]
+pub mod google;
 #[cfg(feature = "embedding-integration")]
 pub mod openai;
 
 #[cfg(feature = "llm-integration")]
 pub use aisdk::AisdkLlmService;
+#[cfg(feature = "bedrock-provider")]
+pub use bedrock::BedrockLlmService;
 #[cfg(feature = "llm-integration")]
 pub use extractor::EntityExtractor;
+pub use factory::{
+    LlmFactoryError, LlmProviderConfig, LlmProviderType, create_llm_service_from_env,
+};
+#[cfg(feature = "google-provider")]
+pub use google::GoogleLlmService;
 #[cfg(feature = "embedding-integration")]
 pub use openai::OpenAILlmService;

--- a/openspec/changes/add-cloud-llm-providers/design.md
+++ b/openspec/changes/add-cloud-llm-providers/design.md
@@ -1,0 +1,119 @@
+## Context
+
+Aeterna already defines provider-agnostic `LlmService` and `EmbeddingService` traits, and the `MemoryManager` can accept concrete implementations through dependency injection. However, the production runtime does not have a factory that reads deployment configuration and instantiates the requested provider. The only clearly implemented core path today is OpenAI. Helm and setup surfaces mention Anthropic and Ollama, but those options are not fully wired through the server runtime.
+
+At the same time, the project already carries patterns that make cloud-provider support plausible: vector backend factories, Vertex AI vector integration, feature-gated provider modules, and deployment-time environment injection. This change needs to convert those pieces into a coherent runtime provider model for server-side LLM and embedding services.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a runtime provider factory for LLM and embedding services
+- Add Google Cloud Vertex AI / Gemini as a supported provider for text generation and embeddings
+- Add AWS Bedrock as a supported provider for text generation and embeddings
+- Ensure provider selection is driven by deployment/runtime config rather than ad hoc service construction
+- Extend Helm and setup surfaces to configure provider-specific auth and model settings
+- Preserve explicit fail-closed behavior when provider configuration is missing or invalid
+
+**Non-Goals:**
+- Rework the existing trait model for LLM or embedding services
+- Implement every documented provider mentioned in setup or docs
+- Add direct browser-user identity federation to Bedrock or Google APIs
+- Replace OpenAI as a supported provider
+- Solve every cloud-specific optimization such as provider-specific streaming, guardrails, or advanced tool-use semantics in the first change
+
+## Decisions
+
+### Decision: Introduce a dedicated runtime factory for LLM and embedding providers
+
+The server runtime will gain a provider factory layer that reads runtime configuration and constructs concrete `LlmService` and `EmbeddingService` implementations. This mirrors the existing vector backend factory pattern and removes the current mismatch where Helm sets `AETERNA_LLM_PROVIDER` but the Rust runtime does not consume it directly.
+
+**Why:**
+- The current trait boundary is good, but provider selection is missing
+- New providers should not require ad hoc wiring at every call site
+- A single construction layer makes fail-closed validation testable and consistent
+
+**Alternatives considered:**
+- Continue constructing providers manually in callers: rejected because it spreads provider-selection logic and keeps deployment configuration disconnected from runtime behavior
+- Fold provider selection into `MemoryManager::new()`: rejected because factory concerns should remain separate from manager lifecycle and test injection
+
+### Decision: Treat Google Cloud support as Vertex AI / Gemini server-side integration
+
+Google Cloud support will target Vertex AI / Gemini rather than ad hoc Google AI Studio paths. The provider will support server-side text generation and embeddings through a consistent cloud-authenticated runtime path.
+
+**Why:**
+- Enterprise deployments need project/location-scoped server credentials rather than user API keys
+- The repo already contains Vertex-style patterns on the vector side
+- Vertex AI offers both generation and embeddings in one cloud integration model
+
+**Alternatives considered:**
+- Google AI Studio API-key path as the primary provider: rejected because it is less aligned with enterprise cloud deployment and existing repo patterns
+- Gemini-only generation without embeddings: rejected because memory workflows require embeddings as a first-class server capability
+
+### Decision: Treat AWS support as Bedrock Runtime integration
+
+AWS support will target Bedrock Runtime for text generation and embeddings. Text generation will use the normalized conversational runtime path where possible, while embeddings will use the provider-appropriate invocation path for supported embedding models.
+
+**Why:**
+- Bedrock is the AWS-managed model surface that fits the enterprise deployment goal
+- It allows operators to use AWS-managed credentials and model access rather than external API keys
+- It supports both generation and embeddings under the same cloud control plane, even if the API shapes differ internally
+
+**Alternatives considered:**
+- Direct vendor APIs from AWS-hosted workloads: rejected because that does not provide a first-class AWS cloud-provider integration
+- Limiting AWS to generation only: rejected because the memory system depends on embeddings too
+
+### Decision: Keep the common trait surface simple and absorb provider differences in adapters
+
+The existing `generate()` and `embed()` trait model will remain the common server interface. Provider-specific differences — such as model path formats, regional configuration, ADC/IAM auth, or Bedrock embedding request schemas — will be handled inside provider adapters and provider configuration parsing.
+
+**Why:**
+- The current trait abstraction is already sufficient for the current server needs
+- Avoids leaking provider-specific complexity across the rest of the codebase
+- Makes tests and fail-closed behavior easier to reason about
+
+**Alternatives considered:**
+- Expand the trait model immediately for every advanced provider-specific feature: rejected because it would make the first multi-cloud provider step much larger and less coherent
+
+### Decision: Deployment surfaces MUST expose explicit provider-specific auth and model settings
+
+Helm, setup flows, and runtime config will explicitly model the settings needed to run each provider:
+- OpenAI: API key and model identifiers
+- Google Cloud: project, location, model identifiers, and ADC/service-account credential references
+- AWS Bedrock: region, model identifiers, and IAM/credential-chain compatible runtime settings
+
+Missing or inconsistent provider configuration MUST fail closed during render, startup, or provider construction rather than silently falling back.
+
+**Why:**
+- Bedrock and Vertex AI have materially different auth and model selection requirements from OpenAI
+- Deployment surfaces must reflect those differences honestly
+- Silent fallback would create confusing and insecure runtime behavior
+
+**Alternatives considered:**
+- One generic provider config blob for all providers: rejected because it obscures required fields and weakens validation
+
+## Risks / Trade-offs
+
+- **[Provider factory without full runtime adoption]** → Mitigate by defining explicit server-side provider-construction requirements and wiring tests
+- **[Google auth complexity]** → Reuse ADC/service-account patterns already familiar from GCP environments and document required secrets/workload identity behavior
+- **[Bedrock request-shape differences for embeddings]** → Keep those differences inside the Bedrock embedding adapter and constrain the first supported model set
+- **[Feature-flag drift]** → Tie provider modules and Cargo features to explicit tests and deployment docs so unsupported builds fail clearly
+- **[Operators choosing providers that are scaffolded but not fully wired]** → Add fail-closed validation in Helm/runtime and document exactly which providers are production-supported
+
+## Migration Plan
+
+1. Add runtime provider factory modules and connect server-side construction to explicit provider configuration
+2. Add Google Cloud provider implementations and tests for generation, embeddings, and fail-closed config validation
+3. Add AWS Bedrock provider implementations and tests for generation, embeddings, and fail-closed config validation
+4. Extend setup and Helm surfaces to support Google Cloud and Bedrock config/auth requirements
+5. Document the supported production paths and rollout requirements for both providers
+
+Rollback strategy:
+- revert provider selection to `none` or an already-supported provider such as OpenAI
+- keep fail-closed runtime behavior for operations that require unavailable LLM or embedding services
+
+## Open Questions
+
+- Which Google model set should be the initial supported default for generation and embeddings?
+- Which Bedrock embedding model(s) should be the first officially supported set?
+- Should the first Bedrock implementation support only synchronous calls, leaving streaming for a later change?
+- Should provider-specific secrets/config validation happen entirely at Helm render time, or also at binary startup even outside Helm-managed deployments?

--- a/openspec/changes/add-cloud-llm-providers/proposal.md
+++ b/openspec/changes/add-cloud-llm-providers/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Aeterna currently defines provider-agnostic LLM and embedding traits, but the core runtime only has a clearly implemented OpenAI path and lacks a runtime factory that selects providers from deployment configuration. Enterprise deployments need first-class support for cloud-managed providers so operators can run Aeterna on AWS or Google Cloud without forcing all model traffic through OpenAI-specific credentials and APIs.
+
+## What Changes
+
+- Add a supported runtime provider-selection layer for LLM and embedding services so the server can instantiate providers from deployment configuration instead of relying on ad hoc construction
+- Add Google Cloud Vertex AI / Gemini as a supported server-side provider for text generation and embeddings
+- Add AWS Bedrock as a supported server-side provider for text generation and embeddings
+- Extend deployment, Helm, and setup surfaces so operators can configure provider-specific credentials, model identifiers, regions/projects, and runtime environment for OpenAI, Google Cloud, AWS Bedrock, and explicit no-provider mode
+- Document provider-specific operational requirements, including ADC/service-account setup for Google Cloud and IAM/region requirements for AWS Bedrock
+
+## Capabilities
+
+### New Capabilities
+- `model-provider-runtime`: Runtime selection and configuration of LLM and embedding providers for server-side Aeterna services
+
+### Modified Capabilities
+- `memory-system`: Change memory and reasoning requirements so configured LLM and embedding providers can be instantiated from runtime configuration and used consistently across server-side operations
+- `deployment`: Add supported deployment requirements for Google Cloud and AWS Bedrock credentials, secret handling, runtime env wiring, and provider-specific configuration
+
+## Impact
+
+- Affected code:
+  - `memory/`
+  - `mk_core/`
+  - `cli/src/commands/setup/`
+  - `charts/aeterna/`
+  - `docs/`, `README.md`, `INSTALL.md`
+- Affected systems:
+  - server-side LLM/embedding service construction
+  - memory and reasoning workflows that depend on embeddings or text generation
+  - Helm values, secrets, and runtime environment configuration
+- External dependencies:
+  - Google Cloud Vertex AI / Gemini SDK or API integration
+  - AWS Bedrock Runtime SDK integration
+  - Google ADC / service account credentials
+  - AWS IAM / regional Bedrock model access

--- a/openspec/changes/add-cloud-llm-providers/specs/deployment/spec.md
+++ b/openspec/changes/add-cloud-llm-providers/specs/deployment/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Deployment Configuration
+The system SHALL support deployment-time configuration of server-side model providers, including provider-specific credentials, model identifiers, and runtime settings.
+
+#### Scenario: Configure Google Cloud model provider
+- **WHEN** deploying with Google Cloud as the selected model provider
+- **THEN** the deployment configuration SHALL expose the required project, location, generation model, embedding model, and credential reference settings
+- **AND** the runtime environment SHALL receive the corresponding configuration needed to construct the provider
+
+#### Scenario: Configure AWS Bedrock model provider
+- **WHEN** deploying with AWS Bedrock as the selected model provider
+- **THEN** the deployment configuration SHALL expose the required AWS region, generation model, embedding model, and credential-chain-compatible runtime settings
+- **AND** the runtime environment SHALL receive the corresponding configuration needed to construct the provider
+
+#### Scenario: Reject incomplete cloud provider deployment configuration
+- **WHEN** a deployment selects Google Cloud or AWS Bedrock without the required provider-specific configuration
+- **THEN** the deployment SHALL fail closed during validation or startup
+- **AND** the operator SHALL receive an error identifying the missing required settings

--- a/openspec/changes/add-cloud-llm-providers/specs/memory-system/spec.md
+++ b/openspec/changes/add-cloud-llm-providers/specs/memory-system/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Embedding Generation
+The system SHALL generate vector embeddings for memory content using the configured runtime embedding provider.
+
+#### Scenario: Generate embedding for new content
+- **WHEN** adding a memory with new content
+- **THEN** the system SHALL generate vector embedding using the configured runtime embedding provider
+- **AND** the system SHALL store the embedding with memory
+- **AND** the system SHALL return `embeddingGenerated: true`
+
+#### Scenario: Cache repeated embeddings
+- **WHEN** adding memory with content seen before
+- **THEN** the system SHALL return a cached embedding if one exists
+- **AND** the system SHALL NOT call the embedding provider again
+
+#### Scenario: Reject provider-dependent embedding operation when provider construction failed
+- **WHEN** an operation requires embeddings but the configured embedding provider failed validation or construction
+- **THEN** the system SHALL fail closed
+- **AND** the error SHALL indicate that the configured embedding provider is unavailable
+
+### Requirement: LLM-based Entity Extraction
+The system SHALL use the configured runtime LLM provider to extract entities and relationships from memory content.
+
+#### Scenario: Extract entities with configured runtime provider
+- **WHEN** processing memory content that requires entity extraction
+- **THEN** the system SHALL invoke the configured runtime LLM provider to extract named entities
+
+#### Scenario: Extract relationships with configured runtime provider
+- **WHEN** processing memory content that contains multiple named entities
+- **THEN** the system SHALL invoke the configured runtime LLM provider to identify relationships between entities
+
+#### Scenario: Fail closed when configured LLM provider is unavailable
+- **WHEN** an operation requires LLM-based extraction and the configured runtime LLM provider failed validation or construction
+- **THEN** the system SHALL fail closed
+- **AND** the error SHALL identify that the configured LLM provider is unavailable

--- a/openspec/changes/add-cloud-llm-providers/specs/model-provider-runtime/spec.md
+++ b/openspec/changes/add-cloud-llm-providers/specs/model-provider-runtime/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Runtime Model Provider Selection
+The system SHALL support explicit runtime selection of server-side LLM and embedding providers from deployment configuration.
+
+#### Scenario: Construct configured provider pair at startup
+- **WHEN** the runtime is configured with a supported model provider and the required provider settings
+- **THEN** the system SHALL construct the matching LLM and embedding services through a dedicated runtime factory
+- **AND** the constructed services SHALL be injected into server-side memory and reasoning workflows
+
+#### Scenario: Reject unsupported provider selection
+- **WHEN** the runtime is configured with a provider value that is not implemented
+- **THEN** the system SHALL fail closed during provider construction
+- **AND** the error SHALL identify the unsupported provider
+
+### Requirement: Provider-Specific Configuration Validation
+The system SHALL validate provider-specific configuration before enabling server-side LLM or embedding operations.
+
+#### Scenario: Reject incomplete Google provider configuration
+- **WHEN** the runtime selects the Google Cloud provider without the required project, location, or model configuration
+- **THEN** the system SHALL fail closed before serving provider-dependent operations
+- **AND** the error SHALL identify the missing Google configuration fields
+
+#### Scenario: Reject incomplete Bedrock provider configuration
+- **WHEN** the runtime selects the AWS Bedrock provider without the required region or model configuration
+- **THEN** the system SHALL fail closed before serving provider-dependent operations
+- **AND** the error SHALL identify the missing Bedrock configuration fields
+
+### Requirement: Supported Cloud Provider Set
+The system SHALL support Google Cloud and AWS Bedrock as first-class server-side provider options.
+
+#### Scenario: Use Google Cloud provider
+- **WHEN** the runtime selects the Google Cloud provider with valid credentials and model configuration
+- **THEN** the system SHALL use Google Cloud for text generation and embeddings
+
+#### Scenario: Use AWS Bedrock provider
+- **WHEN** the runtime selects the AWS Bedrock provider with valid credentials and model configuration
+- **THEN** the system SHALL use AWS Bedrock for text generation and embeddings

--- a/openspec/changes/add-cloud-llm-providers/tasks.md
+++ b/openspec/changes/add-cloud-llm-providers/tasks.md
@@ -1,0 +1,25 @@
+## 1. Shared runtime provider factory
+- [x] 1.1 Add runtime factory modules for LLM and embedding provider construction
+- [x] 1.2 Define provider-selection config parsing and fail-closed validation for supported providers
+- [x] 1.3 Wire factory-created services into server-side memory and reasoning initialization paths
+- [x] 1.4 Add unit tests for provider selection, invalid provider handling, and missing-config failures
+
+## 2. Google Cloud provider support
+- [x] 2.1 Add Google Cloud generation provider implementation
+- [x] 2.2 Add Google Cloud embedding provider implementation
+- [x] 2.3 Add tests for Google provider request/response adaptation and fail-closed config handling
+
+## 3. AWS Bedrock provider support
+- [x] 3.1 Add AWS Bedrock generation provider implementation
+- [x] 3.2 Add AWS Bedrock embedding provider implementation
+- [x] 3.3 Add tests for Bedrock request/response adaptation and fail-closed config handling
+
+## 4. Deployment and setup surfaces
+- [x] 4.1 Extend Helm values, schema, configmap, deployment, and secret handling for Google Cloud and AWS Bedrock
+- [x] 4.2 Extend setup CLI provider enums, prompts, and config generation for Google Cloud and AWS Bedrock
+- [x] 4.3 Add deployment validation coverage for supported provider configurations
+
+## 5. Documentation and verification
+- [x] 5.1 Document supported provider configuration and operational requirements for Google Cloud and AWS Bedrock
+- [x] 5.2 Run targeted tests for new provider modules and provider-factory wiring
+- [ ] 5.3 Run required workspace validation and coverage checks and resolve regressions caused by the change

--- a/storage/src/policy_evaluator.rs
+++ b/storage/src/policy_evaluator.rs
@@ -267,3 +267,276 @@ impl PolicyEvaluator for CachedPolicyEvaluator {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    fn allow_all_policy() -> &'static str {
+        r#"
+permit(
+    principal,
+    action,
+    resource
+);
+"#
+    }
+
+    fn deny_all_policy() -> &'static str {
+        r#"
+forbid(
+    principal,
+    action,
+    resource
+);
+"#
+    }
+
+    fn allow_admin_only_policy() -> &'static str {
+        r#"
+permit(
+    principal in Aeterna::Role::"admin",
+    action,
+    resource
+);
+"#
+    }
+
+    fn make_context(principal_id: &str, roles: &[&str], tenant_id: &str) -> PolicyContext {
+        PolicyContext {
+            principal_id: principal_id.to_string(),
+            principal_roles: roles.iter().map(|s| s.to_string()).collect(),
+            tenant_id: tenant_id.to_string(),
+        }
+    }
+
+    fn make_repo(id: &str, tenant_id: &str, name: &str) -> crate::repo_manager::Repository {
+        use chrono::Utc;
+        use uuid::Uuid;
+        crate::repo_manager::Repository {
+            id: id.parse::<Uuid>().unwrap_or_else(|_| Uuid::new_v4()),
+            tenant_id: tenant_id.to_string(),
+            identity_id: None,
+            name: name.to_string(),
+            r#type: crate::repo_manager::RepositoryType::Remote,
+            remote_url: None,
+            local_path: None,
+            current_branch: "main".to_string(),
+            tracked_branches: vec![],
+            sync_strategy: crate::repo_manager::SyncStrategy::Job,
+            sync_interval_mins: None,
+            status: crate::repo_manager::RepositoryStatus::Ready,
+            last_indexed_commit: None,
+            last_indexed_at: None,
+            last_used_at: None,
+            owner_id: None,
+            shard_id: None,
+            cold_storage_uri: None,
+            config: serde_json::Value::Null,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn make_request(id: &str) -> crate::repo_manager::RepoRequest {
+        use chrono::Utc;
+        use uuid::Uuid;
+        crate::repo_manager::RepoRequest {
+            id: id.parse::<Uuid>().unwrap_or_else(|_| Uuid::new_v4()),
+            repository_id: Uuid::new_v4(),
+            requester_id: "user-1".to_string(),
+            status: crate::repo_manager::RepoRequestStatus::Pending,
+            policy_result: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // CedarPolicyEvaluator — construction
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_cedar_evaluator_bad_policy_returns_error() {
+        let result = CedarPolicyEvaluator::new("this is not valid cedar syntax !!!");
+        assert!(result.is_err(), "Expected parse error for invalid Cedar policy");
+    }
+
+    #[test]
+    fn test_cedar_evaluator_valid_policy_constructs_ok() {
+        let result = CedarPolicyEvaluator::new(allow_all_policy());
+        assert!(result.is_ok(), "Expected Ok for valid Cedar policy");
+    }
+
+    // ---------------------------------------------------------------------------
+    // CedarPolicyEvaluator — evaluate_request
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_evaluate_request_allow_all() {
+        let evaluator = CedarPolicyEvaluator::new(allow_all_policy()).unwrap();
+        let ctx = make_context("user-1", &["developer"], "tenant-a");
+        let repo = make_repo("00000000-0000-0000-0000-000000000001", "tenant-a", "my-repo");
+
+        let allowed = evaluator.evaluate_request(&ctx, "ReadCode", &repo).await.unwrap();
+        assert!(allowed, "allow-all policy should allow the request");
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_request_deny_all() {
+        let evaluator = CedarPolicyEvaluator::new(deny_all_policy()).unwrap();
+        let ctx = make_context("user-1", &["admin"], "tenant-a");
+        let repo = make_repo("00000000-0000-0000-0000-000000000002", "tenant-a", "my-repo");
+
+        let allowed = evaluator.evaluate_request(&ctx, "WriteCode", &repo).await.unwrap();
+        assert!(!allowed, "deny-all (forbid) policy should deny the request");
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_request_role_based_allow() {
+        let evaluator = CedarPolicyEvaluator::new(allow_admin_only_policy()).unwrap();
+        let admin_ctx = make_context("alice", &["admin"], "tenant-a");
+        let dev_ctx = make_context("bob", &["developer"], "tenant-a");
+        let repo = make_repo("00000000-0000-0000-0000-000000000003", "tenant-a", "my-repo");
+
+        let admin_allowed = evaluator.evaluate_request(&admin_ctx, "ManageRepo", &repo).await.unwrap();
+        let dev_allowed = evaluator.evaluate_request(&dev_ctx, "ManageRepo", &repo).await.unwrap();
+
+        assert!(admin_allowed, "admin role should be allowed by admin-only policy");
+        assert!(!dev_allowed, "developer role should not be allowed by admin-only policy");
+    }
+
+    // ---------------------------------------------------------------------------
+    // CedarPolicyEvaluator — evaluate_approval
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_evaluate_approval_allow_all() {
+        let evaluator = CedarPolicyEvaluator::new(allow_all_policy()).unwrap();
+        let ctx = make_context("user-1", &["developer"], "tenant-a");
+        let request = make_request("00000000-0000-0000-0000-000000000010");
+
+        let allowed = evaluator.evaluate_approval(&ctx, &request).await.unwrap();
+        assert!(allowed, "allow-all policy should allow approval");
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_approval_deny_all() {
+        let evaluator = CedarPolicyEvaluator::new(deny_all_policy()).unwrap();
+        let ctx = make_context("user-1", &["admin"], "tenant-a");
+        let request = make_request("00000000-0000-0000-0000-000000000011");
+
+        let allowed = evaluator.evaluate_approval(&ctx, &request).await.unwrap();
+        assert!(!allowed, "deny-all policy should deny approval");
+    }
+
+    // ---------------------------------------------------------------------------
+    // CacheEntry
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_cache_entry_valid_before_expiry() {
+        let entry = CacheEntry::new(true, Duration::from_secs(60));
+        assert!(entry.is_valid(), "Entry should be valid before TTL expires");
+        assert!(entry.allowed);
+    }
+
+    #[test]
+    fn test_cache_entry_expired_immediately() {
+        let entry = CacheEntry::new(false, Duration::from_millis(0));
+        // Give the CPU a tiny bit so Instant::now() > expires_at
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(!entry.is_valid(), "Entry with 0 TTL should immediately expire");
+        assert!(!entry.allowed);
+    }
+
+    // ---------------------------------------------------------------------------
+    // cache_key
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_cache_key_format() {
+        let key = cache_key("user-1", "ReadCode", &"repo-42");
+        assert_eq!(key, "user-1::ReadCode::repo-42");
+    }
+
+    #[test]
+    fn test_cache_key_unique_on_different_actions() {
+        let k1 = cache_key("user-1", "Read", &"r");
+        let k2 = cache_key("user-1", "Write", &"r");
+        assert_ne!(k1, k2);
+    }
+
+    // ---------------------------------------------------------------------------
+    // CachedPolicyEvaluator
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_cached_evaluator_cache_miss_then_hit() {
+        let inner = Arc::new(CedarPolicyEvaluator::new(allow_all_policy()).unwrap());
+        let cached = CachedPolicyEvaluator::new(inner, Duration::from_secs(60));
+
+        let ctx = make_context("user-1", &["developer"], "tenant-a");
+        let repo = make_repo("00000000-0000-0000-0000-000000000020", "tenant-a", "repo");
+
+        // First call: cache miss — should call inner and store result.
+        let result1 = cached.evaluate_request(&ctx, "Read", &repo).await.unwrap();
+        // Second call with same args: should be a cache hit.
+        let result2 = cached.evaluate_request(&ctx, "Read", &repo).await.unwrap();
+
+        assert_eq!(result1, result2);
+        assert!(result1);
+    }
+
+    #[tokio::test]
+    async fn test_cached_evaluator_invalidate_clears_cache() {
+        let inner = Arc::new(CedarPolicyEvaluator::new(allow_all_policy()).unwrap());
+        let cached = CachedPolicyEvaluator::new(inner, Duration::from_secs(60));
+
+        let ctx = make_context("user-1", &["developer"], "tenant-a");
+        let repo = make_repo("00000000-0000-0000-0000-000000000021", "tenant-a", "repo");
+
+        // Populate cache.
+        let _ = cached.evaluate_request(&ctx, "Read", &repo).await.unwrap();
+        assert!(!cached.cache.read().is_empty(), "Cache should be populated");
+
+        cached.invalidate();
+        assert!(cached.cache.read().is_empty(), "Cache should be empty after invalidate()");
+    }
+
+    #[tokio::test]
+    async fn test_cached_evaluator_evict_expired_removes_stale_entries() {
+        let inner = Arc::new(CedarPolicyEvaluator::new(allow_all_policy()).unwrap());
+        let cached = CachedPolicyEvaluator::new(inner, Duration::from_millis(1));
+
+        let ctx = make_context("user-1", &["developer"], "tenant-a");
+        let repo = make_repo("00000000-0000-0000-0000-000000000022", "tenant-a", "repo");
+
+        // Populate cache with a very short TTL entry.
+        let _ = cached.evaluate_request(&ctx, "Read", &repo).await.unwrap();
+        // Wait for TTL to expire.
+        std::thread::sleep(Duration::from_millis(10));
+
+        cached.evict_expired();
+        assert!(cached.cache.read().is_empty(), "Expired entries should be removed by evict_expired()");
+    }
+
+    #[tokio::test]
+    async fn test_cached_evaluator_approval_hit() {
+        let inner = Arc::new(CedarPolicyEvaluator::new(allow_all_policy()).unwrap());
+        let cached = CachedPolicyEvaluator::new(inner, Duration::from_secs(60));
+
+        let ctx = make_context("user-1", &["developer"], "tenant-a");
+        let request = make_request("00000000-0000-0000-0000-000000000030");
+
+        let r1 = cached.evaluate_approval(&ctx, &request).await.unwrap();
+        let r2 = cached.evaluate_approval(&ctx, &request).await.unwrap();
+        assert_eq!(r1, r2);
+        assert!(r1);
+    }
+}

--- a/storage/src/secret_provider.rs
+++ b/storage/src/secret_provider.rs
@@ -166,3 +166,150 @@ impl SecretProvider for VaultSecretProvider {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    // ---------------------------------------------------------------------------
+    // SecretError — Display
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_secret_error_display_variants() {
+        let cases: Vec<(&str, SecretError)> = vec![
+            ("Secret operation failed: boom", SecretError::OperationFailed("boom".into())),
+            ("Secret not found: my-key", SecretError::NotFound("my-key".into())),
+            ("Authentication failed: bad token", SecretError::AuthFailed("bad token".into())),
+            ("Invalid configuration: missing field", SecretError::ConfigError("missing field".into())),
+            ("Connection failed: timeout", SecretError::ConnectionFailed("timeout".into())),
+            ("Format error: bad json", SecretError::FormatError("bad json".into())),
+            ("Retrieval failed: 403", SecretError::RetrievalFailed("403".into())),
+        ];
+
+        for (expected, err) in cases {
+            assert_eq!(err.to_string(), expected);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // SecretProviderConfig — serde round-trip
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_secret_provider_config_serde_aws() {
+        let cfg = SecretProviderConfig::Aws {
+            region: "us-east-1".to_string(),
+            endpoint: None,
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: SecretProviderConfig = serde_json::from_str(&json).unwrap();
+        match back {
+            SecretProviderConfig::Aws { region, endpoint } => {
+                assert_eq!(region, "us-east-1");
+                assert!(endpoint.is_none());
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_secret_provider_config_serde_vault() {
+        let cfg = SecretProviderConfig::Vault {
+            address: "http://vault:8200".to_string(),
+            token: "root".to_string(),
+            mount_path: "secret".to_string(),
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: SecretProviderConfig = serde_json::from_str(&json).unwrap();
+        match back {
+            SecretProviderConfig::Vault { address, token, mount_path } => {
+                assert_eq!(address, "http://vault:8200");
+                assert_eq!(token, "root");
+                assert_eq!(mount_path, "secret");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_secret_provider_config_serde_local() {
+        let mut secrets = HashMap::new();
+        secrets.insert("key-a".to_string(), "value-a".to_string());
+        let cfg = SecretProviderConfig::Local { secrets: secrets.clone() };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: SecretProviderConfig = serde_json::from_str(&json).unwrap();
+        match back {
+            SecretProviderConfig::Local { secrets: s } => assert_eq!(s, secrets),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // LocalSecretProvider
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_local_provider_get_existing_secret() {
+        let mut secrets = HashMap::new();
+        secrets.insert("db-password".to_string(), "super-secret".to_string());
+        let provider = LocalSecretProvider::new(secrets);
+
+        let value = provider.get_secret("db-password").await.unwrap();
+        assert_eq!(value, "super-secret");
+    }
+
+    #[tokio::test]
+    async fn test_local_provider_get_missing_secret_returns_not_found() {
+        let provider = LocalSecretProvider::new(HashMap::new());
+        let err = provider.get_secret("nonexistent-key").await.unwrap_err();
+        assert!(matches!(err, SecretError::NotFound(_)));
+        assert!(err.to_string().contains("nonexistent-key"));
+    }
+
+    #[tokio::test]
+    async fn test_local_provider_is_available() {
+        let provider = LocalSecretProvider::new(HashMap::new());
+        assert!(provider.is_available().await);
+    }
+
+    #[tokio::test]
+    async fn test_local_provider_multiple_secrets() {
+        let mut secrets = HashMap::new();
+        secrets.insert("k1".to_string(), "v1".to_string());
+        secrets.insert("k2".to_string(), "v2".to_string());
+        secrets.insert("k3".to_string(), "v3".to_string());
+        let provider = LocalSecretProvider::new(secrets);
+
+        assert_eq!(provider.get_secret("k1").await.unwrap(), "v1");
+        assert_eq!(provider.get_secret("k2").await.unwrap(), "v2");
+        assert_eq!(provider.get_secret("k3").await.unwrap(), "v3");
+    }
+
+    // ---------------------------------------------------------------------------
+    // AwsSecretProvider — mock (returns deterministic string, no real AWS call)
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_aws_provider_returns_mock_secret_with_region_and_id() {
+        let provider = AwsSecretProvider::new("eu-west-1".to_string(), None);
+        let value = provider.get_secret("my-token").await.unwrap();
+        assert!(value.contains("eu-west-1"), "Expected region in mock secret: {}", value);
+        assert!(value.contains("my-token"), "Expected secret_id in mock secret: {}", value);
+    }
+
+    #[tokio::test]
+    async fn test_aws_provider_is_available() {
+        let provider = AwsSecretProvider::new("us-west-2".to_string(), Some("http://localhost:4566".to_string()));
+        assert!(provider.is_available().await);
+    }
+
+    #[tokio::test]
+    async fn test_aws_provider_with_endpoint() {
+        let provider = AwsSecretProvider::new("us-east-1".to_string(), Some("http://localstack:4566".to_string()));
+        // Endpoint is stored but the mock ignores it — just verify construction & call succeed.
+        let result = provider.get_secret("secret-abc").await;
+        assert!(result.is_ok());
+    }
+}

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -3,5 +3,16 @@ all-features = true
 workspace = true
 timeout = "1200s"
 out = ["Html", "Json"]
-exclude-files = ["*/tests/*", "tests/*"]
+exclude-files = [
+    "*/tests/*",
+    "tests/*",
+    # Binary entrypoints — no runnable logic inside
+    "*/src/main.rs",
+    # CLI search commands — all code paths shell out to the `codesearch` binary via
+    # std::process::Command; there is no in-process logic to unit-test here.
+    "cli/src/commands/search/init.rs",
+    "cli/src/commands/search/search.rs",
+    "cli/src/commands/search/status.rs",
+    "cli/src/commands/search/trace.rs",
+]
 fail-under = 80

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -11,3 +11,7 @@ tracing = { workspace = true }
 redis = { workspace = true }
 reqwest = { workspace = true }
 anyhow = { workspace = true }
+mk_core = { workspace = true }
+async-trait = { workspace = true }
+dashmap = { workspace = true }
+storage = { workspace = true }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -10,5 +10,5 @@
 //! cleaned up when the process exits.
 
 mod fixtures;
-
+pub mod mock_storage;
 pub use fixtures::*;

--- a/testing/src/mock_storage.rs
+++ b/testing/src/mock_storage.rs
@@ -1,0 +1,659 @@
+//! In-memory `StorageBackend` implementation for unit tests.
+//!
+//! Provides `MockStorageBackend` — a thread-safe, `Arc`-friendly implementation
+//! of `mk_core::traits::StorageBackend` that stores everything in `DashMap`s.
+//! No database, no network, no Docker required.
+//!
+//! The associated `Error` type is `storage::postgres::PostgresError` so that
+//! this mock can be dropped directly into governance tools and other code that
+//! is hardcoded to `dyn StorageBackend<Error = PostgresError>`.
+//!
+//! # Usage
+//!
+//! ```rust,no_run
+//! use std::sync::Arc;
+//! use testing::mock_storage::MockStorageBackend;
+//!
+//! let backend = Arc::new(MockStorageBackend::new());
+//! ```
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use mk_core::traits::StorageBackend;
+use mk_core::types::{
+    ConsumerState, DriftConfig, DriftResult, DriftSuppression, EventDeliveryMetrics, EventStatus,
+    GovernanceEvent, OrganizationalUnit, PersistentEvent, Policy, Role, TenantContext, TenantId,
+    UserId,
+};
+use storage::postgres::PostgresError;
+
+/// Thread-safe in-memory storage backend for unit tests.
+///
+/// All state lives in `DashMap` collections, which are safe to share across
+/// async tasks via `Arc<MockStorageBackend>`.
+pub struct MockStorageBackend {
+    pub kv: DashMap<String, Vec<u8>>,
+    pub units: DashMap<String, OrganizationalUnit>,
+    pub policies: DashMap<String, Vec<Policy>>, // key = unit_id
+    pub roles: DashMap<String, Vec<Role>>,      // key = "{user_id}:{tenant_id}:{unit_id}"
+    pub drift_results: DashMap<String, DriftResult>, // key = project_id
+    pub drift_configs: DashMap<String, DriftConfig>, // key = project_id
+    pub suppressions: DashMap<String, Vec<DriftSuppression>>, // key = project_id
+    pub events: DashMap<String, PersistentEvent>, // key = event_id
+    pub governance_events: DashMap<String, Vec<GovernanceEvent>>, // key = tenant_id
+    pub consumer_states: DashMap<String, ConsumerState>,
+    pub metrics: DashMap<String, EventDeliveryMetrics>,
+    pub idempotency_keys: DashMap<String, bool>, // key = "{consumer_group}:{key}"
+    pub job_statuses: DashMap<String, String>,
+}
+
+impl Default for MockStorageBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockStorageBackend {
+    /// Create a new, empty `MockStorageBackend`.
+    pub fn new() -> Self {
+        Self {
+            kv: DashMap::new(),
+            units: DashMap::new(),
+            policies: DashMap::new(),
+            roles: DashMap::new(),
+            drift_results: DashMap::new(),
+            drift_configs: DashMap::new(),
+            suppressions: DashMap::new(),
+            events: DashMap::new(),
+            governance_events: DashMap::new(),
+            consumer_states: DashMap::new(),
+            metrics: DashMap::new(),
+            idempotency_keys: DashMap::new(),
+            job_statuses: DashMap::new(),
+        }
+    }
+
+    /// Wrap in an `Arc` for ergonomic use in tests.
+    pub fn arc() -> Arc<Self> {
+        Arc::new(Self::new())
+    }
+}
+
+#[async_trait]
+impl StorageBackend for MockStorageBackend {
+    type Error = PostgresError;
+
+    async fn store(&self, ctx: TenantContext, key: &str, value: &[u8]) -> Result<(), Self::Error> {
+        let full_key = format!("{}:{}", ctx.tenant_id, key);
+        self.kv.insert(full_key, value.to_vec());
+        Ok(())
+    }
+
+    async fn retrieve(
+        &self,
+        ctx: TenantContext,
+        key: &str,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        let full_key = format!("{}:{}", ctx.tenant_id, key);
+        Ok(self.kv.get(&full_key).map(|v| v.clone()))
+    }
+
+    async fn delete(&self, ctx: TenantContext, key: &str) -> Result<(), Self::Error> {
+        let full_key = format!("{}:{}", ctx.tenant_id, key);
+        self.kv.remove(&full_key);
+        Ok(())
+    }
+
+    async fn exists(&self, ctx: TenantContext, key: &str) -> Result<bool, Self::Error> {
+        let full_key = format!("{}:{}", ctx.tenant_id, key);
+        Ok(self.kv.contains_key(&full_key))
+    }
+
+    async fn get_ancestors(
+        &self,
+        _ctx: TenantContext,
+        unit_id: &str,
+    ) -> Result<Vec<OrganizationalUnit>, Self::Error> {
+        // Walk parent chain until no parent.
+        let mut result = Vec::new();
+        let mut current_id = unit_id.to_string();
+        let mut visited = std::collections::HashSet::new();
+        loop {
+            if !visited.insert(current_id.clone()) {
+                break; // Cycle guard
+            }
+            let unit = self.units.get(&current_id).map(|u| u.clone());
+            match unit {
+                Some(u) => {
+                    if let Some(ref parent_id) = u.parent_id {
+                        let pid = parent_id.clone();
+                        result.push(u);
+                        current_id = pid;
+                    } else {
+                        result.push(u);
+                        break;
+                    }
+                }
+                None => break,
+            }
+        }
+        Ok(result)
+    }
+
+    async fn get_descendants(
+        &self,
+        _ctx: TenantContext,
+        unit_id: &str,
+    ) -> Result<Vec<OrganizationalUnit>, Self::Error> {
+        // BFS over parent_id references.
+        let mut result = Vec::new();
+        let mut queue = std::collections::VecDeque::new();
+        queue.push_back(unit_id.to_string());
+        let mut visited = std::collections::HashSet::new();
+
+        while let Some(current) = queue.pop_front() {
+            if !visited.insert(current.clone()) {
+                continue;
+            }
+            for entry in self.units.iter() {
+                if entry.parent_id.as_deref() == Some(&current) {
+                    queue.push_back(entry.id.clone());
+                    result.push(entry.clone());
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    async fn get_unit_policies(
+        &self,
+        _ctx: TenantContext,
+        unit_id: &str,
+    ) -> Result<Vec<Policy>, Self::Error> {
+        Ok(self
+            .policies
+            .get(unit_id)
+            .map(|p| p.clone())
+            .unwrap_or_default())
+    }
+
+    async fn create_unit(&self, unit: &OrganizationalUnit) -> Result<(), Self::Error> {
+        self.units.insert(unit.id.clone(), unit.clone());
+        Ok(())
+    }
+
+    async fn add_unit_policy(
+        &self,
+        _ctx: &TenantContext,
+        unit_id: &str,
+        policy: &Policy,
+    ) -> Result<(), Self::Error> {
+        self.policies
+            .entry(unit_id.to_string())
+            .or_default()
+            .push(policy.clone());
+        Ok(())
+    }
+
+    async fn assign_role(
+        &self,
+        user_id: &UserId,
+        tenant_id: &TenantId,
+        unit_id: &str,
+        role: Role,
+    ) -> Result<(), Self::Error> {
+        let key = format!("{}:{}:{}", user_id.as_str(), tenant_id.as_str(), unit_id);
+        self.roles.entry(key).or_default().push(role);
+        Ok(())
+    }
+
+    async fn remove_role(
+        &self,
+        user_id: &UserId,
+        tenant_id: &TenantId,
+        unit_id: &str,
+        role: Role,
+    ) -> Result<(), Self::Error> {
+        let key = format!("{}:{}:{}", user_id.as_str(), tenant_id.as_str(), unit_id);
+        if let Some(mut roles) = self.roles.get_mut(&key) {
+            roles.retain(|r| r != &role);
+        }
+        Ok(())
+    }
+
+    async fn store_drift_result(&self, result: DriftResult) -> Result<(), Self::Error> {
+        self.drift_results.insert(result.project_id.clone(), result);
+        Ok(())
+    }
+
+    async fn get_latest_drift_result(
+        &self,
+        _ctx: TenantContext,
+        project_id: &str,
+    ) -> Result<Option<DriftResult>, Self::Error> {
+        Ok(self.drift_results.get(project_id).map(|r| r.clone()))
+    }
+
+    async fn list_all_units(&self) -> Result<Vec<OrganizationalUnit>, Self::Error> {
+        Ok(self.units.iter().map(|e| e.clone()).collect())
+    }
+
+    async fn record_job_status(
+        &self,
+        job_name: &str,
+        tenant_id: &str,
+        status: &str,
+        _message: Option<&str>,
+        _started_at: i64,
+        _finished_at: Option<i64>,
+    ) -> Result<(), Self::Error> {
+        let key = format!("{}:{}", tenant_id, job_name);
+        self.job_statuses.insert(key, status.to_string());
+        Ok(())
+    }
+
+    async fn get_governance_events(
+        &self,
+        ctx: TenantContext,
+        _since_timestamp: i64,
+        limit: usize,
+    ) -> Result<Vec<GovernanceEvent>, Self::Error> {
+        Ok(self
+            .governance_events
+            .get(ctx.tenant_id.as_str())
+            .map(|e| e.iter().take(limit).cloned().collect())
+            .unwrap_or_default())
+    }
+
+    async fn create_suppression(&self, suppression: DriftSuppression) -> Result<(), Self::Error> {
+        self.suppressions
+            .entry(suppression.project_id.clone())
+            .or_default()
+            .push(suppression);
+        Ok(())
+    }
+
+    async fn list_suppressions(
+        &self,
+        _ctx: TenantContext,
+        project_id: &str,
+    ) -> Result<Vec<DriftSuppression>, Self::Error> {
+        Ok(self
+            .suppressions
+            .get(project_id)
+            .map(|s| s.clone())
+            .unwrap_or_default())
+    }
+
+    async fn delete_suppression(
+        &self,
+        _ctx: TenantContext,
+        suppression_id: &str,
+    ) -> Result<(), Self::Error> {
+        for mut entry in self.suppressions.iter_mut() {
+            entry.retain(|s| s.id != suppression_id);
+        }
+        Ok(())
+    }
+
+    async fn get_drift_config(
+        &self,
+        _ctx: TenantContext,
+        project_id: &str,
+    ) -> Result<Option<DriftConfig>, Self::Error> {
+        Ok(self.drift_configs.get(project_id).map(|c| c.clone()))
+    }
+
+    async fn save_drift_config(&self, config: DriftConfig) -> Result<(), Self::Error> {
+        self.drift_configs.insert(config.project_id.clone(), config);
+        Ok(())
+    }
+
+    async fn persist_event(&self, event: PersistentEvent) -> Result<(), Self::Error> {
+        self.events.insert(event.id.clone(), event);
+        Ok(())
+    }
+
+    async fn get_pending_events(
+        &self,
+        _ctx: TenantContext,
+        limit: usize,
+    ) -> Result<Vec<PersistentEvent>, Self::Error> {
+        Ok(self
+            .events
+            .iter()
+            .filter(|e| e.status == EventStatus::Pending)
+            .take(limit)
+            .map(|e| e.clone())
+            .collect())
+    }
+
+    async fn update_event_status(
+        &self,
+        event_id: &str,
+        status: EventStatus,
+        _error: Option<String>,
+    ) -> Result<(), Self::Error> {
+        if let Some(mut event) = self.events.get_mut(event_id) {
+            event.status = status;
+        }
+        Ok(())
+    }
+
+    async fn get_dead_letter_events(
+        &self,
+        _ctx: TenantContext,
+        limit: usize,
+    ) -> Result<Vec<PersistentEvent>, Self::Error> {
+        Ok(self
+            .events
+            .iter()
+            .filter(|e| e.status == EventStatus::DeadLettered)
+            .take(limit)
+            .map(|e| e.clone())
+            .collect())
+    }
+
+    async fn check_idempotency(
+        &self,
+        consumer_group: &str,
+        idempotency_key: &str,
+    ) -> Result<bool, Self::Error> {
+        let key = format!("{}:{}", consumer_group, idempotency_key);
+        if self.idempotency_keys.contains_key(&key) {
+            return Ok(true); // Already processed
+        }
+        self.idempotency_keys.insert(key, true);
+        Ok(false)
+    }
+
+    async fn record_consumer_state(&self, state: ConsumerState) -> Result<(), Self::Error> {
+        self.consumer_states
+            .insert(state.consumer_group.clone(), state);
+        Ok(())
+    }
+
+    async fn get_event_metrics(
+        &self,
+        _ctx: TenantContext,
+        _period_start: i64,
+        _period_end: i64,
+    ) -> Result<Vec<EventDeliveryMetrics>, Self::Error> {
+        Ok(self.metrics.iter().map(|e| e.clone()).collect())
+    }
+
+    async fn record_event_metrics(&self, metrics: EventDeliveryMetrics) -> Result<(), Self::Error> {
+        self.metrics.insert(metrics.event_type.clone(), metrics);
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Self-tests for MockStorageBackend
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mk_core::types::{TenantContext, TenantId, UnitType, UserId};
+
+    fn tenant_ctx(id: &str) -> TenantContext {
+        TenantContext {
+            tenant_id: TenantId::new(id.to_string()).unwrap(),
+            user_id: UserId::new("user-1".to_string()).unwrap(),
+            agent_id: None,
+        }
+    }
+
+    fn make_unit(id: &str, parent: Option<&str>, tenant: &str) -> OrganizationalUnit {
+        OrganizationalUnit {
+            id: id.to_string(),
+            name: id.to_string(),
+            unit_type: UnitType::Team,
+            parent_id: parent.map(|s| s.to_string()),
+            tenant_id: TenantId::new(tenant.to_string()).unwrap(),
+            metadata: std::collections::HashMap::new(),
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    // -----------
+    // KV store
+    // -----------
+
+    #[tokio::test]
+    async fn test_store_and_retrieve() {
+        let backend = MockStorageBackend::new();
+        let ctx = tenant_ctx("acme");
+        backend.store(ctx.clone(), "key1", b"hello").await.unwrap();
+        let val = backend.retrieve(ctx, "key1").await.unwrap();
+        assert_eq!(val, Some(b"hello".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_missing_returns_none() {
+        let backend = MockStorageBackend::new();
+        let ctx = tenant_ctx("acme");
+        let val = backend.retrieve(ctx, "missing-key").await.unwrap();
+        assert!(val.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_removes_entry() {
+        let backend = MockStorageBackend::new();
+        let ctx = tenant_ctx("acme");
+        backend.store(ctx.clone(), "key", b"val").await.unwrap();
+        backend.delete(ctx.clone(), "key").await.unwrap();
+        assert_eq!(backend.retrieve(ctx, "key").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_exists_true_and_false() {
+        let backend = MockStorageBackend::new();
+        let ctx = tenant_ctx("acme");
+        assert!(!backend.exists(ctx.clone(), "k").await.unwrap());
+        backend.store(ctx.clone(), "k", b"v").await.unwrap();
+        assert!(backend.exists(ctx, "k").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_tenant_isolation() {
+        let backend = MockStorageBackend::new();
+        let ctx_a = tenant_ctx("tenant-a");
+        let ctx_b = tenant_ctx("tenant-b");
+        backend.store(ctx_a.clone(), "key", b"from-a").await.unwrap();
+        let val_b = backend.retrieve(ctx_b, "key").await.unwrap();
+        assert!(val_b.is_none(), "Tenant B should not see Tenant A's data");
+    }
+
+    // -----------
+    // Units
+    // -----------
+
+    #[tokio::test]
+    async fn test_create_unit_and_list_all() {
+        let backend = MockStorageBackend::new();
+        let unit = make_unit("unit-1", None, "t1");
+        backend.create_unit(&unit).await.unwrap();
+        let all = backend.list_all_units().await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id, "unit-1");
+    }
+
+    #[tokio::test]
+    async fn test_get_ancestors_chain() {
+        let backend = MockStorageBackend::new();
+        let grandparent = make_unit("gp", None, "t");
+        let parent = make_unit("p", Some("gp"), "t");
+        let child = make_unit("c", Some("p"), "t");
+        backend.create_unit(&grandparent).await.unwrap();
+        backend.create_unit(&parent).await.unwrap();
+        backend.create_unit(&child).await.unwrap();
+
+        let ctx = tenant_ctx("t");
+        let ancestors = backend.get_ancestors(ctx, "c").await.unwrap();
+        // Should include child itself, then parent, then grandparent
+        let ids: Vec<&str> = ancestors.iter().map(|u| u.id.as_str()).collect();
+        assert!(ids.contains(&"c"), "Should include starting unit");
+        assert!(ids.contains(&"p"), "Should include parent");
+        assert!(ids.contains(&"gp"), "Should include grandparent");
+    }
+
+    #[tokio::test]
+    async fn test_get_descendants() {
+        let backend = MockStorageBackend::new();
+        let root = make_unit("root", None, "t");
+        let child1 = make_unit("c1", Some("root"), "t");
+        let child2 = make_unit("c2", Some("root"), "t");
+        let grandchild = make_unit("gc", Some("c1"), "t");
+        backend.create_unit(&root).await.unwrap();
+        backend.create_unit(&child1).await.unwrap();
+        backend.create_unit(&child2).await.unwrap();
+        backend.create_unit(&grandchild).await.unwrap();
+
+        let ctx = tenant_ctx("t");
+        let descendants = backend.get_descendants(ctx, "root").await.unwrap();
+        let ids: Vec<&str> = descendants.iter().map(|u| u.id.as_str()).collect();
+        assert!(ids.contains(&"c1"));
+        assert!(ids.contains(&"c2"));
+        assert!(ids.contains(&"gc"));
+        assert!(!ids.contains(&"root"), "Root should not be in its own descendants");
+    }
+
+    // -----------
+    // Roles
+    // -----------
+
+    #[tokio::test]
+    async fn test_assign_and_remove_role() {
+        let backend = MockStorageBackend::new();
+        let user = UserId::new("user-alice".to_string()).unwrap();
+        let tenant = TenantId::new("t1".to_string()).unwrap();
+
+        backend
+            .assign_role(&user, &tenant, "unit-1", Role::Developer)
+            .await
+            .unwrap();
+
+        let key = "user-alice:t1:unit-1";
+        assert!(backend.roles.get(key).unwrap().contains(&Role::Developer));
+
+        backend
+            .remove_role(&user, &tenant, "unit-1", Role::Developer)
+            .await
+            .unwrap();
+        assert!(backend.roles.get(key).unwrap().is_empty());
+    }
+
+    // -----------
+    // Policies
+    // -----------
+
+    #[tokio::test]
+    async fn test_add_and_get_unit_policies() {
+        use mk_core::types::{KnowledgeLayer, Policy, PolicyMode, RuleMergeStrategy};
+
+        let backend = MockStorageBackend::new();
+        let ctx = tenant_ctx("t");
+        let policy = Policy {
+            id: "p1".to_string(),
+            layer: KnowledgeLayer::Team,
+            mode: PolicyMode::Mandatory,
+            merge_strategy: RuleMergeStrategy::Merge,
+            rules: vec![],
+            metadata: std::collections::HashMap::new(),
+        };
+
+        backend.add_unit_policy(&ctx, "unit-x", &policy).await.unwrap();
+        let policies = backend.get_unit_policies(ctx, "unit-x").await.unwrap();
+        assert_eq!(policies.len(), 1);
+        assert_eq!(policies[0].id, "p1");
+    }
+
+    // -----------
+    // Idempotency
+    // -----------
+
+    #[tokio::test]
+    async fn test_idempotency_first_call_returns_false_second_returns_true() {
+        let backend = MockStorageBackend::new();
+        let first = backend
+            .check_idempotency("group-a", "event-xyz")
+            .await
+            .unwrap();
+        let second = backend
+            .check_idempotency("group-a", "event-xyz")
+            .await
+            .unwrap();
+        assert!(!first, "First call should return false (not yet seen)");
+        assert!(second, "Second call should return true (already processed)");
+    }
+
+    // -----------
+    // Events
+    // -----------
+
+    #[tokio::test]
+    async fn test_persist_and_get_pending_events() {
+        use mk_core::types::GovernanceEvent;
+
+        let backend = MockStorageBackend::new();
+        let ctx = tenant_ctx("t");
+
+        let event = PersistentEvent {
+            id: "evt-1".to_string(),
+            tenant_id: "t".to_string(),
+            payload: GovernanceEvent::ConfigUpdated {
+                config_id: "cfg-1".to_string(),
+                scope: "company".to_string(),
+                tenant_id: "t".to_string(),
+                timestamp: 0,
+            },
+            status: EventStatus::Pending,
+            created_at: 0,
+            retry_count: 0,
+            last_error: None,
+            idempotency_key: "key-1".to_string(),
+        };
+
+        backend.persist_event(event).await.unwrap();
+        let pending = backend.get_pending_events(ctx, 10).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, "evt-1");
+    }
+
+    #[tokio::test]
+    async fn test_update_event_status() {
+        use mk_core::types::GovernanceEvent;
+
+        let backend = MockStorageBackend::new();
+
+        let event = PersistentEvent {
+            id: "evt-2".to_string(),
+            tenant_id: "t".to_string(),
+            payload: GovernanceEvent::ConfigUpdated {
+                config_id: "cfg-2".to_string(),
+                scope: "org".to_string(),
+                tenant_id: "t".to_string(),
+                timestamp: 0,
+            },
+            status: EventStatus::Pending,
+            created_at: 0,
+            retry_count: 0,
+            last_error: None,
+            idempotency_key: "key-2".to_string(),
+        };
+
+        backend.persist_event(event).await.unwrap();
+        backend
+            .update_event_status("evt-2", EventStatus::Acknowledged, None)
+            .await
+            .unwrap();
+
+        let updated = backend.events.get("evt-2").unwrap();
+        assert_eq!(updated.status, EventStatus::Acknowledged);
+    }
+}

--- a/tools/src/governance.rs
+++ b/tools/src/governance.rs
@@ -1592,3 +1592,451 @@ impl Tool for GovernanceRoleListTool {
         }))
     }
 }
+
+// =============================================================================
+// Unit tests for governance tools
+// =============================================================================
+//
+// These tests cover:
+//   1. Pure methods (`name`, `description`, `input_schema`) — no I/O.
+//   2. Full `call()` round-trips for the 5 StorageBackend-backed tools using
+//      MockStorageBackend so no Postgres instance is required.
+//
+// The GovernanceStorage-backed tools (GovernanceConfigure*, GovernanceRequest*,
+// etc.) require a live PgPool and are tested separately as integration tests.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mk_core::traits::StorageBackend;
+    use std::sync::Arc;
+    use testing::mock_storage::MockStorageBackend;
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    fn make_engine() -> Arc<GovernanceEngine> {
+        Arc::new(GovernanceEngine::new())
+    }
+
+    fn make_backend() -> Arc<MockStorageBackend> {
+        MockStorageBackend::arc()
+    }
+
+    fn tenant_ctx_json(tenant: &str, user: &str) -> Value {
+        serde_json::json!({
+            "tenant_id": tenant,
+            "user_id": user
+        })
+    }
+
+    // -------------------------------------------------------------------------
+    // UnitCreateTool
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_unit_create_tool_pure_methods() {
+        let tool = UnitCreateTool::new(make_backend(), make_engine());
+        assert_eq!(tool.name(), "governance_unit_create");
+        assert!(!tool.description().is_empty());
+        let schema = tool.input_schema();
+        assert_eq!(schema["type"], "object");
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "name"));
+        assert!(required.iter().any(|v| v == "unit_type"));
+    }
+
+    #[tokio::test]
+    async fn test_unit_create_tool_call_succeeds() {
+        let backend = make_backend();
+        let tool = UnitCreateTool::new(backend.clone(), make_engine());
+
+        let result = tool
+            .call(serde_json::json!({
+                "name": "Acme Platform",
+                "unit_type": "company",
+                "tenantContext": tenant_ctx_json("acme", "user-1")
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["success"], true);
+        let unit_id = result["unit_id"].as_str().unwrap();
+        assert!(!unit_id.is_empty());
+
+        // Confirm the unit was actually stored
+        let units = backend.list_all_units().await.unwrap();
+        assert_eq!(units.len(), 1);
+        assert_eq!(units[0].name, "Acme Platform");
+    }
+
+    #[tokio::test]
+    async fn test_unit_create_tool_with_parent_id() {
+        let backend = make_backend();
+        let tool = UnitCreateTool::new(backend.clone(), make_engine());
+
+        // Create parent first
+        tool.call(serde_json::json!({
+            "name": "Parent Corp",
+            "unit_type": "company",
+            "tenantContext": tenant_ctx_json("t", "u")
+        }))
+        .await
+        .unwrap();
+
+        let parent_id = backend.list_all_units().await.unwrap()[0].id.clone();
+
+        // Create child referencing parent
+        let result = tool
+            .call(serde_json::json!({
+                "name": "Platform Eng",
+                "unit_type": "organization",
+                "parent_id": parent_id,
+                "tenantContext": tenant_ctx_json("t", "u")
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["success"], true);
+        let units = backend.list_all_units().await.unwrap();
+        assert_eq!(units.len(), 2);
+        let child = units.iter().find(|u| u.name == "Platform Eng").unwrap();
+        assert_eq!(child.parent_id.as_deref(), Some(parent_id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn test_unit_create_tool_invalid_unit_type_returns_error() {
+        let tool = UnitCreateTool::new(make_backend(), make_engine());
+        let err = tool
+            .call(serde_json::json!({
+                "name": "X",
+                "unit_type": "INVALID_TYPE",
+                "tenantContext": tenant_ctx_json("t", "u")
+            }))
+            .await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_unit_create_tool_missing_tenant_context_returns_error() {
+        let tool = UnitCreateTool::new(make_backend(), make_engine());
+        let err = tool
+            .call(serde_json::json!({
+                "name": "X",
+                "unit_type": "team"
+                // no tenantContext
+            }))
+            .await;
+        assert!(err.is_err());
+    }
+
+    // -------------------------------------------------------------------------
+    // UnitPolicyAddTool
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_unit_policy_add_tool_pure_methods() {
+        let tool = UnitPolicyAddTool::new(make_backend(), make_engine());
+        assert_eq!(tool.name(), "governance_policy_add");
+        assert!(!tool.description().is_empty());
+        let schema = tool.input_schema();
+        assert_eq!(schema["type"], "object");
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "unit_id"));
+        assert!(required.iter().any(|v| v == "policy"));
+    }
+
+    #[tokio::test]
+    async fn test_unit_policy_add_tool_call_succeeds() {
+        let backend = make_backend();
+        let tool = UnitPolicyAddTool::new(backend.clone(), make_engine());
+
+        let result = tool
+            .call(serde_json::json!({
+                "unit_id": "unit-abc",
+                "policy": {
+                    "id": "pol-1",
+                    "name": "Test Policy",
+                    "layer": "team",
+                    "mode": "mandatory",
+                    "merge_strategy": "merge",
+                    "rules": [],
+                    "metadata": {}
+                },
+                "tenantContext": tenant_ctx_json("t", "u")
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["policy_id"], "pol-1");
+
+        // Confirm stored
+        let ctx = mk_core::types::TenantContext {
+            tenant_id: mk_core::types::TenantId::new("t".to_string()).unwrap(),
+            user_id: mk_core::types::UserId::new("u".to_string()).unwrap(),
+            agent_id: None,
+        };
+        let stored = backend.get_unit_policies(ctx, "unit-abc").await.unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].id, "pol-1");
+    }
+
+    // -------------------------------------------------------------------------
+    // UserRoleAssignTool
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_user_role_assign_tool_pure_methods() {
+        let tool = UserRoleAssignTool::new(make_backend(), make_engine());
+        assert_eq!(tool.name(), "governance_role_assign");
+        assert!(!tool.description().is_empty());
+        let schema = tool.input_schema();
+        assert_eq!(schema["type"], "object");
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "user_id"));
+        assert!(required.iter().any(|v| v == "unit_id"));
+        assert!(required.iter().any(|v| v == "role"));
+    }
+
+    #[tokio::test]
+    async fn test_user_role_assign_tool_call_succeeds() {
+        let backend = make_backend();
+        let tool = UserRoleAssignTool::new(backend.clone(), make_engine());
+
+        let result = tool
+            .call(serde_json::json!({
+                "user_id": "alice",
+                "unit_id": "unit-x",
+                "role": "developer",
+                "tenantContext": tenant_ctx_json("t1", "alice")
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["success"], true);
+
+        // Confirm role stored
+        let key = "alice:t1:unit-x";
+        let roles = backend.roles.get(key).unwrap();
+        assert!(roles.contains(&mk_core::types::Role::Developer));
+    }
+
+    #[tokio::test]
+    async fn test_user_role_assign_tool_invalid_role_returns_error() {
+        let tool = UserRoleAssignTool::new(make_backend(), make_engine());
+        let err = tool
+            .call(serde_json::json!({
+                "user_id": "alice",
+                "unit_id": "unit-x",
+                "role": "SUPER_ADMIN",
+                "tenantContext": tenant_ctx_json("t1", "alice")
+            }))
+            .await;
+        assert!(err.is_err());
+    }
+
+    // -------------------------------------------------------------------------
+    // UserRoleRemoveTool
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_user_role_remove_tool_pure_methods() {
+        let tool = UserRoleRemoveTool::new(make_backend(), make_engine());
+        assert_eq!(tool.name(), "governance_role_remove");
+        assert!(!tool.description().is_empty());
+        let schema = tool.input_schema();
+        assert_eq!(schema["type"], "object");
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "user_id"));
+        assert!(required.iter().any(|v| v == "role"));
+    }
+
+    #[tokio::test]
+    async fn test_user_role_remove_tool_call_removes_role() {
+        let backend = make_backend();
+        let assign_tool = UserRoleAssignTool::new(backend.clone(), make_engine());
+        let remove_tool = UserRoleRemoveTool::new(backend.clone(), make_engine());
+
+        // First assign
+        assign_tool
+            .call(serde_json::json!({
+                "user_id": "bob",
+                "unit_id": "unit-y",
+                "role": "techlead",
+                "tenantContext": tenant_ctx_json("t1", "bob")
+            }))
+            .await
+            .unwrap();
+
+        let key = "bob:t1:unit-y";
+        assert!(backend.roles.get(key).unwrap().contains(&mk_core::types::Role::TechLead));
+
+        // Then remove
+        let result = remove_tool
+            .call(serde_json::json!({
+                "user_id": "bob",
+                "unit_id": "unit-y",
+                "role": "techlead",
+                "tenantContext": tenant_ctx_json("t1", "bob")
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["success"], true);
+        assert!(backend.roles.get(key).unwrap().is_empty());
+    }
+
+    // -------------------------------------------------------------------------
+    // HierarchyNavigateTool
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_hierarchy_navigate_tool_pure_methods() {
+        let tool = HierarchyNavigateTool::new(make_backend());
+        assert_eq!(tool.name(), "governance_hierarchy_navigate");
+        assert!(!tool.description().is_empty());
+        let schema = tool.input_schema();
+        assert_eq!(schema["type"], "object");
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "unit_id"));
+        assert!(required.iter().any(|v| v == "direction"));
+        // Verify direction enum values
+        let direction_enum = schema["properties"]["direction"]["enum"].as_array().unwrap();
+        assert!(direction_enum.iter().any(|v| v == "ancestors"));
+        assert!(direction_enum.iter().any(|v| v == "descendants"));
+    }
+
+    #[tokio::test]
+    async fn test_hierarchy_navigate_tool_ancestors() {
+        let backend = make_backend();
+
+        // Seed: gp -> parent -> child
+        let gp = mk_core::types::OrganizationalUnit {
+            id: "gp".to_string(),
+            name: "GrandParent".to_string(),
+            unit_type: mk_core::types::UnitType::Company,
+            parent_id: None,
+            tenant_id: mk_core::types::TenantId::new("t".to_string()).unwrap(),
+            metadata: std::collections::HashMap::new(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        let parent = mk_core::types::OrganizationalUnit {
+            id: "parent".to_string(),
+            name: "Parent".to_string(),
+            unit_type: mk_core::types::UnitType::Organization,
+            parent_id: Some("gp".to_string()),
+            tenant_id: mk_core::types::TenantId::new("t".to_string()).unwrap(),
+            metadata: std::collections::HashMap::new(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        let child = mk_core::types::OrganizationalUnit {
+            id: "child".to_string(),
+            name: "Child".to_string(),
+            unit_type: mk_core::types::UnitType::Team,
+            parent_id: Some("parent".to_string()),
+            tenant_id: mk_core::types::TenantId::new("t".to_string()).unwrap(),
+            metadata: std::collections::HashMap::new(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        backend.create_unit(&gp).await.unwrap();
+        backend.create_unit(&parent).await.unwrap();
+        backend.create_unit(&child).await.unwrap();
+
+        let tool = HierarchyNavigateTool::new(backend.clone());
+        let result = tool
+            .call(serde_json::json!({
+                "unit_id": "child",
+                "direction": "ancestors",
+                "tenantContext": tenant_ctx_json("t", "u")
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["success"], true);
+        let units = result["units"].as_array().unwrap();
+        let ids: Vec<&str> = units
+            .iter()
+            .map(|u| u["id"].as_str().unwrap())
+            .collect();
+        assert!(ids.contains(&"child"));
+        assert!(ids.contains(&"parent"));
+        assert!(ids.contains(&"gp"));
+    }
+
+    #[tokio::test]
+    async fn test_hierarchy_navigate_tool_descendants() {
+        let backend = make_backend();
+
+        let root = mk_core::types::OrganizationalUnit {
+            id: "root".to_string(),
+            name: "Root".to_string(),
+            unit_type: mk_core::types::UnitType::Company,
+            parent_id: None,
+            tenant_id: mk_core::types::TenantId::new("t".to_string()).unwrap(),
+            metadata: std::collections::HashMap::new(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        let child1 = mk_core::types::OrganizationalUnit {
+            id: "c1".to_string(),
+            name: "Child1".to_string(),
+            unit_type: mk_core::types::UnitType::Team,
+            parent_id: Some("root".to_string()),
+            tenant_id: mk_core::types::TenantId::new("t".to_string()).unwrap(),
+            metadata: std::collections::HashMap::new(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        let child2 = mk_core::types::OrganizationalUnit {
+            id: "c2".to_string(),
+            name: "Child2".to_string(),
+            unit_type: mk_core::types::UnitType::Team,
+            parent_id: Some("root".to_string()),
+            tenant_id: mk_core::types::TenantId::new("t".to_string()).unwrap(),
+            metadata: std::collections::HashMap::new(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        backend.create_unit(&root).await.unwrap();
+        backend.create_unit(&child1).await.unwrap();
+        backend.create_unit(&child2).await.unwrap();
+
+        let tool = HierarchyNavigateTool::new(backend.clone());
+        let result = tool
+            .call(serde_json::json!({
+                "unit_id": "root",
+                "direction": "descendants",
+                "tenantContext": tenant_ctx_json("t", "u")
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["success"], true);
+        let units = result["units"].as_array().unwrap();
+        assert_eq!(units.len(), 2);
+        let ids: Vec<&str> = units
+            .iter()
+            .map(|u| u["id"].as_str().unwrap())
+            .collect();
+        assert!(ids.contains(&"c1"));
+        assert!(ids.contains(&"c2"));
+    }
+
+    #[tokio::test]
+    async fn test_hierarchy_navigate_tool_invalid_direction_returns_error() {
+        let tool = HierarchyNavigateTool::new(make_backend());
+        let err = tool
+            .call(serde_json::json!({
+                "unit_id": "some-id",
+                "direction": "sideways",
+                "tenantContext": tenant_ctx_json("t", "u")
+            }))
+            .await;
+        assert!(err.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Add cloud LLM provider support (Google Vertex AI, AWS Bedrock) for memory and embedding services
- Fix Docker build: bump Rust to 1.93 for edition2024 support, use native runners per arch
- Add Helm chart validation for cloud LLM providers
- Add deployment examples and security cleanup (remove internal values, add templatized examples)
- Add storage and governance test coverage

## Test plan
- [ ] Docker build completes successfully on merge (multi-arch: amd64 + arm64)
- [ ] Helm chart lints and templates correctly with cloud LLM provider values
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)