### PR TITLE
fix(ci): add valkey helm repo to chart release workflow

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -61,6 +61,7 @@ jobs:
           helm repo add qdrant https://qdrant.github.io/qdrant-helm
           helm repo add weaviate https://weaviate.github.io/weaviate-helm/
           helm repo add percona https://percona.github.io/percona-helm-charts/
+          helm repo add valkey https://valkey.io/valkey-helm/
           helm repo update
 
       - name: Build dependencies


### PR DESCRIPTION
## Summary
- Add missing `valkey` Helm repo to the chart release workflow
- Without this, `helm dependency build` fails when building the chart for release

## Test plan
- [ ] Re-trigger `helm-release.yml` after merge — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)