### PR TITLE
fix(ci): release env.REGISTRY parse error + kubeconform download resilience

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,8 +302,6 @@ jobs:
       contents: read
       packages: write
       id-token: write      # cosign keyless
-    env:
-      IMAGE: ${{ env.REGISTRY }}/${{ github.repository }}-admin-ui
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Two independent CI fixes, bundled since both are small and touch only `.github/workflows/`.

---

## 1. `release.yml` — parser error blocking master pushes

```
Invalid workflow file: .github/workflows/release.yml#L1
(Line: 306, Col: 14): Unrecognized named-value: 'env'. Located at position 1 within expression: env.REGISTRY
```

**Root cause:** `admin-ui-release` had `env: IMAGE: ${{ env.REGISTRY }}/...` at job level. GitHub Actions does not resolve `env.*` inside a job-level `env:` block — the env context is only populated at step evaluation, not during job env construction. Documented limitation.

**Fix:** delete. The `IMAGE` variable was never consumed — every step already inlines `${{ env.REGISTRY }}/${{ github.repository }}-admin-ui` (valid at step level).

Commit: e48f628

---

## 2. `pr-fast.yml` — kubeconform install flake

```
gzip: stdin: not in gzip format
tar: Child returned status 1
```

**Root cause:** `curl -sL <url> | tar xz` with no `-f` and no retry. When the GitHub release CDN hiccups (transient 5xx or HTML error page), curl is silent and pipes the HTML straight into tar, which fails on gunzip. Downloading the same URL from elsewhere succeeds — pure transient.

**Fix:**

- `--fail` so curl exits non-zero on HTTP errors instead of piping HTML.
- `--retry 5 --retry-delay 3 --retry-all-errors` to survive CDN flakes.
- Download to file first; verify `file` output reports gzip before extracting.
- Print `kubeconform -v` as a smoke test that the binary actually runs.
- Version pinned via `KUBECONFORM_VERSION` env for easier future bumps.

Commit: a15bc95

---

## Scope

CI-only. No runtime / build semantics change. Total diff: 2 deletions + 15 net additions across 2 files.

## Why one PR

Both fixes are urgent (master is broken, PRs are broken) and the combined diff is tiny. Happy to split if you prefer — let me know.