### PR TITLE
ci: integrate admin-ui container into release pipeline

### DIFF
--- a/.github/workflows/admin-ui-docker.yml
+++ b/.github/workflows/admin-ui-docker.yml
@@ -1,5 +1,16 @@
 name: Admin UI Docker Build
 
+# Builds and publishes the admin-ui container image.
+#
+# Triggers:
+#   - push to master (path-filtered on admin-ui/**) → tags: master, sha-<short>
+#   - workflow_dispatch                             → tags: master, sha-<short>
+#     optional `version` input                      → additional tag: <version>
+#
+# The `version` input is how release.yml drives this workflow to produce
+# a version-tagged image in lockstep with the main aeterna image.
+# See .github/workflows/release.yml → admin-ui-release job.
+
 on:
   push:
     branches: [master]
@@ -7,6 +18,12 @@ on:
       - 'admin-ui/**'
       - 'Dockerfile.admin-ui'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Optional version tag to apply (e.g. 0.8.0-rc.1 — no leading v). Leave empty for master + sha tags only.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -23,6 +40,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -42,12 +62,14 @@ jobs:
           tags: |
             type=ref,event=branch
             type=sha,format=short
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
-      - name: Build and push
+      - name: Build and push (multi-arch)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.admin-ui
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,6 +283,89 @@ jobs:
             ${{ matrix.archive }}.sha256
           retention-days: 7
 
+  # ─── 2b. Admin UI container image (multi-arch, cosign-signed) ────────
+  #
+  # The admin-ui image is referenced by the Helm chart via
+  # `.Values.adminUi.image.repository/tag` (default tag is Chart.AppVersion
+  # — e.g. `0.8.0-rc.1`, no `v` prefix). v0.8.0-rc.1 shipped without this
+  # job and the deploy broke on `image not found`. Producing it in lockstep
+  # with the main image prevents recurrence.
+  #
+  # Simpler than docker-build/docker-merge because admin-ui is a static
+  # node build + nginx:alpine — fast enough (~3min) to do multi-arch in
+  # a single job without digest-shuffling.
+  admin-ui-release:
+    name: admin-ui image
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write      # cosign keyless
+    env:
+      IMAGE: ${{ env.REGISTRY }}/${{ github.repository }}-admin-ui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-admin-ui
+          # Tags use NO leading `v` to match Chart.AppVersion (which is
+          # the default used by .Values.adminUi.image.tag in the chart).
+          tags: |
+            type=raw,value=${{ needs.resolve-version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.resolve-version.outputs.version }}
+            type=semver,pattern={{major}},value=${{ needs.resolve-version.outputs.version }}
+            type=raw,value=latest
+            type=sha,prefix=sha-
+      - name: Build & push (multi-arch)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.admin-ui
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=admin-ui
+          cache-to: type=gha,scope=admin-ui,mode=max
+      - uses: sigstore/cosign-installer@v3.4.0
+      - name: Sign image (cosign keyless)
+        env:
+          COSIGN_EXPERIMENTAL: '1'
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes "${{ env.REGISTRY }}/${{ github.repository }}-admin-ui@${DIGEST}"
+      - name: Verify signature
+        env:
+          COSIGN_EXPERIMENTAL: '1'
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign verify "${{ env.REGISTRY }}/${{ github.repository }}-admin-ui@${DIGEST}" \
+            --certificate-identity-regexp="https://github.com/${{ github.repository }}/.*" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+      - name: Summary
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          echo "### Admin UI image published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
+          echo "docker pull ${{ env.REGISTRY }}/${{ github.repository }}-admin-ui:${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tags: \`${VERSION}\`, major.minor, major, \`latest\`, \`sha-<sha>\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Architectures: linux/amd64, linux/arm64" >> "$GITHUB_STEP_SUMMARY"
+          echo "Signed: cosign keyless (GitHub OIDC)" >> "$GITHUB_STEP_SUMMARY"
+
   # ─── 3. Helm charts (aeterna + aeterna-prereqs) ──────────────────────
   helm-release:
     name: helm charts
@@ -442,7 +525,7 @@ jobs:
   # ─── 5. Single GitHub Release with all assets attached ────────────────
   github-release:
     name: github release
-    needs: [resolve-version, docker-merge, docker-scan-sbom, cli-build, helm-release, npm-release]
+    needs: [resolve-version, docker-merge, docker-scan-sbom, cli-build, helm-release, npm-release, admin-ui-release]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -466,10 +549,15 @@ jobs:
           body: |
             ## Aeterna v${{ needs.resolve-version.outputs.version }}
 
-            **Container image**
+            **Container image** (main)
             ```bash
             docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ needs.resolve-version.outputs.version }}
             # digest: ${{ needs.docker-merge.outputs.digest }}
+            ```
+
+            **Admin UI image**
+            ```bash
+            docker pull ${{ env.REGISTRY }}/${{ github.repository }}-admin-ui:${{ needs.resolve-version.outputs.version }}
             ```
 
             **Helm chart (OCI)**


### PR DESCRIPTION
## Bug this fixes

v0.8.0-rc.1 helm deploy blew up with:

\`\`\`
Failed to pull image "ghcr.io/kikokikok/aeterna-admin-ui:0.8.0-rc.1":
not found
\`\`\`

because `admin-ui-docker.yml` only ever tagged `master` and `sha-<short>` — **never a version tag**. Release pipeline (`release.yml`) had no awareness of admin-ui at all. Helm chart references `ghcr.io/<owner>/aeterna-admin-ui:<AppVersion>` (via `.Values.adminUi.image.{repository,tag}`) — at every tag cut this was going to fail.

## What this PR does

### 1. `admin-ui-docker.yml` — make it useful beyond master pushes
- New `workflow_dispatch.inputs.version` (optional) → adds `<version>` as an extra tag
- Adds QEMU + `platforms: linux/amd64,linux/arm64` (was amd64-only)
- Used to unblock v0.8.0-rc.1 by dispatching this workflow against the PR branch with `version=0.8.0-rc.1` — image `0.8.0-rc.1` now exists on GHCR.

### 2. `release.yml` — new `admin-ui-release` job
- Runs on every `v*` tag alongside main docker / helm / npm / cli jobs
- Multi-arch build (amd64 + arm64), cosign keyless signed, verify step included
- Standard tag set: `<version>`, `major.minor`, `major`, `latest`, `sha-<sha>`
- `github-release` now `needs:` this job; release body documents the admin-ui image pull command

### Tag convention note
Admin-ui tags use **no leading `v`** (`0.8.0-rc.1`, not `v0.8.0-rc.1`) to match `Chart.AppVersion`, which is what `.Values.adminUi.image.tag` defaults to in the chart. Main aeterna image still uses `v`-prefix — that's a separate inconsistency tracked for a follow-up (changing it would break any existing puller of `vX.Y.Z`).

## v0.8.0-rc.1 status after this PR

✅ `ghcr.io/kikokikok/aeterna-admin-ui:0.8.0-rc.1` — multi-arch, live on GHCR
   (produced via workflow_dispatch on this branch, already verified with
   `docker buildx imagetools inspect`)

Your deploy should work now. Re-run:
\`\`\`bash
kubectl rollout restart deployment/aeterna   # or re-apply helm
\`\`\`

## Verification

\`\`\`bash
$ docker buildx imagetools inspect ghcr.io/kikokikok/aeterna-admin-ui:0.8.0-rc.1
Name:      ghcr.io/kikokikok/aeterna-admin-ui:0.8.0-rc.1
MediaType: application/vnd.oci.image.index.v1+json
Manifests:
  Platform:    linux/amd64
  Platform:    linux/arm64
\`\`\`

## Related

- Builds on #41 (release workflow hardening)
- Doesn't affect v0.8.0-rc.1 automatically (rerun uses tagged workflow file); unblock was done out-of-band via this branch. From v0.8.0-rc.2 onward the release pipeline is complete.