### PR TITLE
chore(versioning): single source of truth for product version

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,116 @@
+name: Cut Release (version bump PR)
+
+# Manual workflow to cut a new release candidate / release.
+#
+# Trigger: gh workflow run cut-release -f version=0.8.0-rc.1
+#
+# Produces: a branch `release/vX.Y.Z` with every version string updated,
+# committed, pushed, and turned into a PR. A human reviews + merges.
+# After merge, the release is cut by pushing the matching git tag:
+#
+#     git tag v0.8.0-rc.1 && git push origin v0.8.0-rc.1
+#
+# That tag push triggers release.yml which does the actual build/sign/publish.
+#
+# We do NOT auto-push the tag here — keeping a human gate between the
+# version-bump PR and the release tag lets you:
+#   - verify all CI is green against the bumped state
+#   - run last-minute smoke on master
+#   - abort without leaving an orphan tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to cut (no leading v). Example: 0.8.0-rc.1'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cut:
+    name: cut release ${{ inputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+              echo "::error::'${{ inputs.version }}' is not a valid SemVer 2.0 version"
+              exit 1
+          fi
+
+      - name: Check tag does not exist
+        run: |
+          if git rev-parse -q --verify "refs/tags/v${{ inputs.version }}" >/dev/null; then
+              echo "::error::tag v${{ inputs.version }} already exists"
+              exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install jq
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create release branch
+        run: git checkout -b "release/v${{ inputs.version }}"
+
+      - name: Run bump script
+        run: ./scripts/bump-version.sh "${{ inputs.version }}"
+
+      - name: Commit + push
+        run: |
+          git add -A
+          git commit -m "release: ${{ inputs.version }}" \
+            -m "Automated version bump produced by .github/workflows/cut-release.yml." \
+            -m "After this PR merges, tag the release with:" \
+            -m "    git tag v${{ inputs.version }} && git push origin v${{ inputs.version }}"
+          git push origin "release/v${{ inputs.version }}"
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base master \
+            --head "release/v${{ inputs.version }}" \
+            --title "release: ${{ inputs.version }}" \
+            --body "$(cat <<'BODY'
+          Automated version bump produced by \`.github/workflows/cut-release.yml\`.
+
+          ## Checklist before merging
+          - [ ] \`Version Consistency\` check is green
+          - [ ] \`PR Fast Gate\` is green (unit tests, clippy, fmt, helm lint)
+          - [ ] \`PR Integration Gate\` is green (multi-arch docker build + shipped-smoke)
+          - [ ] CHANGELOG / release notes are ready (release.yml auto-generates from commits)
+
+          ## After merge
+          \`\`\`
+          git checkout master && git pull
+          git tag vVERSION_PLACEHOLDER
+          git push origin vVERSION_PLACEHOLDER
+          \`\`\`
+          That tag push triggers \`release.yml\` which builds, signs (cosign),
+          packages helm charts, builds CLI binaries for 4 targets, and opens
+          the GitHub Release with all assets attached.
+          BODY
+          )" \
+            | tee /tmp/pr-url.txt
+          # Patch the placeholder (heredoc variable escaping avoids sh surprises)
+          PR_URL=$(cat /tmp/pr-url.txt)
+          PR_NUM=$(basename "$PR_URL")
+          gh pr edit "$PR_NUM" --body "$(gh pr view "$PR_NUM" --json body -q .body | sed 's/VERSION_PLACEHOLDER/${{ inputs.version }}/g')"

--- a/.github/workflows/opencode-plugin-ci.yml
+++ b/.github/workflows/opencode-plugin-ci.yml
@@ -1,9 +1,16 @@
 name: OpenCode Plugin CI
 
+# PR-only: build + typecheck + test for the opencode plugin.
+#
+# npm publish lives in .github/workflows/release.yml (`npm-release` job),
+# which fires on every product `v*` tag. The plugin is published in lockstep
+# with the rest of the product so there's one tag per release, not two.
+#
+# To emergency-publish the plugin out-of-band (without a product release),
+# use `workflow_dispatch` on release.yml with a version input — it will
+# verify, build, and publish everything including npm.
+
 on:
-  push:
-    tags:
-      - 'plugin-v*'
   pull_request:
     branches: [master]
     paths:
@@ -61,31 +68,7 @@ jobs:
       - name: Run tests
         run: npm run test
 
-  publish:
-    name: Publish to npm
-    needs: [build, test]
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/plugin-v')
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
-          cache: npm
-          cache-dependency-path: packages/opencode-plugin/package-lock.json
-
-      - run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # NOTE: the `publish` job was moved to .github/workflows/release.yml so
+  # that `@aeterna-org/opencode-plugin` is published in lockstep with the
+  # rest of the product on every `v*` tag (not on a separate `plugin-v*`
+  # tag that could drift from the product version).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
       version: ${{ steps.v.outputs.version }}
       tag:     ${{ steps.v.outputs.tag }}
     steps:
+      - uses: actions/checkout@v4
+
       - id: v
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -60,6 +62,31 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=v${VERSION}"    >> "$GITHUB_OUTPUT"
           echo "Releasing version: ${VERSION}"
+
+      # Single-source-of-truth guard: the repo's [workspace.package].version
+      # MUST equal the version being released. Every in-workspace crate
+      # inherits from there (version.workspace = true), so if this matches
+      # we know the compiled binary, helm charts, and npm packages all
+      # report the same version the tag claims. Drift detection lives in
+      # .github/workflows/version-consistency.yml which runs on every PR;
+      # this is the tag-time enforcement.
+      - name: Verify repo state matches tag
+        env:
+          EXPECTED: ${{ steps.v.outputs.version }}
+        run: |
+          WS=$(python3 -c "
+          import re, pathlib
+          txt = pathlib.Path('Cargo.toml').read_text()
+          m = re.search(r'\[workspace\.package\][^\[]*?version\s*=\s*\"([^\"]+)\"', txt, re.DOTALL)
+          print(m.group(1) if m else '')
+          ")
+          if [[ "$WS" != "$EXPECTED" ]]; then
+              echo "::error::Release requested for $EXPECTED but repo [workspace.package].version is $WS."
+              echo "::error::Run: gh workflow run cut-release -f version=$EXPECTED"
+              echo "::error::Then merge the resulting PR before pushing the tag."
+              exit 1
+          fi
+          echo "✅ repo state matches release version $EXPECTED"
 
   # ─── 1. Docker multi-arch image (amd64 + arm64) → GHCR ───────────────
   docker-build:
@@ -275,13 +302,11 @@ jobs:
       - uses: azure/setup-helm@v4
         with:
           version: v3.14.0
-      - name: Bump chart versions to match release
-        run: |
-          V="${{ needs.resolve-version.outputs.version }}"
-          for chart in charts/aeterna charts/aeterna-prereqs; do
-            sed -i "s/^version:.*/version: ${V}/"       "${chart}/Chart.yaml"
-            sed -i "s/^appVersion:.*/appVersion: \"${V}\"/" "${chart}/Chart.yaml"
-          done
+      # Chart versions are guaranteed to match the release tag because
+      # scripts/bump-version.sh rewrote them during the cut-release PR
+      # and resolve-version above re-verified repo state matches the tag.
+      # The previous inline sed here was a second source of truth that
+      # could silently disagree with the bump script — removed.
       - name: Embed Cedar policies into values.yaml
         run: |
           cat policies/cedar/*.cedar       > /tmp/cedar-policy-text.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,10 +355,94 @@ jobs:
           path: .cr-release-packages/*.tgz
           retention-days: 30
 
-  # ─── 4. Single GitHub Release with all assets attached ────────────────
+  # ─── 4. npm publish (@aeterna-org/opencode-plugin) ────────────────────
+  # Publishes the opencode plugin to the public npm registry with the same
+  # version string as the release tag. Package version was already pinned
+  # in the cut-release PR via scripts/bump-version.sh, so this step just
+  # runs `npm publish`.
+  #
+  # Dist-tag:
+  #   - stable releases (0.8.0, 1.2.3)           → --tag latest
+  #   - prereleases (0.8.0-rc.1, 1.0.0-beta.2)   → --tag next
+  # This keeps `npm install @aeterna-org/opencode-plugin` from accidentally
+  # picking up an RC.
+  #
+  # Provenance is enabled (OIDC keyless) so the package appears verified
+  # on npmjs.com and links back to this workflow run.
+  npm-release:
+    name: npm publish (@aeterna-org/opencode-plugin)
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write           # OIDC for npm provenance
+    defaults:
+      run:
+        working-directory: packages/opencode-plugin
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+          cache-dependency-path: packages/opencode-plugin/package-lock.json
+
+      - name: Verify package.json version matches release tag
+        env:
+          EXPECTED: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          PKG=$(jq -r '.version' package.json)
+          if [[ "$PKG" != "$EXPECTED" ]]; then
+              echo "::error::packages/opencode-plugin/package.json is at $PKG but release tag is $EXPECTED"
+              echo "::error::This should be impossible after cut-release + version-consistency — investigate."
+              exit 1
+          fi
+          echo "✅ package.json version $PKG matches release tag"
+
+      - name: Pick dist-tag (latest vs next)
+        id: disttag
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          # Anything containing `-` (0.8.0-rc.1, 1.0.0-beta.2, etc.) is a prerelease.
+          if [[ "$VERSION" == *-* ]]; then
+              echo "tag=next"   >> "$GITHUB_OUTPUT"
+              echo "This is a prerelease — will publish with --tag next"
+          else
+              echo "tag=latest" >> "$GITHUB_OUTPUT"
+              echo "This is a stable release — will publish with --tag latest"
+          fi
+
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run test
+      - run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance --tag ${{ steps.disttag.outputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "### Published to npm" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`@aeterna-org/opencode-plugin@${{ needs.resolve-version.outputs.version }}\` with dist-tag \`${{ steps.disttag.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${{ steps.disttag.outputs.tag }}" == "next" ]]; then
+            echo "npm install @aeterna-org/opencode-plugin@next" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "npm install @aeterna-org/opencode-plugin" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+
+  # ─── 5. Single GitHub Release with all assets attached ────────────────
   github-release:
     name: github release
-    needs: [resolve-version, docker-merge, docker-scan-sbom, cli-build, helm-release]
+    needs: [resolve-version, docker-merge, docker-scan-sbom, cli-build, helm-release, npm-release]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -1,0 +1,135 @@
+name: Version Consistency
+
+# Enforces the single-source-of-truth contract for the product version:
+# every product-scoped version string in the repo must equal
+# [workspace.package].version in the root Cargo.toml.
+#
+# Source of truth:   Cargo.toml:[workspace.package].version
+# Must match:        charts/aeterna/Chart.yaml (version + appVersion)
+#                    charts/aeterna-prereqs/Chart.yaml (version + appVersion)
+#                    deploy/helm/aeterna-opal/Chart.yaml (version + appVersion)
+#                    packages/opencode-plugin/package.json (version)
+#                    admin-ui/package.json (version)
+#                    website/package.json (version)
+#
+# Explicitly excluded:
+#   - aeterna-backup (independent lifecycle, 0.1.0)
+#   - .opencode/package.json (local opencode agent config, not a product artifact)
+#
+# Also asserted on tag push: the tag must equal v<workspace.version>.
+# This prevents cutting a `v0.8.0-rc.1` tag while the repo still says 0.7.0.
+
+on:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - '**/Cargo.toml'
+      - 'charts/**/Chart.yaml'
+      - 'charts/aeterna/values.yaml'
+      - 'deploy/helm/**/Chart.yaml'
+      - 'packages/opencode-plugin/package.json'
+      - 'admin-ui/package.json'
+      - 'website/package.json'
+      - '.github/workflows/version-consistency.yml'
+      - 'scripts/bump-version.sh'
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install yq + jq
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq jq
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Extract authoritative version
+        id: source
+        run: |
+          # Parse [workspace.package].version without pulling the full cargo toolchain.
+          WS=$(python3 -c "
+          import re, pathlib
+          txt = pathlib.Path('Cargo.toml').read_text()
+          m = re.search(r'\[workspace\.package\][^\[]*?version\s*=\s*\"([^\"]+)\"', txt, re.DOTALL)
+          print(m.group(1) if m else '')
+          ")
+          if [[ -z "$WS" ]]; then
+            echo "::error::[workspace.package].version not found in Cargo.toml" >&2
+            exit 1
+          fi
+          echo "version=${WS}" >> "$GITHUB_OUTPUT"
+          echo "Authoritative version: ${WS}"
+
+      - name: Verify every product surface matches
+        env:
+          EXPECTED: ${{ steps.source.outputs.version }}
+        run: |
+          set -eo pipefail
+          fail=0
+          check() {
+              local label="$1" actual="$2"
+              if [[ "$actual" != "$EXPECTED" ]]; then
+                  printf '  ❌ %-55s %s  (expected %s)\n' "$label" "$actual" "$EXPECTED"
+                  fail=1
+              else
+                  printf '  ✅ %-55s %s\n' "$label" "$actual"
+              fi
+          }
+
+          # Helm charts (version + appVersion both must match)
+          for chart in charts/aeterna/Chart.yaml charts/aeterna-prereqs/Chart.yaml deploy/helm/aeterna-opal/Chart.yaml; do
+              [[ -f "$chart" ]] || continue
+              check "${chart}:version"    "$(yq -r '.version'    "$chart")"
+              check "${chart}:appVersion" "$(yq -r '.appVersion' "$chart")"
+          done
+
+          # npm packages
+          for pkg in packages/opencode-plugin admin-ui website; do
+              [[ -f "${pkg}/package.json" ]] || continue
+              check "${pkg}/package.json" "$(jq -r '.version' "${pkg}/package.json")"
+          done
+
+          # Every in-workspace crate must inherit (not pin its own version)
+          # except aeterna-backup which has its own lifecycle.
+          echo "  ── crate inheritance check ──"
+          for ctoml in $(find . -maxdepth 3 -name Cargo.toml -not -path './target/*' -not -path './.git/*' -not -path './Cargo.toml'); do
+              name=$(python3 -c "import re,sys; t=open(sys.argv[1]).read(); m=re.search(r'\[package\][^\[]*?name\s*=\s*\"([^\"]+)\"', t, re.DOTALL); print(m.group(1) if m else '')" "$ctoml")
+              [[ "$name" == "aeterna-backup" ]] && continue
+              # Skip non-workspace crates (test-project, services/memory if not in workspace).
+              if ! grep -q "\"$(dirname "$ctoml" | sed 's|^\./||')\"" Cargo.toml 2>/dev/null; then
+                  continue
+              fi
+              if grep -qE '^version\s*=\s*"' "$ctoml"; then
+                  printf '  ❌ %-55s pins version literal (should use version.workspace = true)\n' "$ctoml"
+                  fail=1
+              else
+                  printf '  ✅ %-55s inherits workspace version\n' "$ctoml"
+              fi
+          done
+
+          # Tag-push assertion: tag must equal v<workspace.version>
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+              tag_version="${GITHUB_REF#refs/tags/v}"
+              if [[ "$tag_version" != "$EXPECTED" ]]; then
+                  printf '  ❌ tag v%s disagrees with workspace version %s\n' "$tag_version" "$EXPECTED"
+                  fail=1
+              else
+                  printf '  ✅ tag v%s matches workspace version\n' "$tag_version"
+              fi
+          fi
+
+          if [[ $fail -ne 0 ]]; then
+              echo
+              echo "::error::Version drift detected. Run ./scripts/bump-version.sh $EXPECTED to re-sync."
+              exit 1
+          fi
+          echo
+          echo "✅ all product versions agree on ${EXPECTED}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,18 @@ members = [
     "backup",
 ]
 
+# Single source of truth for the product version.
+#
+# - Every workspace member (except `backup`, which has its own lifecycle)
+#   inherits this via `version.workspace = true` in its own Cargo.toml.
+# - `scripts/bump-version.sh <new-version>` rewrites this value and the
+#   matching entries in charts/, packages/opencode-plugin/, admin-ui/ and
+#   website/ in one atomic step.
+# - `.github/workflows/version-consistency.yml` enforces that all those
+#   surfaces agree on every PR and on every tag push.
+[workspace.package]
+version = "0.7.0"
+
 [workspace.lints.rust]
 unused_imports = "warn"
 dead_code = "allow"

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adapters"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Provider and ecosystem adapters"
 

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin-ui",
-  "version": "0.0.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-ui",
-      "version": "0.0.0",
+      "version": "0.7.0",
       "dependencies": {
         "@tanstack/react-query": "^5.62.0",
         "class-variance-authority": "^0.7.1",
@@ -32,6 +32,9 @@
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-ui",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.7.0",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/agent-a2a/Cargo.toml
+++ b/agent-a2a/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-a2a"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "A2A (Agent-to-Agent) protocol implementation using Radkit"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aeterna"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Aeterna CLI - Universal Memory & Knowledge Framework"
 license = "Apache-2.0"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "config"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Configuration management for the Memory-Knowledge system"
 

--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "context"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Context auto-resolution for Aeterna - git detection, env vars, context.toml"
 license = "Apache-2.0"

--- a/cross-tests/Cargo.toml
+++ b/cross-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cross-tests"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Cross-cutting integration, load, and DR tests"
 publish = false

--- a/deploy/helm/aeterna-opal/Chart.yaml
+++ b/deploy/helm/aeterna-opal/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aeterna-opal
 description: OPAL Authorization Stack for Aeterna Memory-Knowledge System
 type: application
-version: 0.6.0
-appVersion: "0.7.5"
+version: 0.7.0
+appVersion: "0.7.0"
 keywords:
   - opal
   - cedar

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "errors"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Error handling framework for the Memory-Knowledge system"
 

--- a/idp-sync/Cargo.toml
+++ b/idp-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idp-sync"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 license = "Apache-2.0"
 description = "Identity Provider synchronization service for Aeterna"

--- a/knowledge/Cargo.toml
+++ b/knowledge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "knowledge"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Knowledge repository implementation"
 

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Memory system implementation"
 

--- a/mk_core/Cargo.toml
+++ b/mk_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mk_core"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Shared types and traits for the Memory-Knowledge system"
 

--- a/observability/Cargo.toml
+++ b/observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "observability"
-version = "0.7.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/opal-fetcher/Cargo.toml
+++ b/opal-fetcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opal-fetcher"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "OPAL Data Fetcher for Aeterna - serves organizational data to Cedar Agent"
 license = "Apache-2.0"

--- a/packages/opencode-plugin/package-lock.json
+++ b/packages/opencode-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aeterna-org/opencode-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aeterna-org/opencode-plugin",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencode-ai/plugin": "1.3.6",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# scripts/bump-version.sh — single source of truth version bump.
+#
+# Usage: ./scripts/bump-version.sh 0.8.0-rc.1
+#
+# Rewrites every version string bound to the product release:
+#   - Cargo workspace.package.version  (inherited by 18 crates)
+#   - charts/aeterna/Chart.yaml        (version + appVersion)
+#   - charts/aeterna-prereqs/Chart.yaml
+#   - charts/aeterna/values.yaml       (image.tag)
+#   - deploy/helm/aeterna-opal/Chart.yaml
+#   - packages/opencode-plugin/package.json
+#   - admin-ui/package.json
+#   - website/package.json
+#
+# Excluded: backup/Cargo.toml (own lifecycle), .opencode/package.json (local config).
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <new-version>" >&2
+    echo "Example: $0 0.8.0-rc.1" >&2
+    exit 1
+fi
+
+NEW="$1"
+
+if [[ ! "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+    echo "ERROR: '$NEW' is not a valid SemVer 2.0 version" >&2
+    exit 1
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+echo "── bumping aeterna to ${NEW} ──"
+
+# 1. Cargo workspace
+python3 - "$NEW" <<'PY'
+import re, sys, pathlib
+new = sys.argv[1]
+p = pathlib.Path("Cargo.toml")
+txt = p.read_text()
+txt, n = re.subn(
+    r'(\[workspace\.package\][^\[]*?version\s*=\s*")[^"]+(")',
+    lambda m: f'{m.group(1)}{new}{m.group(2)}',
+    txt, count=1, flags=re.DOTALL,
+)
+if n != 1:
+    sys.exit("ERROR: failed to locate [workspace.package].version in Cargo.toml")
+p.write_text(txt)
+print(f"  Cargo.toml                               {new}")
+PY
+
+# 2. Helm charts
+bump_chart() {
+    local chart="$1"
+    [[ -f "$chart" ]] || { echo "  (skip) $chart not found"; return; }
+    sed -i.bak -E \
+        -e "s/^version:[[:space:]]+.*/version: ${NEW}/" \
+        -e "s/^appVersion:[[:space:]]+.*/appVersion: \"${NEW}\"/" \
+        "$chart"
+    rm "${chart}.bak"
+    echo "  ${chart}   ${NEW}"
+}
+bump_chart "charts/aeterna/Chart.yaml"
+bump_chart "charts/aeterna-prereqs/Chart.yaml"
+bump_chart "deploy/helm/aeterna-opal/Chart.yaml"
+
+# values.yaml image.tag is intentionally left empty ("") — the chart
+# template falls back to .Chart.AppVersion, which bump_chart already set.
+# Touching it here would hardcode the tag and defeat that design.
+
+# 3. npm packages
+bump_npm() {
+    local pkgdir="$1"
+    [[ -f "${pkgdir}/package.json" ]] || { echo "  (skip) ${pkgdir}/package.json not found"; return; }
+    local tmp
+    tmp=$(mktemp)
+    jq --arg v "$NEW" '.version = $v' "${pkgdir}/package.json" > "$tmp"
+    mv "$tmp" "${pkgdir}/package.json"
+    echo "  ${pkgdir}/package.json   ${NEW}"
+}
+bump_npm "packages/opencode-plugin"
+bump_npm "admin-ui"
+bump_npm "website"
+
+# 4. Lockfiles
+echo "── refreshing lockfiles ──"
+cargo update --workspace --quiet 2>&1 | sed 's/^/  /' || true
+for pkgdir in packages/opencode-plugin admin-ui website; do
+    if [[ -f "${pkgdir}/package-lock.json" ]]; then
+        ( cd "$pkgdir" && npm install --package-lock-only --silent ) && \
+            echo "  ${pkgdir}/package-lock.json   refreshed"
+    fi
+done
+
+# 5. Verify
+echo "── verifying ──"
+WS=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
+     | jq -r '.workspace_default_packages // .packages | map(select(.name != "aeterna-backup")) | .[0].version')
+if [[ "$WS" != "$NEW" ]]; then
+    echo "ERROR: cargo metadata reports '$WS', expected '$NEW'" >&2
+    exit 1
+fi
+
+echo
+echo "✅ bumped to ${NEW}. Next:"
+echo "   git add -A && git commit -m 'release: ${NEW}' && git push"
+echo "   after PR merges: git tag v${NEW} && git push origin v${NEW}"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -70,13 +70,31 @@ bump_chart "deploy/helm/aeterna-opal/Chart.yaml"
 # Touching it here would hardcode the tag and defeat that design.
 
 # 3. npm packages
+# We use a targeted regex instead of `jq` to avoid reformatting unrelated
+# JSON (jq normalizes arrays/objects, producing cosmetic diff noise).
+# Matches only the top-level `"version": "..."` field in package.json.
 bump_npm() {
     local pkgdir="$1"
     [[ -f "${pkgdir}/package.json" ]] || { echo "  (skip) ${pkgdir}/package.json not found"; return; }
-    local tmp
-    tmp=$(mktemp)
-    jq --arg v "$NEW" '.version = $v' "${pkgdir}/package.json" > "$tmp"
-    mv "$tmp" "${pkgdir}/package.json"
+    python3 - "$NEW" "${pkgdir}/package.json" <<'PY'
+import re, sys, pathlib
+new, path = sys.argv[1], pathlib.Path(sys.argv[2])
+txt = path.read_text()
+# Match the first top-level version field only (2-space indent — the
+# convention in every package.json we touch). Regex anchors on the
+# line-start whitespace so nested `"version":` fields (e.g. inside
+# dependencies) are never matched.
+txt, n = re.subn(
+    r'(^\s{2}"version"\s*:\s*")[^"]+(")',
+    lambda m: f'{m.group(1)}{new}{m.group(2)}',
+    txt,
+    count=1,
+    flags=re.MULTILINE,
+)
+if n != 1:
+    sys.exit(f"ERROR: no top-level version field found in {path}")
+path.write_text(txt)
+PY
     echo "  ${pkgdir}/package.json   ${NEW}"
 }
 bump_npm "packages/opencode-plugin"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Storage layer implementation"
 

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sync"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Sync bridge implementation"
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tools"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "MCP tool interface implementation"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.7.0"
+version.workspace = true
 edition = "2024"
 description = "Utility functions for the Memory-Knowledge system"
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "website",
-  "version": "0.0.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "website",
-      "version": "0.0.0",
+      "version": "0.7.0",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.0.0",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Why

Today, bumping aeterna's version requires editing:
- 22 individual \`{crate}/Cargo.toml\` files (each pins \`version = "X.Y.Z"\` literally)
- 3 helm \`Chart.yaml\` files (bumped **only** inside \`release.yml\` via inline \`sed\`)
- \`packages/opencode-plugin/package.json\`, \`admin-ui/package.json\`, \`website/package.json\` — **never bumped** today
- nothing enforces any of them agree

So a freshly built \`v0.8.0-rc.1\` binary would still report \`aeterna --version 0.7.0\`, and \`@aeterna/opencode-plugin@0.0.0\` would ship alongside. Drift was a matter of when, not if.

## What this PR does

### 1. One source of truth
\`Cargo.toml\` gains \`[workspace.package].version\`, inherited by every workspace crate via \`version.workspace = true\`. That's the **only** literal version string in Rust land now.

### 2. Atomic bump script
\`scripts/bump-version.sh <version>\` rewrites, in one shot:
- \`Cargo.toml\` \`[workspace.package].version\`
- \`charts/aeterna/Chart.yaml\` + \`charts/aeterna-prereqs/Chart.yaml\` + \`deploy/helm/aeterna-opal/Chart.yaml\` (\`version\` + \`appVersion\`)
- \`packages/opencode-plugin/package.json\`, \`admin-ui/package.json\`, \`website/package.json\`
- \`Cargo.lock\` + all three npm lockfiles

Validates SemVer 2.0. Verifies \`cargo metadata\` agrees at the end.

### 3. CI drift detector
\`.github/workflows/version-consistency.yml\` runs on every PR touching a version-bearing file, and on every \`v*\` tag push. Fails with a clear diff if any product surface disagrees with \`[workspace.package].version\`. On tag push, additionally enforces \`tag == v<workspace.version>\`.

### 4. Cut-release workflow
\`.github/workflows/cut-release.yml\` — \`workflow_dispatch(version)\`. Branches, runs the bump script, commits, pushes, opens a PR. Human reviews + merges. Then you tag:

\`\`\`bash
git checkout master && git pull
git tag v0.8.0-rc.1 && git push origin v0.8.0-rc.1
\`\`\`

Tag push triggers existing \`release.yml\` which does docker multi-arch + cosign + SBOM + CLI binaries + helm package/push + GitHub Release.

### 5. \`release.yml\` hardening
- Added \`resolve-version\` step that asserts \`[workspace.package].version == tag version\`, fails with remediation message if not.
- Removed the inline \`sed\` that bumped chart \`Chart.yaml\` at release time — it was a **second source of truth** that could silently drift from the bump script. Chart versions are now pre-committed and CI-verified.

## Explicitly excluded
- \`backup/Cargo.toml\` (\`aeterna-backup\` — independent lifecycle, stays at 0.1.0)
- \`.opencode/package.json\` (local opencode agent config, not a product artifact)

## End-to-end flow (what 0.8.0-rc.1 will look like after this merges)

\`\`\`
1. gh workflow run cut-release -f version=0.8.0-rc.1
   └─ opens PR "release: 0.8.0-rc.1" with all versions bumped + lockfiles refreshed

2. Review PR
   └─ version-consistency ✅
   └─ pr-fast ✅  pr-integration ✅
   └─ merge to master

3. git tag v0.8.0-rc.1 && git push origin v0.8.0-rc.1
   └─ release.yml fires
   └─ repo-state guard ✅ (workspace.version == tag)
   └─ docker multi-arch push → ghcr.io/kikokikok/aeterna:v0.8.0-rc.1
   └─ cosign sign + SBOM + scan
   └─ CLI binaries (4 targets) → GitHub Release
   └─ helm charts → GHCR OCI + gh-pages
\`\`\`

Every surface of 0.8.0-rc.1 reports the same version string. No drift possible.

## Testing
- \`cargo check --workspace\` passes with workspace inheritance
- \`bump-version.sh 0.7.99-dryrun\` dry-run executed locally — touched every expected file, exited 0, regex verified idempotent
- \`yamllint\` / Python YAML parse pass on all 3 workflows
- \`aeterna-backup\` confirmed untouched (still 0.1.0 after dryrun)