### PR TITLE
docs(openspec): platform-admin impersonation, tenant UX, token-kind split (5 proposals)

### DIFF
--- a/openspec/changes/add-cli-auth-tenant-switch/README.md
+++ b/openspec/changes/add-cli-auth-tenant-switch/README.md
@@ -1,0 +1,3 @@
+# add-cli-auth-tenant-switch
+
+Add `aeterna auth switch` interactive picker and server-side default tenant management, gh-style

--- a/openspec/changes/add-cli-auth-tenant-switch/proposal.md
+++ b/openspec/changes/add-cli-auth-tenant-switch/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `aeterna` CLI already has `auth status`, `tenant use`, `context show/set/clear`, and a profiles system. What it lacks is a gh-CLI-style tenant switcher: one command that lists the user's accessible tenants, prompts a selection, and persists the choice both locally (for the repo-pinned context) and server-side (for the portable `users.default_tenant_id` preference). Today users either remember a slug and run `aeterna tenant use <slug>` per repo, or they fall back to the UI's browser-session selector — neither carries across machines or clients.
+
+Additionally, when the server returns the new `400 select_tenant` error (introduced by `refactor-platform-admin-impersonation`), the CLI must recognize the enriched payload, render a clean picker, and retry the original request transparently. Without this, multi-tenant users hit a dead-end error at every command.
+
+## What Changes
+
+- Add `aeterna auth switch [slug]` command — interactive picker when invoked without a slug, non-interactive when a slug is provided. Updates both the local context file (`.aeterna/context.toml`) and the server-side `users.default_tenant_id` via `PUT /api/v1/user/me/default-tenant`. Flags: `--server-only` (skip local write), `--local-only` (skip server write).
+- Add `aeterna auth default-tenant [slug]` — narrower command that manages ONLY the server-side default. `aeterna auth default-tenant` (no args) prints current; `aeterna auth default-tenant <slug>` sets; `aeterna auth default-tenant --clear` unsets.
+- Extend `aeterna auth status` output to show: current profile, authenticated user, access-token validity window, resolved tenant and the resolution source (flag/env/header/local-context/server-default/auto-select), full list of accessible tenants, and the server-side default tenant slug if set. Add `--json` flag for machine-readable output.
+- Add transparent `select_tenant` handling: when any CLI command receives `400 select_tenant`, the CLI SHALL use the `availableTenants` payload to prompt interactively, persist the selection per the `AETERNA_TENANT_PICKER_PERSISTENCE` env var (default: session-only), and retry the original request with the chosen tenant injected as `X-Tenant-ID`. A `--non-interactive` global flag disables the picker and exits with the error.
+- Add `aeterna tenant use --server` flag so the existing `tenant use <slug>` command can optionally persist to the server-side default in addition to the local context.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cli-device-flow-auth`: adds `aeterna auth switch` and `aeterna auth default-tenant` subcommands; extends `aeterna auth status` output shape; specifies CLI behavior when the server emits `400 select_tenant`; adds `--server` flag to the existing `tenant use` command.
+
+## Impact
+
+- **Affected code**: `cli/src/commands/auth.rs` (new subcommands), `cli/src/commands/tenant.rs` (new `--server` flag on `use`), new `cli/src/ui/tenant_picker.rs` (dialoguer-based picker), `cli/src/api/client.rs` (detect `select_tenant` error and delegate to picker with single-retry guard), `cli/src/profile.rs` (optional: cache last-resolved tenant per profile).
+- **Affected APIs consumed**: `GET|PUT|DELETE /api/v1/user/me/default-tenant` and extended `/api/v1/auth/session` payload (both provided by `refactor-platform-admin-impersonation`).
+- **Dependencies**: requires `refactor-platform-admin-impersonation` to be merged first — both for the new endpoints and for the `select_tenant` error shape.
+- **UX**: `--non-interactive` global behavior must be respected across all existing commands that now defer to the picker; CI pipelines using the CLI already set `AETERNA_TENANT` and SHALL be unaffected.

--- a/openspec/changes/add-cli-auth-tenant-switch/specs/cli-device-flow-auth/spec.md
+++ b/openspec/changes/add-cli-auth-tenant-switch/specs/cli-device-flow-auth/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: CLI Tenant Switch Command
+The CLI SHALL provide an `aeterna auth switch [slug]` command that lets the authenticated user select or change their active tenant. The command SHALL persist the selection both locally (in `.aeterna/context.toml`) and server-side (via `PUT /api/v1/user/me/default-tenant`) by default.
+
+#### Scenario: Interactive tenant switch
+- **WHEN** the user runs `aeterna auth switch` with no slug argument
+- **AND** stdin is a TTY
+- **THEN** the CLI SHALL fetch `GET /api/v1/auth/session`, render a selectable list of accessible tenants, and prompt the user to choose one
+- **AND** after selection, the CLI SHALL call `PUT /api/v1/user/me/default-tenant` and write the slug to `.aeterna/context.toml`
+- **AND** the CLI SHALL print a confirmation indicating which destinations were updated
+
+#### Scenario: Non-interactive tenant switch
+- **WHEN** the user runs `aeterna auth switch <slug>`
+- **AND** the slug is one of the user's accessible tenants, OR the user is a PlatformAdmin
+- **THEN** the CLI SHALL persist the selection without prompting and print the confirmation
+
+#### Scenario: Tenant switch with --server-only
+- **WHEN** the user runs `aeterna auth switch <slug> --server-only`
+- **THEN** the CLI SHALL update the server-side default only and SHALL NOT modify `.aeterna/context.toml`
+
+#### Scenario: Tenant switch with --local-only
+- **WHEN** the user runs `aeterna auth switch <slug> --local-only`
+- **THEN** the CLI SHALL update `.aeterna/context.toml` only and SHALL NOT call any server endpoint
+
+#### Scenario: Tenant switch to foreign tenant by non-admin
+- **WHEN** a non-PlatformAdmin user runs `aeterna auth switch <slug>` with a slug they have no membership in
+- **THEN** the CLI SHALL refuse the operation client-side with a friendly error and SHALL NOT issue the PUT request
+
+### Requirement: CLI Default-Tenant Subcommand
+The CLI SHALL provide an `aeterna auth default-tenant [slug]` command that manages only the server-side default tenant preference, without touching local context files.
+
+#### Scenario: Read current default
+- **WHEN** the user runs `aeterna auth default-tenant` with no arguments
+- **THEN** the CLI SHALL call `GET /api/v1/user/me/default-tenant` and print the current value (slug and name), or `<none>` if unset
+
+#### Scenario: Set default
+- **WHEN** the user runs `aeterna auth default-tenant <slug>`
+- **THEN** the CLI SHALL call `PUT /api/v1/user/me/default-tenant { slug }` and print the updated value
+
+#### Scenario: Clear default
+- **WHEN** the user runs `aeterna auth default-tenant --clear`
+- **THEN** the CLI SHALL call `DELETE /api/v1/user/me/default-tenant` and print `<none>`
+
+### Requirement: Transparent select_tenant Handling
+When any CLI command receives `400 select_tenant` from the server, the CLI SHALL interpret the enriched error payload, prompt the user to select a tenant (when interactive and when `--non-interactive` is not set), and transparently retry the original request with the chosen tenant applied as `X-Tenant-ID`.
+
+#### Scenario: Interactive picker triggered by select_tenant
+- **WHEN** the CLI sends a request that receives `400 select_tenant`
+- **AND** stdin is a TTY and `--non-interactive` is not set
+- **THEN** the CLI SHALL render the `availableTenants` list from the error payload in a selectable prompt
+- **AND** after selection, the CLI SHALL retry the original request exactly once with `X-Tenant-ID: <chosen-slug>` added
+
+#### Scenario: Non-interactive select_tenant failure
+- **WHEN** the CLI sends a request that receives `400 select_tenant`
+- **AND** stdin is not a TTY, or `--non-interactive` is set
+- **THEN** the CLI SHALL exit with a non-zero status and print the error `hint` along with the accessible tenants from the payload
+
+#### Scenario: Picker persistence modes
+- **WHEN** the user selects a tenant via the `select_tenant` picker
+- **AND** `AETERNA_TENANT_PICKER_PERSISTENCE` is set to `session` (default)
+- **THEN** the CLI SHALL use the selection only for the current invocation and SHALL NOT persist it anywhere
+- **WHEN** the value is `local`, the CLI SHALL additionally write `.aeterna/context.toml`
+- **WHEN** the value is `server`, the CLI SHALL additionally call `PUT /api/v1/user/me/default-tenant`
+- **WHEN** the value is `none`, the CLI SHALL behave as `session` but SHALL also suppress future pickers in the same run (for scripted loops)
+
+#### Scenario: Retry loop guard
+- **WHEN** a retried request also returns `400 select_tenant`
+- **THEN** the CLI SHALL NOT prompt again and SHALL exit with a non-zero status
+
+### Requirement: Extended auth status Output
+The `aeterna auth status` command SHALL report the full authentication and tenant-resolution state so users can diagnose context issues without reading code or inspecting files.
+
+#### Scenario: Status shows resolution source
+- **WHEN** the user runs `aeterna auth status`
+- **THEN** the output SHALL include the resolved active tenant (if any) and the source that produced it (one of: `flag`, `env`, `header`, `local-context`, `server-default`, `auto-single-tenant`, `unresolved`)
+- **AND** the output SHALL list all accessible tenants with an indicator on the active one
+- **AND** the output SHALL show the server-side default tenant slug (or `<none>`)
+
+#### Scenario: Status JSON output
+- **WHEN** the user runs `aeterna auth status --json`
+- **THEN** the CLI SHALL output a stable JSON document containing `profile`, `identity`, `tenants[]`, `defaultTenant`, and `context` fields
+
+## MODIFIED Requirements
+
+### Requirement: CLI Tenant Use Command
+The existing `aeterna tenant use <slug>` command SHALL continue to set the local repo-pinned tenant in `.aeterna/context.toml`. It SHALL additionally support a `--server` flag that mirrors the selection to the server-side default.
+
+#### Scenario: Local-only tenant use (default)
+- **WHEN** the user runs `aeterna tenant use <slug>`
+- **THEN** the CLI SHALL write the slug to `.aeterna/context.toml` and SHALL NOT call the server default-tenant endpoint
+
+#### Scenario: Tenant use with --server
+- **WHEN** the user runs `aeterna tenant use <slug> --server`
+- **THEN** the CLI SHALL write the slug to `.aeterna/context.toml` AND call `PUT /api/v1/user/me/default-tenant`

--- a/openspec/changes/add-cli-auth-tenant-switch/tasks.md
+++ b/openspec/changes/add-cli-auth-tenant-switch/tasks.md
@@ -1,0 +1,53 @@
+## 1. `aeterna auth switch` command
+
+- [ ] 1.1 Add `Switch(SwitchArgs)` variant to `AuthCommand` enum in `cli/src/commands/auth.rs`.
+- [ ] 1.2 `SwitchArgs { slug: Option<String>, server_only: bool, local_only: bool }` with clap attributes; `server_only` and `local_only` are mutually exclusive.
+- [ ] 1.3 Implement `switch_interactive()` — fetches `GET /auth/session`, extracts tenants, uses `dialoguer::Select` to prompt with the active tenant pre-highlighted.
+- [ ] 1.4 Implement `switch_non_interactive(slug)` — validates slug against session tenants list (or any tenant if PlatformAdmin), rejects with friendly message if not a member.
+- [ ] 1.5 Wire persistence: by default, call both `PUT /user/me/default-tenant` AND `write_context_file(slug)`. Respect `--server-only` / `--local-only`.
+- [ ] 1.6 Print a confirmation: `✓ Active tenant: <name> (<slug>)\n  Server default: updated\n  Local context (.aeterna/context.toml): updated`.
+
+## 2. `aeterna auth default-tenant` command
+
+- [ ] 2.1 Add `DefaultTenant(DefaultTenantArgs)` variant to `AuthCommand`.
+- [ ] 2.2 `DefaultTenantArgs { slug: Option<String>, clear: bool }`; mutually exclusive.
+- [ ] 2.3 No args → `GET /user/me/default-tenant` and print the current value or `<none>`.
+- [ ] 2.4 With slug → `PUT /user/me/default-tenant { slug }`.
+- [ ] 2.5 `--clear` → `DELETE /user/me/default-tenant`.
+
+## 3. Extended `aeterna auth status`
+
+- [ ] 3.1 Fetch `GET /auth/session` in addition to local profile data.
+- [ ] 3.2 Render sections: **Profile** (name, endpoint, token expiry), **Identity** (user login, email, platformAdmin flag), **Tenants** (list with active marker, membership role), **Default tenant** (server-side), **Context** (resolved tenant + resolution source).
+- [ ] 3.3 Use colorized output respecting `--no-color` / `NO_COLOR` env.
+- [ ] 3.4 Add `--json` flag for machine-readable output; fields stable for scripting.
+
+## 4. Transparent `select_tenant` error handling
+
+- [ ] 4.1 In `cli/src/api/client.rs`, detect HTTP 400 with `error: "select_tenant"` and parse `availableTenants[]`.
+- [ ] 4.2 On detection, invoke `prompt_tenant_picker(tenants)` from a new `cli/src/ui/tenant_picker.rs`.
+- [ ] 4.3 Picker behavior: if TTY and `--non-interactive` not set → prompt; else exit with the original error message and the helpful hint.
+- [ ] 4.4 After a selection, retry the original request exactly once with `X-Tenant-ID: <chosen-slug>` appended.
+- [ ] 4.5 Persistence: honor `AETERNA_TENANT_PICKER_PERSISTENCE=session|local|server|none`. Default `session`.
+- [ ] 4.6 Guard against infinite retry loops (max 1 retry per request; a second `select_tenant` becomes a hard error).
+
+## 5. `aeterna tenant use --server`
+
+- [ ] 5.1 Add `--server` flag to `TenantUseArgs` in `cli/src/commands/tenant.rs`.
+- [ ] 5.2 When set, also call `PUT /user/me/default-tenant` in addition to the existing local context write.
+- [ ] 5.3 Print which destinations were updated.
+
+## 6. Tests
+
+- [ ] 6.1 Unit-test slug validation in `switch_non_interactive` (member, non-member, platformAdmin).
+- [ ] 6.2 Integration test: mock server returns 2-tenant session; `aeterna auth switch` with stdin simulating arrow+enter picks one; both HTTP PUT and file write verified.
+- [ ] 6.3 Integration test: mock server returns `400 select_tenant` on `aeterna user list`; CLI prompts, user picks, retry succeeds with header.
+- [ ] 6.4 Integration test: `--non-interactive` + `select_tenant` error → exits 1 with the hint printed.
+- [ ] 6.5 Integration test: `aeterna auth default-tenant` with no server-side value set → prints `<none>`; after `PUT`, prints the slug.
+- [ ] 6.6 Integration test: `AETERNA_TENANT_PICKER_PERSISTENCE=server` after picker selection → verifies PUT issued.
+
+## 7. Documentation
+
+- [ ] 7.1 Update `docs/cli.md` with an `Authentication and tenant context` section covering the full resolution chain and the new commands.
+- [ ] 7.2 Add examples to `README.md`: `aeterna auth switch`, `aeterna auth switch <slug>`, `aeterna auth default-tenant <slug>`.
+- [ ] 7.3 Update `aeterna auth --help` output.

--- a/openspec/changes/fix-spa-fallback-status-code/README.md
+++ b/openspec/changes/fix-spa-fallback-status-code/README.md
@@ -1,0 +1,3 @@
+# fix-spa-fallback-status-code
+
+SPA fallback serves index.html with 200 instead of 404 for unmatched /admin/* paths

--- a/openspec/changes/fix-spa-fallback-status-code/proposal.md
+++ b/openspec/changes/fix-spa-fallback-status-code/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The admin UI static asset route in `server-runtime` serves `index.html` as an SPA fallback for unmatched `/admin/*` paths. Today the fallback response is emitted with HTTP status `404 Not Found` because it is plumbed through the `ServeDir` fallback handler. Browsers render the HTML correctly, but:
+
+1. **Monitoring false-alarms**: every deep link shows up as a 404 in access logs and CloudFront/ALB metrics, inflating the error rate and making real 404s (broken external links) invisible.
+2. **Crawlers and link checkers**: tools like Lighthouse, Sentry's `rrweb`, and internal link-checkers flag every SPA route as broken.
+3. **CDN caching**: some CDNs refuse to cache 4xx responses by default, so the SPA shell is re-fetched on every deep-link, negating the benefit of a built bundle.
+
+This is a small, mechanical fix: SPA fallbacks MUST return `200 OK` with the HTML body. The `ServeDir` configuration needs a dedicated fallback that sets the status explicitly.
+
+## What Changes
+
+- Change the `/admin/*` SPA fallback to return `200 OK` instead of `404 Not Found`.
+- Emit the same `index.html` body (unchanged).
+- Real non-admin 404s (paths that don't match any handler at all) continue to return `404 Not Found` — the fix is scoped to the `/admin/*` prefix.
+- Add a smoke test that asserts `curl -I /admin/nonexistent-route` returns `200`.
+- Update `README.md` and `docs/deployment.md` to note the behavior for operators configuring monitoring dashboards.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `server-runtime`: the SPA fallback for the `/admin/*` route group returns `200 OK` with the admin UI `index.html` body instead of `404 Not Found`.
+
+## Impact
+
+- **Affected code**: `cli/src/server/router.rs` (replace `ServeDir` default fallback with a custom handler that responds with 200 + index.html bytes), possibly a small helper in `cli/src/server/admin_ui.rs`.
+- **Affected APIs**: none — this is a status-code correction on the admin UI static asset response only.
+- **Backward compatibility**: first-party clients that matched the browser's URL bar on 404 (there shouldn't be any) see the old path succeed. External monitoring dashboards should reclassify `/admin/*` responses if they previously filtered on 404.

--- a/openspec/changes/fix-spa-fallback-status-code/specs/server-runtime/spec.md
+++ b/openspec/changes/fix-spa-fallback-status-code/specs/server-runtime/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Admin UI SPA Fallback Status Code
+When the server is configured with an admin UI dist directory, requests under the `/admin/*` path prefix that do not match a static asset SHALL return the `index.html` document with HTTP status `200 OK`. This behavior preserves client-side routing while avoiding monitoring false-alarms caused by `404 Not Found` responses.
+
+#### Scenario: SPA route returns 200 with index.html
+- **WHEN** an admin UI dist directory is configured
+- **AND** a `GET` request is made to `/admin/<any-client-side-route>` that does not match a static asset
+- **THEN** the server SHALL respond with HTTP status `200 OK`
+- **AND** the response `Content-Type` SHALL be `text/html; charset=utf-8`
+- **AND** the response body SHALL be the contents of the admin UI `index.html`
+
+#### Scenario: Static asset takes precedence
+- **WHEN** a `GET` request is made to `/admin/<path>` that matches an existing file in the dist directory (e.g., `/admin/main.js`, `/admin/favicon.ico`)
+- **THEN** the server SHALL serve that file with its actual content and `Content-Type`
+- **AND** the SPA fallback SHALL NOT be triggered
+
+#### Scenario: Non-admin paths preserve 404
+- **WHEN** a `GET` request is made to a path outside `/admin/*` that does not match any route
+- **THEN** the server SHALL return the default `404 Not Found` response (unchanged behavior)
+
+#### Scenario: Admin UI not configured
+- **WHEN** `AETERNA_ADMIN_UI_PATH` is not set, or points to a nonexistent directory
+- **THEN** the `/admin/*` route group SHALL NOT be registered
+- **AND** requests to `/admin/*` SHALL fall through to the default `404 Not Found` response (no SPA fallback)

--- a/openspec/changes/fix-spa-fallback-status-code/tasks.md
+++ b/openspec/changes/fix-spa-fallback-status-code/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+- [ ] 1.1 Replace the `ServeDir::not_found_service` / `fallback` call in `cli/src/server/router.rs` (admin UI route group) with a custom `axum::routing::any_service` fallback that reads `index.html` once at startup and returns it with `StatusCode::OK` and `Content-Type: text/html; charset=utf-8`.
+- [ ] 1.2 Cache the `index.html` body in an `Arc<Bytes>` at router build time (no disk read per request).
+- [ ] 1.3 Keep the real static files served by `ServeDir` (hits for `main.js`, `styles.css`, favicon, etc.) unchanged and ensure they still short-circuit before the fallback.
+- [ ] 1.4 Ensure non-`/admin/*` paths continue to receive the default `404` fallback.
+
+## 2. Tests
+
+- [ ] 2.1 Integration test: `GET /admin/nonexistent/deep/path` returns `200` with `Content-Type: text/html` and body starting with `<!DOCTYPE html>`.
+- [ ] 2.2 Integration test: `GET /admin/main.js` (existing static file) returns `200` with `Content-Type: application/javascript` and the actual bundle content (not index.html).
+- [ ] 2.3 Integration test: `GET /nonexistent-top-level-path` returns `404 Not Found` (confirming the fix is scoped).
+- [ ] 2.4 Integration test: `AETERNA_ADMIN_UI_PATH` unset → `GET /admin/whatever` returns `404` (no admin UI → no SPA fallback).
+
+## 3. Documentation and ops
+
+- [ ] 3.1 Update `docs/deployment.md` (or create if missing) noting the `/admin/*` route returns `200` for SPA paths.
+- [ ] 3.2 Add a note to `README.md` monitoring section to exclude `/admin/*` from 404 alerting dashboards where applicable.

--- a/openspec/changes/persist-ui-tenant-selection/README.md
+++ b/openspec/changes/persist-ui-tenant-selection/README.md
@@ -1,0 +1,3 @@
+# persist-ui-tenant-selection
+
+Admin UI TenantSelector persists choice to server-side default_tenant_id, surfaces select_tenant banner

--- a/openspec/changes/persist-ui-tenant-selection/proposal.md
+++ b/openspec/changes/persist-ui-tenant-selection/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The admin UI's `TenantSelector` currently stores the active tenant in browser `sessionStorage` and sends it as `X-Target-Tenant-ID` on every API call. There is no link to the new server-side `users.default_tenant_id` preference (introduced by `refactor-platform-admin-impersonation`). A user who switches devices, refreshes after closing the tab, or opens a new browser starts from "no tenant selected" every time. Worse, when the server emits `400 select_tenant` on tenant-scoped endpoints, the UI currently surfaces a generic "Something went wrong" banner instead of routing the user to a picker with the payload already in hand.
+
+This change makes the UI a first-class consumer of the server's preference model: the TenantSelector persists to the server by default, bootstraps from the session payload on load, and surfaces `400 select_tenant` as an actionable banner.
+
+## What Changes
+
+- On UI load, `AuthContext` reads `defaultTenantId`/`defaultTenantSlug` from `GET /api/v1/auth/session` and uses it to seed the active tenant when `sessionStorage` has no override.
+- `TenantSelector` change writes: when the user picks a tenant, the UI calls `PUT /api/v1/user/me/default-tenant { slug }` in addition to updating local state. A toggle in the selector (`[Remember across devices]`, checked by default) controls whether the server write happens.
+- Add a `SelectTenantBanner` component: whenever any API call returns `400 select_tenant`, the global error interceptor surfaces the banner at the top of the app with the `availableTenants` payload, a picker dropdown, and a `hint` tooltip. Selecting a tenant sets the active tenant, optionally persists via `PUT /user/me/default-tenant`, and retries the pending request.
+- Extend the top-bar to show the current tenant's source (`local session`, `server default`, `admin-impersonation`) as a small muted label next to the selector, matching the CLI `auth status` vocabulary.
+- PlatformAdmin-only UX: TenantSelector exposes a "Clear active tenant" option that removes the `X-Target-Tenant-ID` header for subsequent calls (enabling platform-scoped pages and cross-tenant listings with `?tenant=*`).
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `admin-dashboard`: TenantSelector gains server-side persistence and bootstrap; new `SelectTenantBanner` handles `400 select_tenant`; tenant source label added to the shell; PlatformAdmin can explicitly clear the active tenant.
+
+## Impact
+
+- **Affected code**: `admin-ui/src/auth/AuthContext.tsx` (bootstrap from session payload, new `defaultTenantId` state), `admin-ui/src/components/TenantSelector.tsx` (server write, remember-across-devices toggle, clear option), `admin-ui/src/api/client.ts` (global 400 interceptor), new `admin-ui/src/components/SelectTenantBanner.tsx`, `admin-ui/src/hooks/useTenant.ts` (include source label).
+- **Affected APIs consumed**: `GET|PUT|DELETE /api/v1/user/me/default-tenant` and extended `/api/v1/auth/session` payload (from `refactor-platform-admin-impersonation`).
+- **Dependencies**: requires `refactor-platform-admin-impersonation` merged (server endpoints and error shape) and `add-admin-web-ui` archived (introduces the `admin-dashboard` capability).
+- **UX**: no visible regression for users with a single tenant — selector remains hidden, auto-select behavior on server covers them.

--- a/openspec/changes/persist-ui-tenant-selection/specs/admin-dashboard/spec.md
+++ b/openspec/changes/persist-ui-tenant-selection/specs/admin-dashboard/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Tenant Selector
+The admin UI SHALL provide a tenant selector in the shell header that enables the authenticated user to choose an active tenant. The selector SHALL bootstrap from the server-side default tenant preference on load and SHALL, by default, persist the user's choice back to the server so it is available on other devices.
+
+#### Scenario: Bootstrap from server default
+- **WHEN** the admin UI loads after a successful login
+- **AND** the `GET /api/v1/auth/session` response includes `defaultTenantSlug: "<slug>"`
+- **AND** no local override exists in `sessionStorage`
+- **THEN** the UI SHALL set the active tenant to that slug and render it in the selector
+
+#### Scenario: Persist selection across devices (default)
+- **WHEN** the user selects a tenant in the `TenantSelector`
+- **AND** the `Remember across devices` toggle is checked (default)
+- **THEN** the UI SHALL call `PUT /api/v1/user/me/default-tenant { slug }` in addition to updating local state
+- **AND** on success, the UI SHALL display the new active tenant immediately
+- **AND** on failure, the UI SHALL roll back the local state and show a toast error
+
+#### Scenario: Session-only selection
+- **WHEN** the user selects a tenant with `Remember across devices` unchecked
+- **THEN** the UI SHALL update only its in-browser state and SHALL NOT call the server default-tenant endpoint
+
+#### Scenario: Clear active tenant (PlatformAdmin only)
+- **WHEN** a PlatformAdmin chooses `Clear active tenant` in the selector menu
+- **THEN** the UI SHALL remove the `X-Target-Tenant-ID` header from subsequent calls
+- **AND** if `Remember across devices` is checked, the UI SHALL call `DELETE /api/v1/user/me/default-tenant`
+- **AND** the selector SHALL display `Platform scope` (no tenant)
+
+### Requirement: Select-Tenant Banner
+When any UI-initiated API call receives `400 select_tenant`, the UI SHALL render a sticky banner allowing the user to pick a tenant from the `availableTenants` payload and SHALL retry the pending request with the chosen tenant applied, without requiring the user to navigate anywhere.
+
+#### Scenario: Banner triggered on tenant-scoped request
+- **WHEN** an API call returns `400 select_tenant` with `availableTenants: [...]`
+- **THEN** the UI SHALL render `SelectTenantBanner` at the top of the current view
+- **AND** the banner SHALL show a dropdown populated from `availableTenants`, the `hint` as a tooltip, and a `[Select]` button
+
+#### Scenario: Selection retries pending request
+- **WHEN** the user picks a tenant and clicks `[Select]` in the banner
+- **THEN** the UI SHALL set the active tenant to the selected slug
+- **AND** retry the original pending request with `X-Target-Tenant-ID: <chosen-slug>`
+- **AND** the banner SHALL disappear on success
+
+#### Scenario: Multiple pending requests coalesce
+- **WHEN** more than one request returns `400 select_tenant` before the user picks
+- **THEN** the UI SHALL show a single banner
+- **AND** the single selection SHALL resolve all pending requests with the chosen tenant
+
+### Requirement: Tenant Source Label
+The UI SHALL indicate the source of the currently active tenant so users can understand why a given tenant is selected and how to change it.
+
+#### Scenario: Source label renders next to selector
+- **WHEN** the UI renders the tenant selector
+- **THEN** a muted label next to the selector SHALL show one of: `from server default`, `session selection`, `single membership`, `admin impersonation`, `explicit selection`
+- **AND** hovering the label SHALL show a tooltip explaining the source

--- a/openspec/changes/persist-ui-tenant-selection/tasks.md
+++ b/openspec/changes/persist-ui-tenant-selection/tasks.md
@@ -1,0 +1,41 @@
+## 1. Bootstrap from server session
+
+- [ ] 1.1 In `AuthContext.tsx`, extend the session fetch to read `defaultTenantId` and `defaultTenantSlug` from the `/auth/session` response.
+- [ ] 1.2 On login/reload, if `sessionStorage.activeTenant` is unset and `defaultTenantSlug` is set, seed `activeTenant` with the default.
+- [ ] 1.3 If neither is set and the user has exactly one membership, auto-select it (mirror server behavior).
+- [ ] 1.4 Add `defaultTenantSlug` to the `AuthContextValue` interface.
+
+## 2. TenantSelector server persistence
+
+- [ ] 2.1 Add `rememberAcrossDevices: boolean` state to `TenantSelector`, default `true`, persisted per-user in `localStorage` under `ui.tenantSelector.remember`.
+- [ ] 2.2 On tenant change, if `rememberAcrossDevices`, call `PUT /api/v1/user/me/default-tenant { slug }` in addition to updating local state.
+- [ ] 2.3 Show a small inline checkbox in the dropdown footer: `[✓] Remember across devices`.
+- [ ] 2.4 On API failure for the PUT (e.g., network), roll back the UI state and show a toast error.
+- [ ] 2.5 Add PlatformAdmin-only "Clear active tenant" menu item that removes `sessionStorage.activeTenant` and, if `rememberAcrossDevices`, calls `DELETE /api/v1/user/me/default-tenant`.
+
+## 3. select_tenant banner
+
+- [ ] 3.1 Create `SelectTenantBanner.tsx` component: renders a sticky top-of-app banner with message, dropdown populated from `availableTenants`, `hint` tooltip, and a `[Select]` button.
+- [ ] 3.2 In `api/client.ts`, detect `HTTP 400` with `error === "select_tenant"`, store the payload in a global `pendingSelectTenant` signal, and defer the original request promise.
+- [ ] 3.3 When the banner submits a selection, resolve the deferred request with the chosen tenant applied as `X-Target-Tenant-ID`.
+- [ ] 3.4 If multiple requests are pending with `select_tenant`, coalesce: one banner, one selection resolves all pending.
+- [ ] 3.5 The banner respects `rememberAcrossDevices`: when the user selects a tenant there, it also writes `PUT /user/me/default-tenant` if the toggle is on.
+
+## 4. Source label in the top-bar
+
+- [ ] 4.1 Compute `tenantSource` in `useTenant()`: `local-session`, `server-default`, `single-membership`, `admin-impersonation`, `explicit-selection`.
+- [ ] 4.2 Render a muted `<span>` next to the selector showing a short form (`from server default`, `impersonating`, etc).
+- [ ] 4.3 Tooltip on the label explains the source and how to change it.
+
+## 5. Tests
+
+- [ ] 5.1 Component test: `TenantSelector` with `rememberAcrossDevices=true` calls the PUT endpoint on change.
+- [ ] 5.2 Component test: `TenantSelector` with `rememberAcrossDevices=false` does not call PUT.
+- [ ] 5.3 Integration (MSW) test: a `GET /user` returning `400 select_tenant` triggers the banner; selecting a tenant retries and succeeds.
+- [ ] 5.4 Integration test: PlatformAdmin's "Clear active tenant" removes the header and triggers a platform-scoped page refresh.
+- [ ] 5.5 Visual regression (Playwright): screenshot of the banner, of the selector with checkbox, of the source label states.
+
+## 6. Documentation
+
+- [ ] 6.1 Update `admin-ui/README.md` with the TenantSelector persistence behavior.
+- [ ] 6.2 Add a note to the user-facing docs describing how "Remember across devices" affects the server-side preference.

--- a/openspec/changes/refactor-admin-ui-token-kind/README.md
+++ b/openspec/changes/refactor-admin-ui-token-kind/README.md
@@ -1,0 +1,3 @@
+# refactor-admin-ui-token-kind
+
+Separate admin UI token kind from plugin-access for clearer audience scoping and revocation

--- a/openspec/changes/refactor-admin-ui-token-kind/proposal.md
+++ b/openspec/changes/refactor-admin-ui-token-kind/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The admin UI authenticates today by reusing the `plugin-access` token kind minted by the OpenCode plugin bootstrap flow (`POST /api/v1/auth/plugin/bootstrap`). This was a pragmatic shortcut when the admin UI shipped: the same JWT issuer, same validation path, same refresh rotation. It has three practical problems:
+
+1. **Audience confusion**: the `aud` claim says `aeterna-plugin`, but the token is being accepted by admin UI flows that were never intended for plugin consumption. Any audit of the token surface reports two different consumers sharing one audience.
+2. **Scope over-grant**: plugin-access tokens are designed for OpenCode plugin API calls — typically narrower than the admin UI's full feature set. Today the check is "is the user a PlatformAdmin or TenantAdmin?" which is coarse; a properly audienced admin token would let us narrow plugin tokens without collateral damage to the UI.
+3. **Revocation asymmetry**: revoking all plugin tokens for a user (because of a compromised plugin) currently also logs them out of the admin UI, because they share the token kind. Users have no way to "log out of my CLI plugins but stay logged in to the browser".
+
+This change introduces a distinct `admin-ui` token kind alongside `plugin-access`, with separate issuance, validation, and revocation paths. Refresh tokens for each kind are fully independent.
+
+## What Changes
+
+- Introduce a new token kind `admin-ui` (in addition to existing `plugin-access`). Both are JWTs signed by the same key but with different `aud` claims (`aeterna-admin-ui` vs `aeterna-plugin`) and potentially different TTLs (admin-ui access tokens shorter, matching browser session norms).
+- Add `POST /api/v1/auth/admin-ui/bootstrap` that exchanges a GitHub OAuth code for an `admin-ui` token pair (access + refresh). The OAuth redirect URI and state management are admin-ui specific.
+- Add `POST /api/v1/auth/admin-ui/refresh` that rotates the admin-ui refresh token (same single-use rotation policy as plugin-access).
+- Add `POST /api/v1/auth/admin-ui/revoke` that revokes all admin-ui tokens for the calling user, without touching plugin tokens.
+- Admin UI migrates from `/auth/plugin/bootstrap` to `/auth/admin-ui/bootstrap`; the plugin-access path remains for the OpenCode plugin unchanged.
+- Server validates `aud` claim against the endpoint family: admin-ui endpoints reject plugin-access tokens, and vice versa, with `401 wrong_audience` error code.
+- Migration: existing admin-ui sessions remain valid (plugin-access tokens keep working on admin-ui endpoints during a grace period gated by `ADMIN_UI_ACCEPT_LEGACY_PLUGIN_TOKENS=true`, default `true` for 1 release cycle, then flipped to `false`).
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `opencode-plugin-auth`: scope narrowed to only `plugin-access` tokens; admin UI sessions no longer consume this endpoint family; `aud` claim enforcement added.
+- `user-auth`: adds a new admin-ui token family (`bootstrap`, `refresh`, `revoke` endpoints) with its own audience, TTLs, and revocation scope; defines `aud`-based endpoint routing.
+
+## Impact
+
+- **Affected code**: `cli/src/server/plugin_auth.rs` (split into `plugin_auth.rs` + new `admin_ui_auth.rs`), `cli/src/server/jwt.rs` (validate `aud` against expected audience per endpoint), `cli/src/server/router.rs` (new `/auth/admin-ui/*` routes), `admin-ui/src/auth/token-manager.ts` + `admin-ui/src/auth/LoginPage.tsx` (switch bootstrap endpoint).
+- **Affected APIs**: new `POST /api/v1/auth/admin-ui/bootstrap|refresh|revoke`. Error code `wrong_audience` added to the error catalog.
+- **Affected storage**: `oauth_refresh_tokens` table grows a `token_kind TEXT NOT NULL DEFAULT 'plugin-access'` column; migration backfills existing rows.
+- **Dependencies**: coordinates with `add-admin-web-ui` (which introduces the admin UI login flow). Can land independently but ideally after the admin UI is in production so real-world traffic informs TTL tuning.
+- **Rollout**: legacy acceptance flag (`ADMIN_UI_ACCEPT_LEGACY_PLUGIN_TOKENS`) defaulting on, flipped off one release later; clients migrate during the grace window.

--- a/openspec/changes/refactor-admin-ui-token-kind/specs/opencode-plugin-auth/spec.md
+++ b/openspec/changes/refactor-admin-ui-token-kind/specs/opencode-plugin-auth/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Plugin-Access Token Scope
+The `plugin-access` token kind issued by `POST /api/v1/auth/plugin/bootstrap` SHALL be used exclusively for OpenCode plugin API calls. Admin UI sessions SHALL use the separate `admin-ui` token kind. During a one-release grace period, admin UI endpoints MAY accept `plugin-access` tokens when `ADMIN_UI_ACCEPT_LEGACY_PLUGIN_TOKENS=true`; after that period, such acceptance is removed.
+
+#### Scenario: Plugin bootstrap still issues plugin-access tokens
+- **WHEN** a valid bootstrap request is made to `POST /api/v1/auth/plugin/bootstrap`
+- **THEN** the server SHALL issue a JWT with `aud: aeterna-plugin` and a refresh token stored with `token_kind = 'plugin-access'`
+- **AND** TTLs SHALL remain at the existing plugin values (access 1 hour, refresh 30 days unless otherwise configured)
+
+#### Scenario: Plugin refresh rejects admin-ui tokens
+- **WHEN** an `admin-ui` refresh token is presented to `POST /api/v1/auth/plugin/refresh`
+- **THEN** the server SHALL return `401 Unauthorized` with error code `wrong_audience`
+
+#### Scenario: Plugin revoke does not affect admin-ui sessions
+- **WHEN** a user calls `POST /api/v1/auth/plugin/revoke`
+- **THEN** the server SHALL delete only `token_kind = 'plugin-access'` refresh tokens for that user
+- **AND** any active admin-ui browser sessions SHALL remain valid
+
+#### Scenario: Admin UI endpoints reject plugin tokens after grace period
+- **WHEN** an admin UI endpoint receives a `plugin-access` token
+- **AND** `ADMIN_UI_ACCEPT_LEGACY_PLUGIN_TOKENS` is `false`
+- **THEN** the server SHALL return `401 wrong_audience`

--- a/openspec/changes/refactor-admin-ui-token-kind/specs/user-auth/spec.md
+++ b/openspec/changes/refactor-admin-ui-token-kind/specs/user-auth/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Admin UI Token Kind
+The server SHALL support an `admin-ui` JWT token kind distinct from the existing `plugin-access` kind. Admin UI sessions SHALL be issued, refreshed, and revoked through dedicated endpoints under `/api/v1/auth/admin-ui/*`, with an audience claim of `aeterna-admin-ui`.
+
+#### Scenario: Admin UI bootstrap issues admin-ui tokens
+- **WHEN** a valid GitHub OAuth code is presented to `POST /api/v1/auth/admin-ui/bootstrap`
+- **THEN** the server SHALL issue a JWT access token with `aud: "aeterna-admin-ui"` and a refresh token stored with `token_kind = 'admin-ui'`
+- **AND** the access token TTL SHALL be 30 minutes and the refresh token TTL SHALL be 14 days (configurable, shorter than plugin-access defaults)
+
+#### Scenario: Admin UI refresh rotates only admin-ui tokens
+- **WHEN** a valid admin-ui refresh token is presented to `POST /api/v1/auth/admin-ui/refresh`
+- **THEN** the server SHALL issue a new admin-ui access/refresh pair, invalidate the presented refresh token (single-use rotation), and return the new pair
+
+#### Scenario: Admin UI refresh rejects plugin tokens
+- **WHEN** a `plugin-access` refresh token is presented to `POST /api/v1/auth/admin-ui/refresh`
+- **THEN** the server SHALL return `401 Unauthorized` with error code `wrong_audience`
+
+#### Scenario: Admin UI revoke is scoped
+- **WHEN** an authenticated user calls `POST /api/v1/auth/admin-ui/revoke`
+- **THEN** the server SHALL delete every `oauth_refresh_tokens` row for that user with `token_kind = 'admin-ui'`
+- **AND** the server SHALL NOT touch rows with `token_kind = 'plugin-access'`
+- **AND** subsequent admin UI calls from the user's browser SHALL result in `401` until re-bootstrap
+
+### Requirement: Audience Claim Enforcement
+The server SHALL validate the JWT `aud` claim against the endpoint's expected audience. Endpoints under `/api/v1/auth/admin-ui/*` SHALL require `aud: aeterna-admin-ui`; endpoints under `/api/v1/auth/plugin/*` SHALL require `aud: aeterna-plugin`; general API endpoints SHALL accept either audience during normal operation.
+
+#### Scenario: Mismatched audience rejected
+- **WHEN** a request to `/api/v1/auth/admin-ui/<action>` carries a token with `aud: aeterna-plugin`
+- **AND** the legacy acceptance flag `ADMIN_UI_ACCEPT_LEGACY_PLUGIN_TOKENS` is `false`
+- **THEN** the server SHALL return `401 Unauthorized` with error code `wrong_audience`
+
+#### Scenario: Legacy acceptance flag permits plugin tokens on admin-ui endpoints
+- **WHEN** a request to `/api/v1/auth/admin-ui/<action>` carries a token with `aud: aeterna-plugin`
+- **AND** `ADMIN_UI_ACCEPT_LEGACY_PLUGIN_TOKENS` is `true`
+- **THEN** the server SHALL accept the token
+- **AND** the server SHALL emit a structured log event `deprecated-token-kind` with fields `user_id`, `endpoint`, `token_aud`
+
+#### Scenario: General endpoints accept either audience
+- **WHEN** a request to a tenant-scoped API endpoint (e.g., `GET /api/v1/user`) carries a token with either `aud: aeterna-admin-ui` or `aud: aeterna-plugin`
+- **THEN** the server SHALL accept the token and authorize the request normally

--- a/openspec/changes/refactor-admin-ui-token-kind/tasks.md
+++ b/openspec/changes/refactor-admin-ui-token-kind/tasks.md
@@ -1,0 +1,40 @@
+## 1. Schema
+
+- [ ] 1.1 Migration `024_admin_ui_token_kind.sql`: add `token_kind TEXT NOT NULL DEFAULT 'plugin-access'` to `oauth_refresh_tokens` with a `CHECK (token_kind IN ('plugin-access', 'admin-ui'))` constraint; add index `idx_oauth_refresh_tokens_user_kind(user_id, token_kind)`.
+- [ ] 1.2 Backfill: existing rows retain `'plugin-access'` via default.
+- [ ] 1.3 Add downgrade note in `storage/migrations/README.md`.
+
+## 2. Server: admin-ui auth endpoints
+
+- [ ] 2.1 Extract common JWT helpers into `cli/src/server/jwt.rs` if not already: mint, verify, extract claims. Parameterize `aud`.
+- [ ] 2.2 Create `cli/src/server/admin_ui_auth.rs` with `admin_ui_bootstrap`, `admin_ui_refresh`, `admin_ui_revoke` handlers. Each mirrors the plugin-auth handler but uses `aud: "aeterna-admin-ui"`.
+- [ ] 2.3 Configure TTLs per kind: `plugin-access` keeps current (1 hour access / 30 day refresh), `admin-ui` gets shorter (30 min access / 14 day refresh).
+- [ ] 2.4 Wire routes at `/api/v1/auth/admin-ui/bootstrap|refresh|revoke`.
+- [ ] 2.5 Revoke endpoint deletes ONLY `token_kind='admin-ui'` rows for the caller.
+
+## 3. Server: audience enforcement
+
+- [ ] 3.1 In the request auth middleware, look up the endpoint's expected `aud` from a route-table (admin-ui endpoints expect `aeterna-admin-ui`, plugin endpoints expect `aeterna-plugin`, general API endpoints accept either).
+- [ ] 3.2 Reject mismatched `aud` with `401 wrong_audience`.
+- [ ] 3.3 Behind `ADMIN_UI_ACCEPT_LEGACY_PLUGIN_TOKENS=true` (default true for one release), allow `plugin-access` tokens on admin-ui endpoints with a `deprecated-token-kind` structured log event.
+
+## 4. Admin UI migration
+
+- [ ] 4.1 Update `admin-ui/src/auth/LoginPage.tsx` to call `POST /api/v1/auth/admin-ui/bootstrap` instead of `/auth/plugin/bootstrap`.
+- [ ] 4.2 Update `admin-ui/src/auth/token-manager.ts` to hit `/auth/admin-ui/refresh` on rotation and `/auth/admin-ui/revoke` on logout.
+- [ ] 4.3 Update `admin-ui/src/api/client.ts` to treat `401 wrong_audience` as "session expired" (force re-login rather than refresh).
+
+## 5. Tests
+
+- [ ] 5.1 Integration: `admin-ui/bootstrap` issues a token with `aud: aeterna-admin-ui`; `plugin/bootstrap` issues with `aud: aeterna-plugin`.
+- [ ] 5.2 Integration: a `plugin-access` token sent to an admin-ui endpoint with legacy flag OFF → `401 wrong_audience`.
+- [ ] 5.3 Integration: a `plugin-access` token sent to an admin-ui endpoint with legacy flag ON → accepted with a deprecation log line.
+- [ ] 5.4 Integration: `admin-ui/revoke` deletes only admin-ui refresh tokens for the user; plugin tokens remain valid.
+- [ ] 5.5 Integration: `admin-ui/refresh` with a plugin refresh token → `401 wrong_audience`.
+- [ ] 5.6 Unit: TTL values applied correctly per kind.
+
+## 6. Rollout
+
+- [ ] 6.1 Release N: ship the new endpoints + audience enforcement with `ADMIN_UI_ACCEPT_LEGACY_PLUGIN_TOKENS=true` default. Admin UI switches to the new endpoints. Existing UI sessions keep working via the legacy flag.
+- [ ] 6.2 Release N+1: flip the default to `false`; document that admins who hard-pinned the old flag must migrate.
+- [ ] 6.3 Monitor the `deprecated-token-kind` log event to detect any unexpected external consumers.

--- a/openspec/changes/refactor-platform-admin-impersonation/README.md
+++ b/openspec/changes/refactor-platform-admin-impersonation/README.md
@@ -1,0 +1,3 @@
+# refactor-platform-admin-impersonation
+
+Refactor auth to support PlatformAdmin full tenant impersonation with optional X-Tenant-ID, server-side default_tenant_id preference, and select_tenant error UX

--- a/openspec/changes/refactor-platform-admin-impersonation/design.md
+++ b/openspec/changes/refactor-platform-admin-impersonation/design.md
@@ -1,0 +1,71 @@
+## Context
+
+Aeterna's request authentication has organically grown around a "tenant-first" assumption: every authenticated request is expected to be scoped to one tenant, and the `X-Tenant-ID` header is how the scope is declared. This assumption is enforced by `authenticated_tenant_context` (at `cli/src/server/mod.rs:235`) which rejects any PlatformAdmin request without `X-Tenant-ID`. It worked while every user had a home tenant, but breaks in three real-world cases:
+
+1. **Fresh-deploy first-tenant provisioning.** The bootstrap seeds a PlatformAdmin user and role, but not a tenant row. The PlatformAdmin's first action must be creating a tenant — and that endpoint demands a tenant header. Workarounds (passing an orphan `X-Tenant-ID` string) happen to work because the header is not validated against the `tenants` table.
+2. **Cross-tenant operator tasks.** PlatformAdmins should be able to list users, projects, or configs across all tenants without picking one. Today this requires N round trips through tenant selection.
+3. **Per-user tenant preference portability.** `aeterna tenant use <slug>` writes to a local file. The UI TenantSelector lives in browser session. Third-party plugins receive no signal. A user who switches client loses their context.
+
+## Goals
+
+- PlatformAdmin can call any endpoint on any existing tenant (with `X-Tenant-ID`) or platform-wide (without).
+- `X-Tenant-ID` is validated against the canonical `tenants` table; orphan IDs never accidentally authorize a request.
+- Non-admin users targeting a foreign tenant are rejected with a clear `403`; users with ambiguous membership receive a `400 select_tenant` that carries everything the client needs to render a picker.
+- A user's preferred tenant is persistable server-side so every client picks it up uniformly.
+- Audit trail distinguishes actor identity from the tenant being impersonated.
+
+## Non-goals
+
+- CLI-side picker UX — lives in `add-cli-auth-tenant-switch`.
+- UI-side selector persistence — lives in `persist-ui-tenant-selection`.
+- Splitting admin-UI token kind from plugin-access — lives in `refactor-admin-ui-token-kind`.
+- Bootstrap auto-seeding a default tenant — explicitly rejected in favor of PlatformAdmin deliberately provisioning the first tenant via `aeterna admin provision-tenant`.
+
+## Decisions
+
+### Decision 1: Single unified `RequestContext` replaces three overlapping helpers
+
+Today there are three nearly identical helpers (`authenticated_tenant_context`, `tenant_scoped_context`, `require_platform_admin`) that all route through the same tenant-header check and differ only in role assertions. Consolidating them into one `RequestContext` resolver makes the resolution chain inspectable in a single place and ensures consistency: every handler sees the same logic.
+
+Alternatives considered:
+- **Keep three helpers, fix each individually.** Rejected: three places to keep in sync, and the asymmetry already caused today's bug where PlatformAdmin routes incorrectly chain through the tenant-header check.
+- **Middleware that populates `RequestContext` into Axum request extensions.** Considered for ergonomics. Deferred to a follow-up — the explicit function call signature is easier to reason about during the initial migration, and Axum extensions can be layered later without another API break.
+
+### Decision 2: Tenant resolution priority chain, deterministic
+
+```
+  1. X-Tenant-ID header        (session-scoped override, UI picker, CLI flag/env propagation)
+  2. users.default_tenant_id   (portable user preference)
+  3. Single-tenant auto-select (if user has exactly one membership)
+  4. None + PlatformAdmin      → platform-scoped request, success
+     None + regular user       → 400 select_tenant
+```
+
+CLI-level priority (`--tenant` flag, `AETERNA_TENANT` env, `.aeterna/context.toml`) is translated into the `X-Tenant-ID` header by the client before the request reaches the server. The server sees one input: the header. This keeps the server contract simple and lets every client (CLI, UI, plugin) layer preference logic on top.
+
+### Decision 3: Validate `X-Tenant-ID` against `tenants` table, always
+
+The current silent-accept of orphan IDs is a latent bug. Validation costs one cached lookup; the tenant store is already in-memory for most deployments. The 404 response matches REST conventions for a resource reference that does not exist.
+
+### Decision 4: `select_tenant` error carries tenant list
+
+Returning the list of accessible tenants in the error payload lets the CLI launch its picker immediately and lets the UI render the selector without a second API call. The payload never enumerates tenants outside the caller's membership (PlatformAdmin sees all, regular users see their own only), preserving isolation.
+
+### Decision 5: Legacy `tenant_required` remains for two minor versions behind an opt-in header
+
+All first-party clients (CLI, UI) migrate to `select_tenant` in the dependent proposals. Third-party plugin consumers that matched on `tenant_required` in error handlers get a grace period via `Accept-Error-Legacy: true` header: when set, the server emits the old code for backward compatibility. This is opt-in (never default) so correct clients move forward immediately.
+
+### Decision 6: Audit log column additions, no table split
+
+Adding `acting_as_tenant_id` to `referential_audit_log` and `governance_audit_log` is preferable to a new `impersonation_log` table. Existing dashboards and queries continue to work; operators query the one column to distinguish impersonated vs. direct actions. A derived `is_impersonation` expression (`acting_as_tenant_id IS DISTINCT FROM user.primary_tenant_id`) handles the PlatformAdmin case where the actor has no primary tenant.
+
+### Decision 7: `?tenant=*` over a separate endpoint family for cross-tenant listing
+
+Reuses the existing handler bodies (single filter change) and keeps URL shape consistent. PlatformAdmin-only guard at the handler entry point; non-admins receive `403`. Alternatives considered: (a) separate `/api/v1/platform/users` family — rejected as URL-sprawl; (b) infer from absent `X-Tenant-ID` — rejected because it collides with platform-scoped endpoints.
+
+## Risks
+
+- **Migration surface**: ~30 handler modules touch the old helpers. Mitigated by keeping the old helpers as `#[deprecated]` shims during the transition; Rust's warn-on-deprecated surfaces every remaining call site.
+- **Silent authorization regression**: if a handler is accidentally migrated to `require_platform_admin` when it should call `require_target_tenant`, a PlatformAdmin might execute a tenant-scoped op without tenant context. Mitigated by task 3.4 (audit every 400 response) and integration tests that assert specific handlers still require a tenant.
+- **Audit log join noise**: adding `acting_as_tenant_id` with FK means every PlatformAdmin impersonation references real tenants. If a tenant is later deleted, audit rows reference a dead tenant. Acceptable: `ON DELETE SET NULL` clears the reference but preserves the actor identity.
+- **Breaking legacy clients**: any external plugin that `assert error.code == "tenant_required"` will break when receiving `select_tenant`. Mitigated by the two-version deprecation window and the `Accept-Error-Legacy` opt-in.

--- a/openspec/changes/refactor-platform-admin-impersonation/proposal.md
+++ b/openspec/changes/refactor-platform-admin-impersonation/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+On a freshly deployed Aeterna instance with zero tenants, a PlatformAdmin cannot create the first tenant through the intended API or CLI path. Every PlatformAdmin request is forced through `authenticated_tenant_context`, which requires an `X-Tenant-ID` header — a chicken-and-egg that blocks `aeterna admin provision-tenant`, `POST /api/v1/admin/tenants`, and even `GET /api/v1/admin/tenants`. The only way through today is passing an `X-Tenant-ID` header whose value does not exist in the `tenants` table (orphan IDs are silently accepted), which is both a UX failure and a latent authorization bug.
+
+Separately, regular users with multiple tenant memberships receive a bare `400 tenant_required` with no tenant list payload, giving clients no way to render a picker without an extra round trip. And there is no server-side per-user preferred tenant, so context is lost when a user switches clients (CLI ↔ UI ↔ third-party plugin).
+
+This change reshapes request authentication around a single `RequestContext` resolver that makes `X-Tenant-ID` optional for PlatformAdmins, enables full cross-tenant impersonation, validates tenant IDs against the canonical table, and persists a per-user preferred tenant server-side.
+
+## What Changes
+
+- **BREAKING** (internal API surface, no external breaking changes): replace `authenticated_tenant_context` / `require_platform_admin` / `tenant_scoped_context` with a unified `RequestContext` resolver (`cli/src/server/mod.rs`). All handlers migrate to the new context.
+- Introduce an explicit tenant resolution chain with deterministic priority: `--tenant` flag → `AETERNA_TENANT` env → `X-Tenant-ID` header → local `.aeterna/context.toml` → `users.default_tenant_id` (server preference) → single-tenant auto-select → `400 select_tenant` with enriched payload.
+- PlatformAdmin impersonation becomes first-class: any PlatformAdmin may target any existing tenant via `X-Tenant-ID`; absent the header, the request is platform-scoped (and succeeds for platform-wide endpoints).
+- Validate `X-Tenant-ID` resolves to an existing tenant row; orphan IDs return `404 tenant_not_found` instead of silently resolving.
+- Add `users.default_tenant_id UUID NULL REFERENCES tenants(id) ON DELETE SET NULL` with new endpoints `GET|PUT|DELETE /api/v1/user/me/default-tenant` and surface `defaultTenantId` in `/api/v1/auth/session`.
+- Replace bare `400 tenant_required` with `400 select_tenant` carrying `availableTenants[]` and a human-readable hint so CLI/UI can drive an interactive picker without extra calls.
+- Extend existing audit tables (`referential_audit_log`, `governance_audit_log`) with `acting_as_tenant_id UUID NULL REFERENCES tenants(id)` so PlatformAdmin impersonation is traceable.
+- Add cross-tenant list mode for PlatformAdmin on selected read endpoints (`?tenant=*` query parameter on `GET /api/v1/admin/users`, `/admin/projects`, `/admin/orgs`) so operators can audit the instance without round-tripping through tenant selection.
+- CLI/UI behavior changes live in separate proposals (`add-cli-auth-tenant-switch`, `persist-ui-tenant-selection`) which depend on this one.
+
+## Capabilities
+
+### New Capabilities
+
+None. This change refactors existing capabilities without introducing new ones.
+
+### Modified Capabilities
+
+- `user-auth`: request authentication model changes — `RequestContext` replaces `authenticated_tenant_context`; `X-Tenant-ID` is now optional for PlatformAdmin and validated against the tenants table for all roles; adds `users.default_tenant_id` and `/user/me/default-tenant` endpoints; `/auth/session` payload gains `defaultTenantId`; `400 select_tenant` replaces `400 tenant_required` with an enriched payload.
+- `granular-authorization`: PlatformAdmin is granted full cross-tenant impersonation (may target any existing tenant via `X-Tenant-ID`, may call platform-scoped endpoints with no tenant header); non-admin users attempting to target a tenant outside their role assignments receive `403 forbidden_tenant`.
+- `tenant-admin-control-plane`: `POST /admin/tenants`, `POST /admin/tenants/provision`, `GET /admin/tenants`, and all platform-wide admin endpoints no longer require `X-Tenant-ID`; `GET /admin/users`, `/admin/projects`, `/admin/orgs` accept `?tenant=*` for cross-tenant listing by PlatformAdmin; fresh-deploy provisioning (`aeterna admin provision-tenant -f manifest.yaml`) succeeds without any pre-existing tenant.
+- `multi-tenant-governance`: audit log tables gain `acting_as_tenant_id` column; every request records both actor identity and the tenant being impersonated (when applicable); audit query APIs expose impersonation filter.
+
+## Impact
+
+- **Affected code**: `cli/src/server/mod.rs` (new `RequestContext`, retire legacy helpers), `cli/src/server/plugin_auth.rs` (session payload extension), `cli/src/server/tenant_api.rs` (remove tenant-header requirement on platform routes, cross-tenant listing), `cli/src/server/user_api.rs` (new default-tenant endpoints), all `*_api.rs` handler modules (migrate call sites from old helpers to `RequestContext` — mechanical), `cli/src/storage/user_store.rs` and related stores (add `default_tenant_id` accessors).
+- **Affected APIs**: new `GET|PUT|DELETE /api/v1/user/me/default-tenant`; `/api/v1/auth/session` response gains `defaultTenantId`; error code rename `tenant_required` → `select_tenant` with new payload shape; `GET /api/v1/admin/users`, `/admin/projects`, `/admin/orgs` accept `?tenant=*`; `X-Tenant-ID` header becomes optional on all platform-admin endpoints.
+- **Affected schema**: new migration adds `users.default_tenant_id`, `referential_audit_log.acting_as_tenant_id`, `governance_audit_log.acting_as_tenant_id` (all NULL-able, no backfill needed).
+- **Affected clients**: CLI and admin UI must migrate from `tenant_required` to `select_tenant` handling — covered by dependent proposals (`add-cli-auth-tenant-switch`, `persist-ui-tenant-selection`). Third-party plugin consumers observe no breaking changes provided they continue to pass `X-Tenant-ID` on tenant-scoped endpoints; PlatformAdmin consumers see new flexibility rather than a break.
+- **Rollout**: migration is additive and backward-compatible; feature gate not required. Old error code `tenant_required` is kept as a compatibility alias for two minor versions, emitted only when a client sends `Accept-Error-Legacy: true` — see design.md.

--- a/openspec/changes/refactor-platform-admin-impersonation/specs/granular-authorization/spec.md
+++ b/openspec/changes/refactor-platform-admin-impersonation/specs/granular-authorization/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: PlatformAdmin Tenant Impersonation
+A user with the PlatformAdmin role SHALL be authorized to act in the context of any existing tenant via the `X-Tenant-ID` header, with full access equivalent to a tenant administrator of the targeted tenant. Absent the header, a PlatformAdmin request is considered platform-scoped and SHALL be authorized only for endpoints declared as platform-wide.
+
+#### Scenario: PlatformAdmin impersonates any existing tenant
+- **WHEN** a PlatformAdmin sends a tenant-scoped request with `X-Tenant-ID: <valid-slug>`
+- **THEN** the server SHALL authorize the request as if the user were the tenant administrator of that tenant
+- **AND** the audit log SHALL record `actor_user_id` (the PlatformAdmin) and `acting_as_tenant_id` (the impersonated tenant)
+
+#### Scenario: PlatformAdmin calls platform-scoped endpoint without tenant header
+- **WHEN** a PlatformAdmin sends a request to a platform-scoped endpoint (e.g., `GET /api/v1/admin/tenants`, `POST /api/v1/admin/tenants/provision`) with no `X-Tenant-ID` header
+- **THEN** the server SHALL authorize the request
+- **AND** the request SHALL succeed without requiring a tenant selection
+
+#### Scenario: PlatformAdmin calls tenant-scoped endpoint without tenant header
+- **WHEN** a PlatformAdmin sends a request to a tenant-scoped endpoint (e.g., `GET /api/v1/user`) with no `X-Tenant-ID` header and no `default_tenant_id` set
+- **THEN** the server SHALL return `400 select_tenant`
+- **AND** the payload's `availableTenants` list SHALL contain every tenant in the system (PlatformAdmin can target any)
+
+### Requirement: Tenant Membership Authorization
+A non-PlatformAdmin user SHALL be authorized only within tenants where the user has an explicit role assignment. Attempting to target a foreign tenant via `X-Tenant-ID` SHALL be rejected.
+
+#### Scenario: Non-admin targets foreign tenant
+- **WHEN** a user without the PlatformAdmin role sends a request with `X-Tenant-ID: <valid-slug>`
+- **AND** the user has no role assignments in that tenant
+- **THEN** the server SHALL return `403 Forbidden` with error code `forbidden_tenant`
+- **AND** the response body SHALL NOT confirm or deny the existence of the tenant beyond what is already known from the 403 vs 404 distinction
+
+#### Scenario: Non-admin within own tenant
+- **WHEN** a user without the PlatformAdmin role sends a request with `X-Tenant-ID: <valid-slug>` matching one of their role assignments
+- **THEN** the server SHALL authorize the request according to the roles the user holds in that tenant
+
+### Requirement: Audit Logging for Impersonation
+Every authenticated request that mutates state or accesses tenant-scoped data SHALL be recorded in the appropriate audit log with both the acting user and, when applicable, the tenant being acted upon.
+
+#### Scenario: Impersonated mutation recorded
+- **WHEN** a PlatformAdmin performs a write action on resources of tenant `T` via `X-Tenant-ID: T`
+- **THEN** the `referential_audit_log` or `governance_audit_log` entry SHALL have `actor_user_id = <admin-user-id>` and `acting_as_tenant_id = <T's-id>`
+
+#### Scenario: Direct action by tenant member
+- **WHEN** a tenant member performs a write action within their own tenant
+- **THEN** the audit log entry SHALL have `actor_user_id = <their-id>` and `acting_as_tenant_id = <their-tenant-id>` (matching, not impersonation)

--- a/openspec/changes/refactor-platform-admin-impersonation/specs/multi-tenant-governance/spec.md
+++ b/openspec/changes/refactor-platform-admin-impersonation/specs/multi-tenant-governance/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Audit Log Schema
+The `referential_audit_log` and `governance_audit_log` tables SHALL record both the identity of the acting user and, when applicable, the tenant in whose context the action was performed. The latter SHALL be represented by an `acting_as_tenant_id UUID NULL REFERENCES tenants(id) ON DELETE SET NULL` column on each audit table.
+
+#### Scenario: Impersonated action record
+- **WHEN** an audit event is written for a request where `RequestContext.tenant = Some(T)` and the acting user is a PlatformAdmin
+- **THEN** the audit row SHALL have `actor_id = <admin-user-id>` and `acting_as_tenant_id = <T.id>`
+
+#### Scenario: Direct tenant-member action record
+- **WHEN** an audit event is written for a request by a tenant member acting within their own tenant
+- **THEN** the audit row SHALL have `actor_id = <user-id>` and `acting_as_tenant_id = <user's-tenant-id>`
+- **AND** consumers MAY derive `is_impersonation = false` by comparing `acting_as_tenant_id` against the user's primary tenant
+
+#### Scenario: Platform-scoped action record
+- **WHEN** an audit event is written for a request where `RequestContext.tenant = None` (e.g., a PlatformAdmin listing all tenants)
+- **THEN** the audit row SHALL have `actor_id = <admin-user-id>` and `acting_as_tenant_id IS NULL`
+
+#### Scenario: Tenant deletion preserves audit history
+- **WHEN** a tenant referenced by audit rows is deleted
+- **THEN** `ON DELETE SET NULL` SHALL clear `acting_as_tenant_id` to `NULL` on those rows
+- **AND** the rest of the audit row (actor, action, old_values, new_values, timestamp) SHALL remain intact
+
+### Requirement: Audit Query Filtering by Impersonation
+The audit query endpoints SHALL support filtering by impersonation status so operators can review PlatformAdmin activity across tenants.
+
+#### Scenario: Impersonation-only filter
+- **WHEN** a PlatformAdmin calls `GET /api/v1/admin/audit?onlyImpersonation=true`
+- **THEN** the server SHALL return audit rows where `acting_as_tenant_id` is set and does not match the actor's primary tenant
+
+#### Scenario: Per-tenant audit with impersonation visibility
+- **WHEN** a tenant administrator calls `GET /api/v1/admin/audit?tenant=<their-tenant>`
+- **THEN** the server SHALL return audit rows where `acting_as_tenant_id = <their-tenant-id>`
+- **AND** those rows SHALL include the `actor_id` and whether the actor is a PlatformAdmin (so tenant admins can see who impersonated their tenant)

--- a/openspec/changes/refactor-platform-admin-impersonation/specs/tenant-admin-control-plane/spec.md
+++ b/openspec/changes/refactor-platform-admin-impersonation/specs/tenant-admin-control-plane/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Platform-Wide Tenant Administration Endpoints
+The endpoints `GET /api/v1/admin/tenants`, `POST /api/v1/admin/tenants`, `POST /api/v1/admin/tenants/provision`, and any other admin endpoints declared as platform-scoped SHALL require PlatformAdmin role but SHALL NOT require the `X-Tenant-ID` header. This enables first-tenant provisioning on fresh deployments.
+
+#### Scenario: Fresh-deploy first tenant provisioning
+- **WHEN** a PlatformAdmin calls `POST /api/v1/admin/tenants/provision` with a valid tenant manifest
+- **AND** no tenants currently exist in the database
+- **AND** no `X-Tenant-ID` header is provided
+- **THEN** the server SHALL return `201 Created` with the provisioned tenant
+- **AND** the new tenant SHALL be visible via subsequent `GET /api/v1/admin/tenants`
+
+#### Scenario: List tenants without tenant context
+- **WHEN** a PlatformAdmin calls `GET /api/v1/admin/tenants` with no `X-Tenant-ID` header
+- **THEN** the server SHALL return `200 OK` with the full list of tenants
+
+#### Scenario: Non-admin calls platform-wide endpoint
+- **WHEN** a user without the PlatformAdmin role calls any endpoint declared platform-scoped (e.g., `GET /api/v1/admin/tenants`)
+- **THEN** the server SHALL return `403 Forbidden` with error code `platform_admin_required`
+
+### Requirement: Cross-Tenant Listing for PlatformAdmin
+Selected read endpoints SHALL accept a `?tenant=*` query parameter that, when provided by a PlatformAdmin, returns results across all tenants. Response items SHALL include `tenantId` and `tenantSlug` columns identifying each row's tenant.
+
+#### Scenario: Cross-tenant user listing
+- **WHEN** a PlatformAdmin calls `GET /api/v1/admin/users?tenant=*`
+- **THEN** the server SHALL return users from all tenants in a single response
+- **AND** each user record SHALL include `tenantId` and `tenantSlug`
+
+#### Scenario: Cross-tenant listing by non-admin
+- **WHEN** a non-PlatformAdmin calls `GET /api/v1/admin/users?tenant=*`
+- **THEN** the server SHALL return `403 Forbidden`
+
+#### Scenario: Single-tenant listing preserved
+- **WHEN** any authenticated caller calls `GET /api/v1/admin/users` without `?tenant=*` and with `X-Tenant-ID: <slug>`
+- **THEN** the server SHALL return only users of that tenant (existing behavior preserved)
+
+### Requirement: Tenant Provisioning Manifest Contract
+The `POST /api/v1/admin/tenants/provision` endpoint SHALL continue to accept a `TenantManifest` body and produce an idempotent, atomic materialization of the tenant, its hierarchy, users, roles, configuration, and secrets. The change in this capability is solely about the authorization pre-conditions (X-Tenant-ID no longer required).
+
+#### Scenario: Re-running the same manifest
+- **WHEN** a PlatformAdmin calls `POST /api/v1/admin/tenants/provision` twice with an identical manifest
+- **THEN** the first call SHALL return `201 Created`
+- **AND** the second call SHALL return `200 OK` with no additional writes (idempotent)
+
+#### Scenario: Dry-run provisioning
+- **WHEN** a PlatformAdmin calls `POST /api/v1/admin/tenants/provision?dryRun=true`
+- **THEN** the server SHALL validate the manifest and return the planned diff without persisting any changes

--- a/openspec/changes/refactor-platform-admin-impersonation/specs/user-auth/spec.md
+++ b/openspec/changes/refactor-platform-admin-impersonation/specs/user-auth/spec.md
@@ -1,0 +1,92 @@
+## MODIFIED Requirements
+
+### Requirement: Request Authentication Context
+The server SHALL resolve every authenticated request to a unified `RequestContext` that identifies the user, the user's PlatformAdmin status, and an optional resolved target tenant. The `X-Tenant-ID` header is a request-level override; when absent, the server SHALL apply a deterministic resolution chain to select the target tenant (or leave it unset for platform-scoped requests).
+
+#### Scenario: X-Tenant-ID resolves to an existing tenant
+- **WHEN** an authenticated request includes `X-Tenant-ID: <slug>`
+- **AND** the slug corresponds to an existing row in the `tenants` table
+- **THEN** the server SHALL populate `RequestContext.tenant` with the resolved tenant (id, slug, name)
+- **AND** the server SHALL proceed to authorization checks using that tenant
+
+#### Scenario: X-Tenant-ID does not resolve
+- **WHEN** an authenticated request includes `X-Tenant-ID: <slug>`
+- **AND** no row in the `tenants` table matches that slug
+- **THEN** the server SHALL return `404 Not Found` with error code `tenant_not_found`
+- **AND** the response body SHALL NOT enumerate any other tenants
+
+#### Scenario: No X-Tenant-ID with server-side default
+- **WHEN** an authenticated request does not include `X-Tenant-ID`
+- **AND** the authenticated user has `users.default_tenant_id` set to a tenant the user is a member of
+- **THEN** the server SHALL populate `RequestContext.tenant` with that default tenant
+
+#### Scenario: No X-Tenant-ID, no default, single membership
+- **WHEN** an authenticated request does not include `X-Tenant-ID`
+- **AND** the user has no `default_tenant_id`
+- **AND** the user is a member of exactly one tenant
+- **THEN** the server SHALL populate `RequestContext.tenant` with that single tenant
+
+#### Scenario: No X-Tenant-ID, PlatformAdmin
+- **WHEN** an authenticated request does not include `X-Tenant-ID`
+- **AND** the user has the PlatformAdmin role
+- **THEN** the server SHALL leave `RequestContext.tenant` as `None`
+- **AND** the request SHALL proceed; handlers decide whether a tenant is required via `require_target_tenant`
+
+#### Scenario: No X-Tenant-ID, no default, multiple memberships, non-admin
+- **WHEN** an authenticated request does not include `X-Tenant-ID`
+- **AND** the user is not a PlatformAdmin
+- **AND** the user has no `default_tenant_id`
+- **AND** the user is a member of two or more tenants
+- **THEN** the server SHALL return `400 Bad Request` with error code `select_tenant`
+- **AND** the response body SHALL include `availableTenants: [{id, slug, name}, ...]` listing ONLY the user's tenant memberships
+- **AND** the response body SHALL include a `hint` string indicating how to select a tenant (CLI and UI guidance)
+
+### Requirement: User Default Tenant Preference
+The server SHALL persist a per-user preferred tenant (`users.default_tenant_id`) and expose endpoints to read, set, and clear it. The default tenant is used when the user's active request does not specify `X-Tenant-ID`.
+
+#### Scenario: Reading the default tenant
+- **WHEN** an authenticated user sends `GET /api/v1/user/me/default-tenant`
+- **THEN** the server SHALL return `{ defaultTenantId, defaultTenantSlug }` (both may be `null` if unset)
+
+#### Scenario: Setting the default tenant as a member
+- **WHEN** an authenticated user sends `PUT /api/v1/user/me/default-tenant` with body `{ slug: "<existing-tenant-slug>" }`
+- **AND** the user is a member of that tenant, OR the user is a PlatformAdmin
+- **THEN** the server SHALL update `users.default_tenant_id` to the tenant's id
+- **AND** the server SHALL return `200 OK` with the updated `{ defaultTenantId, defaultTenantSlug }`
+
+#### Scenario: Setting the default tenant without membership
+- **WHEN** a non-admin user sends `PUT /api/v1/user/me/default-tenant` with a tenant slug they have no role assignments in
+- **THEN** the server SHALL return `403 Forbidden` with error code `forbidden_tenant`
+- **AND** the server SHALL NOT modify `users.default_tenant_id`
+
+#### Scenario: Clearing the default tenant
+- **WHEN** an authenticated user sends `DELETE /api/v1/user/me/default-tenant`
+- **THEN** the server SHALL set `users.default_tenant_id` to `NULL`
+- **AND** the server SHALL return `200 OK` with `{ defaultTenantId: null, defaultTenantSlug: null }`
+
+#### Scenario: Default tenant is deleted
+- **WHEN** a tenant is deleted that is referenced by one or more `users.default_tenant_id` values
+- **THEN** the database FK constraint `ON DELETE SET NULL` SHALL clear those references automatically
+- **AND** the affected users' next request SHALL proceed as if no default was set
+
+### Requirement: Authentication Session Payload
+The `/api/v1/auth/session` endpoint SHALL return the authenticated user's identity, tenant memberships, role assignments, and default tenant preference in a single response so clients can bootstrap their UI/CLI state without additional round trips.
+
+#### Scenario: Session payload includes default tenant
+- **WHEN** a valid bearer token is presented to `GET /api/v1/auth/session`
+- **THEN** the response body SHALL include `defaultTenantId: string | null` and `defaultTenantSlug: string | null`
+- **AND** the response SHALL also include `isPlatformAdmin`, `tenants: [{id, slug, name}, ...]`, and `activeTenantId` (resolved via the request-context chain for this session call)
+
+### Requirement: Select-Tenant Error Shape
+When the server determines that a tenant-scoped request cannot be resolved to a unique tenant, it SHALL return `400 Bad Request` with error code `select_tenant` and a payload that enables clients to render a picker without additional API calls.
+
+#### Scenario: Error payload shape
+- **WHEN** the server emits `select_tenant`
+- **THEN** the JSON body SHALL contain: `error: "select_tenant"`, `message: <human string>`, `availableTenants: [{id, slug, name}]`, `hint: <string>`
+- **AND** `availableTenants` SHALL be the caller's accessible tenants (their memberships, or all tenants if the caller is a PlatformAdmin)
+
+#### Scenario: Legacy compatibility opt-in
+- **WHEN** the request includes the header `Accept-Error-Legacy: true`
+- **AND** the server would otherwise emit `select_tenant`
+- **THEN** the server SHALL emit the legacy error code `tenant_required` instead
+- **AND** the response body SHALL match the pre-refactor shape (`{ error: "tenant_required", message }`) without the `availableTenants` or `hint` fields

--- a/openspec/changes/refactor-platform-admin-impersonation/tasks.md
+++ b/openspec/changes/refactor-platform-admin-impersonation/tasks.md
@@ -1,0 +1,76 @@
+## 1. Schema migration
+
+- [ ] 1.1 Create `storage/migrations/023_platform_admin_impersonation.sql` adding `users.default_tenant_id UUID NULL REFERENCES tenants(id) ON DELETE SET NULL` with an index `idx_users_default_tenant_id`.
+- [ ] 1.2 In the same migration, add `acting_as_tenant_id UUID NULL REFERENCES tenants(id)` to `referential_audit_log` and `governance_audit_log` with matching indexes `idx_*_audit_log_acting_as_tenant`.
+- [ ] 1.3 Verify migration applies cleanly on a copy of a production-shape database (no backfill required; all existing rows stay `NULL`).
+- [ ] 1.4 Add downgrade notes to `storage/migrations/README.md` (columns are drop-safe).
+
+## 2. Core `RequestContext` resolver
+
+- [ ] 2.1 Define `pub struct RequestContext { user: AuthenticatedUser, is_platform_admin: bool, tenant: Option<ResolvedTenant>, request_id: RequestId }` in `cli/src/server/context.rs` (new file).
+- [ ] 2.2 Implement `pub async fn request_context(state: &AppState, headers: &HeaderMap) -> Result<RequestContext, Response>` that executes the resolution chain in order: `X-Tenant-ID` header → `users.default_tenant_id` lookup → single-tenant auto-select → `None` for PlatformAdmin or `Err(select_tenant)` otherwise.
+- [ ] 2.3 Validate `X-Tenant-ID` resolves to an existing `tenants` row; return `404 tenant_not_found` for orphan IDs (include a scenario in tests that regression-guards the current silent-accept bug).
+- [ ] 2.4 For non-admin users targeting a foreign tenant via `X-Tenant-ID`, return `403 forbidden_tenant` with a message that does NOT enumerate foreign tenant names.
+- [ ] 2.5 Add `pub fn require_platform_admin(ctx: &RequestContext) -> Result<(), Response>` that checks `ctx.is_platform_admin` without any tenant dependency.
+- [ ] 2.6 Add `pub fn require_target_tenant(ctx: &RequestContext) -> Result<&ResolvedTenant, Response>` that returns the resolved tenant or emits `400 select_tenant` with enriched payload.
+- [ ] 2.7 Implement `select_tenant` error builder that attaches `{ availableTenants: [{slug, name, id}], hint }` to the JSON body; add `Accept-Error-Legacy` compat header support (emits legacy `tenant_required` when set).
+- [ ] 2.8 Unit-test `request_context` across every branch of the resolution chain (10+ scenarios).
+
+## 3. Retire legacy auth helpers
+
+- [ ] 3.1 Mark `authenticated_tenant_context`, `tenant_scoped_context`, and the old `require_platform_admin` in `cli/src/server/mod.rs` as `#[deprecated]` with a pointer to `RequestContext`.
+- [ ] 3.2 Migrate every call site in `cli/src/server/*_api.rs` to `RequestContext`, preserving behavior. Use `require_target_tenant` for tenant-scoped handlers, `require_platform_admin` for platform-scoped handlers.
+- [ ] 3.3 Remove deprecated helpers after the migration is complete; confirm `cargo build --all-targets` passes with `#[deny(deprecated)]`.
+- [ ] 3.4 Audit every 400 response in the API surface: any remaining `tenant_required` emission sites either move to `select_tenant` or are removed.
+
+## 4. Default tenant preference endpoints
+
+- [ ] 4.1 Add `GET /api/v1/user/me/default-tenant` returning `{ defaultTenantId: string | null, defaultTenantSlug: string | null }`.
+- [ ] 4.2 Add `PUT /api/v1/user/me/default-tenant` with body `{ slug: string }`; validate the caller is a member of the target tenant (PlatformAdmin exempt); update `users.default_tenant_id`; return updated payload.
+- [ ] 4.3 Add `DELETE /api/v1/user/me/default-tenant` clearing the preference (sets to `NULL`).
+- [ ] 4.4 Extend `/api/v1/auth/session` response shape to include `defaultTenantId` and `defaultTenantSlug` fields (backward-compatible additive change).
+- [ ] 4.5 Add storage methods: `UserStore::set_default_tenant(user_id, Option<TenantId>)`, `UserStore::get_default_tenant(user_id) -> Option<ResolvedTenant>`.
+- [ ] 4.6 Ensure `ON DELETE SET NULL` FK behavior is covered by an integration test (create tenant, set as default, delete tenant, confirm default is cleared).
+
+## 5. PlatformAdmin cross-tenant listing
+
+- [ ] 5.1 `GET /api/v1/admin/users?tenant=*` returns users across all tenants (PlatformAdmin only); response items include `tenantId` + `tenantSlug` columns.
+- [ ] 5.2 `GET /api/v1/admin/projects?tenant=*` same shape for projects.
+- [ ] 5.3 `GET /api/v1/admin/orgs?tenant=*` same shape for organizational units.
+- [ ] 5.4 `?tenant=*` requests by non-PlatformAdmin return `403 forbidden`.
+- [ ] 5.5 Without `?tenant=*`, existing single-tenant listing semantics are preserved (requires `X-Tenant-ID` via `require_target_tenant`).
+- [ ] 5.6 Add `tenant_filter` query param documentation to the OpenAPI/Redoc schema.
+
+## 6. Audit log impersonation tracking
+
+- [ ] 6.1 In the audit-log middleware/helpers, populate `acting_as_tenant_id` from `ctx.tenant.as_ref().map(|t| t.id)` for every recorded event.
+- [ ] 6.2 Populate `actor_id` from `ctx.user.id` (unchanged) and add a derived column `is_impersonation = actor_tenant_id IS DISTINCT FROM acting_as_tenant_id` at query time.
+- [ ] 6.3 Extend audit query endpoints (`GET /api/v1/admin/audit`) with a `?onlyImpersonation=true` filter.
+- [ ] 6.4 Add structured log fields `actor_user_id`, `acting_as_tenant_id`, `is_platform_admin`, `request_id` to every request-scoped log line via the tracing middleware.
+
+## 7. Tests
+
+- [ ] 7.1 Integration test: fresh database → PlatformAdmin JWT → `POST /api/v1/admin/tenants/provision` with manifest, no `X-Tenant-ID` → 201 Created, tenant row exists.
+- [ ] 7.2 Integration test: PlatformAdmin with `X-Tenant-ID: <foreign-tenant>` → `GET /api/v1/user` → 200 with that tenant's users.
+- [ ] 7.3 Integration test: PlatformAdmin with no `X-Tenant-ID` → `GET /api/v1/admin/users?tenant=*` → 200 with cross-tenant list.
+- [ ] 7.4 Integration test: regular user with two tenant memberships, no `X-Tenant-ID`, no default → `GET /api/v1/user` → 400 `select_tenant` with `availableTenants[]` populated.
+- [ ] 7.5 Integration test: regular user, `PUT /user/me/default-tenant` with a slug they are NOT a member of → 403.
+- [ ] 7.6 Integration test: regular user, `PUT /user/me/default-tenant` with a valid slug → 200; subsequent `GET /user` (no header) → 200.
+- [ ] 7.7 Integration test: any user, `X-Tenant-ID: nonexistent-slug` → 404 `tenant_not_found`.
+- [ ] 7.8 Integration test: regular user, `X-Tenant-ID: <tenant they are not a member of>` → 403 `forbidden_tenant`.
+- [ ] 7.9 Integration test: audit log row for PlatformAdmin impersonation records both `actor_id` and `acting_as_tenant_id` correctly.
+- [ ] 7.10 Compatibility test: request with `Accept-Error-Legacy: true` and missing tenant → 400 `tenant_required` (legacy code) instead of `select_tenant`.
+
+## 8. Documentation
+
+- [ ] 8.1 Update `docs/auth.md` (or create if missing) with the resolution chain diagram and PlatformAdmin impersonation model.
+- [ ] 8.2 Document the `select_tenant` error shape in `docs/api-errors.md`.
+- [ ] 8.3 Update `README.md` "First-time deployment" section: fresh-deploy workflow is now `aeterna admin provision-tenant -f manifest.yaml` by the bootstrapped PlatformAdmin, no tenant seeding required.
+- [ ] 8.4 Add an example tenant manifest at `examples/tenant-manifest.yaml`.
+- [ ] 8.5 Update the OpenAPI schema generation for the three endpoints in section 4 and the cross-tenant query params in section 5.
+
+## 9. Rollout
+
+- [ ] 9.1 Merge behind no feature flag — the change is additive and safe.
+- [ ] 9.2 Release notes highlight: (a) PlatformAdmin UX unblocked on fresh deploys, (b) new `/user/me/default-tenant` endpoints, (c) `tenant_required` deprecation schedule (removed in 2 minor versions).
+- [ ] 9.3 Coordinate with `add-cli-auth-tenant-switch` and `persist-ui-tenant-selection` so CLI and UI handle `select_tenant` before the server migration lands in production.


### PR DESCRIPTION
## Summary

Five coordinated OpenSpec proposals addressing the platform-admin bootstrap deadlock discovered during fresh-deploy tenant provisioning, plus the broader tenant-UX and token-kind cleanup that fell out of the investigation.

Each change validates with `openspec validate <id> --strict`. No runtime code is modified by this PR — implementation lands in per-capability PRs after review.

## Changes in this PR

| # | Change | Summary |
|---|--------|---------|
| 1 | [`refactor-platform-admin-impersonation`](./openspec/changes/refactor-platform-admin-impersonation/proposal.md) | Unified `RequestContext`, PlatformAdmin full tenant impersonation, `X-Tenant-ID` validation, `users.default_tenant_id`, `select_tenant` error with enriched payload, cross-tenant listing, audit-log `acting_as_tenant_id`. |
| 2 | [`add-cli-auth-tenant-switch`](./openspec/changes/add-cli-auth-tenant-switch/proposal.md) | `aeterna auth switch [slug]` (gh-CLI-style), `aeterna auth default-tenant`, extended `auth status --json`, transparent `select_tenant` interactive picker with retry. |
| 3 | [`persist-ui-tenant-selection`](./openspec/changes/persist-ui-tenant-selection/proposal.md) | Admin UI `TenantSelector` reads/writes server-side default, new `SelectTenantBanner` on `400 select_tenant`, tenant-source label, PlatformAdmin "Clear active tenant". |
| 4 | [`fix-spa-fallback-status-code`](./openspec/changes/fix-spa-fallback-status-code/proposal.md) | `/admin/*` SPA fallback returns `200` instead of `404` to stop polluting monitoring dashboards and allow CDN caching. |
| 5 | [`refactor-admin-ui-token-kind`](./openspec/changes/refactor-admin-ui-token-kind/proposal.md) | Split `admin-ui` JWT kind from `plugin-access`, separate `/auth/admin-ui/*` endpoints, `aud`-claim enforcement, scoped revocation, one-release legacy acceptance flag. |

## Context

- Incident: fresh-deploy provisioning was blocked because every admin endpoint chained through `authenticated_tenant_context`, which rejected any request without `X-Tenant-ID` — a chicken-and-egg on an empty `tenants` table. Workaround (passing an orphan ID) exposed that the header was never validated against the canonical table.
- Design discussion: conversation `YcoEFWpRoF` (Apr 18, 13:37–18:59 CEST).

## Design highlights

### Tenant resolution chain (deterministic)

```
1. --tenant CLI flag
2. AETERNA_TENANT env var
3. X-Tenant-ID request header          (session-scoped override)
4. .aeterna/context.toml               (repo-pinned via `aeterna tenant use`)
5. users.default_tenant_id             (NEW — portable server-side preference)
6. Single-tenant auto-select           (if user has exactly one membership)
7. None for PlatformAdmin → platform-scoped request
   None for regular user  → 400 select_tenant with availableTenants[] payload
```

### `400 select_tenant` enriched error

```json
{
  "error": "select_tenant",
  "message": "Multiple tenants accessible. Select one to continue.",
  "availableTenants": [
    {"id": "...", "slug": "kyriba-eng",   "name": "Kyriba Engineering"},
    {"id": "...", "slug": "kyriba-sales", "name": "Kyriba Sales"}
  ],
  "hint": "CLI: `aeterna auth switch`. UI: use the tenant selector in the header."
}
```

Legacy `tenant_required` preserved behind opt-in `Accept-Error-Legacy: true` for two minor versions.

### PlatformAdmin impersonation + audit

PlatformAdmin may target any existing tenant via `X-Tenant-ID`; absent the header, request is platform-scoped. Every action records both `actor_user_id` and `acting_as_tenant_id` in the referential/governance audit logs (new column, `ON DELETE SET NULL`).

### Cross-tenant listing

`GET /api/v1/admin/users?tenant=*` (also `/admin/projects`, `/admin/orgs`) returns results across all tenants for PlatformAdmins, with `tenantId` / `tenantSlug` columns on each row.

## Rollout

1. Merge this PR — docs only, no runtime changes.
2. Implement each change in its own PR (one-to-one mapping to the OpenSpec folders).
3. Implementation order respects dependencies: **#1 before #2, #3** (they consume new endpoints and error shape). **#4** and **#5** can land in parallel with any of the above.

## Linked issues

Five tracking issues — one per change — will be created in a follow-up comment.

## Verification

```
$ for c in refactor-platform-admin-impersonation add-cli-auth-tenant-switch persist-ui-tenant-selection fix-spa-fallback-status-code refactor-admin-ui-token-kind; do
    openspec validate "$c" --strict
  done
refactor-platform-admin-impersonation: valid
add-cli-auth-tenant-switch: valid
persist-ui-tenant-selection: valid
fix-spa-fallback-status-code: valid
refactor-admin-ui-token-kind: valid
```
