### PR TITLE
ci(release): two fixes from v0.8.0-rc.1 rollout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
     name: docker build (${{ matrix.platform }})
     needs: resolve-version
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Two related fixes, both surfaced during v0.8.0-rc.1 release.

## Fix 1: docker build timeout 30→60 min

On v0.8.0-rc.1 `docker build (linux/amd64)` hit **30m20s** and got killed by `timeout-minutes: 30`. arm64 squeaked under at ~27min. The `needs:` chain meant manifest/sign/sbom/release all got skipped.

Cold-cache Rust release builds on hosted runners are non-deterministic. 60min is comfortable headroom.

## Fix 2: github-release artifact download is surgical

On v0.8.0-rc.1 the `github-release` job failed **twice** after everything else succeeded, because it blindly downloaded all 9 workflow artifacts (including two ~100MB `.dockerbuild` files and bookkeeping `digests-*` artifacts the release doesn't need). Parallel pulls from Azure Blob Storage gave the transient failure rate multiple chances to bite.

Now explicit:

\`\`\`yaml
- uses: actions/download-artifact@v4
  with: { path: assets, pattern: cli-* }
- uses: actions/download-artifact@v4
  with: { path: assets, pattern: sbom-aeterna-* }
\`\`\`

9 artifacts → 5. Skipped ones were internal handoff with zero value outside the run.

Also corrected the Flatten step's `find` pattern to match the post-rename SBOM filename (it was looking for the old `sbom.spdx.json`).

## Why neither helps v0.8.0-rc.1 itself

Reruns use the workflow file from the tag's commit, not current master. That release was finalized manually by pulling artifacts from the workflow run and calling `gh release create` — noted in the release body. From v0.8.0-rc.2 onward, the automated path is clean.

## v0.8.0-rc.1 status

✅ Docker: `ghcr.io/kikokikok/aeterna:v0.8.0-rc.1` (multi-arch, cosign-signed)
✅ Helm OCI: `ghcr.io/kikokikok/charts/aeterna:0.8.0-rc.1`
✅ npm: `@aeterna-org/opencode-plugin@0.8.0-rc.1 --tag next` (provenance)
✅ CLI: 4 tarballs + checksums attached
✅ SBOM: SPDX JSON attached
✅ GitHub Release: https://github.com/kikokikok/aeterna/releases/tag/v0.8.0-rc.1