### PR TITLE
feat(storage): [44.a] migration 023 — platform-admin impersonation schema

### DIFF
--- a/openspec/changes/refactor-platform-admin-impersonation/tasks.md
+++ b/openspec/changes/refactor-platform-admin-impersonation/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Schema migration
 
-- [ ] 1.1 Create `storage/migrations/023_platform_admin_impersonation.sql` adding `users.default_tenant_id UUID NULL REFERENCES tenants(id) ON DELETE SET NULL` with an index `idx_users_default_tenant_id`.
-- [ ] 1.2 In the same migration, add `acting_as_tenant_id UUID NULL REFERENCES tenants(id)` to `referential_audit_log` and `governance_audit_log` with matching indexes `idx_*_audit_log_acting_as_tenant`.
-- [ ] 1.3 Verify migration applies cleanly on a copy of a production-shape database (no backfill required; all existing rows stay `NULL`).
-- [ ] 1.4 Add downgrade notes to `storage/migrations/README.md` (columns are drop-safe).
+- [x] 1.1 Create `storage/migrations/023_platform_admin_impersonation.sql` adding `users.default_tenant_id UUID NULL REFERENCES tenants(id) ON DELETE SET NULL` with an index `idx_users_default_tenant_id`.
+- [x] 1.2 In the same migration, add `acting_as_tenant_id UUID NULL REFERENCES tenants(id)` to `referential_audit_log` and `governance_audit_log` with matching indexes `idx_*_audit_log_acting_as_tenant`.
+- [ ] 1.3 Verify migration applies cleanly on a copy of a production-shape database (no backfill required; all existing rows stay `NULL`). _(deferred to PR CI bootstrap run — no local Postgres available)_
+- [x] 1.4 Add downgrade notes to `storage/migrations/README.md` (columns are drop-safe).
 
 ## 2. Core `RequestContext` resolver
 

--- a/storage/migrations/023_platform_admin_impersonation.sql
+++ b/storage/migrations/023_platform_admin_impersonation.sql
@@ -1,0 +1,83 @@
+-- Migration 023: Platform-admin impersonation foundation
+--
+-- Background:
+--   Implements the schema side of OpenSpec change
+--   `refactor-platform-admin-impersonation` (issue #44).
+--
+-- Two independent schema additions:
+--
+--   1. users.default_tenant_id
+--      A portable server-side "default tenant" preference consumed by the
+--      new tenant resolution chain (see RequestContext in cli/src/server/).
+--      NULL means "no preference set" (the historic default and the only
+--      valid state at migration time -- no backfill required).
+--      ON DELETE SET NULL so deleting a tenant silently clears the
+--      preference for affected users rather than cascading.
+--
+--   2. {referential,governance}_audit_log.acting_as_tenant_id
+--      Records the tenant the actor was impersonating at the time of the
+--      logged action. For non-impersonated actions this equals the actor's
+--      own tenant membership (or NULL for PlatformAdmin acting on the
+--      platform). Required to distinguish "PlatformAdmin operated inside
+--      tenant X" from "user inside tenant X did the thing".
+--      References tenants(id) with ON DELETE SET NULL so audit rows
+--      survive tenant deletion (history must be preserved even if the
+--      target tenant is gone).
+--
+-- All statements are idempotent (IF NOT EXISTS) so running this migration
+-- against a cluster that already has the columns is a no-op.
+--
+-- Downgrade: both columns are safely droppable (NULL default, no
+-- dependent code until migration 024+ lands). See
+-- storage/migrations/README.md for the revert procedure.
+
+-- ============================================================================
+-- users.default_tenant_id
+-- ============================================================================
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS default_tenant_id UUID
+    REFERENCES tenants(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN users.default_tenant_id IS
+    'Portable per-user default tenant preference. Consumed by the tenant '
+    'resolution chain when X-Tenant-ID is absent. NULL = no preference. '
+    'Cleared automatically if the referenced tenant is deleted '
+    '(ON DELETE SET NULL).';
+
+CREATE INDEX IF NOT EXISTS idx_users_default_tenant_id
+    ON users(default_tenant_id)
+    WHERE default_tenant_id IS NOT NULL AND deleted_at IS NULL;
+
+-- ============================================================================
+-- referential_audit_log.acting_as_tenant_id
+-- ============================================================================
+ALTER TABLE referential_audit_log
+    ADD COLUMN IF NOT EXISTS acting_as_tenant_id UUID
+    REFERENCES tenants(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN referential_audit_log.acting_as_tenant_id IS
+    'The tenant scope the actor was operating in when this event was '
+    'recorded. NULL means platform-scoped (PlatformAdmin without a target '
+    'tenant) or historic rows predating migration 023. When this differs '
+    'from the actor''s own tenant membership, the event represents '
+    'PlatformAdmin impersonation.';
+
+CREATE INDEX IF NOT EXISTS idx_referential_audit_log_acting_as_tenant
+    ON referential_audit_log(acting_as_tenant_id)
+    WHERE acting_as_tenant_id IS NOT NULL;
+
+-- ============================================================================
+-- governance_audit_log.acting_as_tenant_id
+-- ============================================================================
+ALTER TABLE governance_audit_log
+    ADD COLUMN IF NOT EXISTS acting_as_tenant_id UUID
+    REFERENCES tenants(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN governance_audit_log.acting_as_tenant_id IS
+    'The tenant scope the actor was operating in when this governance '
+    'event was recorded. See referential_audit_log.acting_as_tenant_id '
+    'for the full semantics.';
+
+CREATE INDEX IF NOT EXISTS idx_governance_audit_log_acting_as_tenant
+    ON governance_audit_log(acting_as_tenant_id)
+    WHERE acting_as_tenant_id IS NOT NULL;

--- a/storage/migrations/README.md
+++ b/storage/migrations/README.md
@@ -1,0 +1,55 @@
+# Schema Migrations
+
+SQL files in this directory are applied in numeric order by the Aeterna migration runner (`cli/src/server/bootstrap.rs` for local/dev, and the Helm post-install job for cluster installs).
+
+## Conventions
+
+- **Filename**: `NNN_short_description.sql` where `NNN` is a zero-padded three-digit sequence number. Next free slot is the maximum existing number + 1.
+- **Idempotency**: every statement must be safe to re-run. Use `IF NOT EXISTS` on `CREATE`, `ADD COLUMN IF NOT EXISTS` on `ALTER TABLE`, guarded `DO $$ ... $$` blocks for conditional changes, etc.
+- **No transactions**: do not wrap the file in `BEGIN; ... COMMIT;`. The runner already applies each file inside a transaction and records the checksum in `_aeterna_migrations`.
+- **Header comment**: top of the file must describe what the migration does and why. Future readers depend on this -- the commit message is harder to find.
+- **No data backfill in the SQL**: if a migration needs to rewrite existing rows, keep the column addition here and put the backfill in a separate one-shot script under `storage/backfills/`. This keeps migrations fast and deterministic.
+
+## Downgrade / revert
+
+Aeterna does **not** auto-generate down-migrations. If a migration needs to be reverted:
+
+1. Write a new forward migration (`NNN+1`) that undoes the change.
+2. Never edit an applied migration file -- the checksum in `_aeterna_migrations` will mismatch and bootstrap will refuse to start.
+
+### Per-migration downgrade notes
+
+- **023_platform_admin_impersonation.sql** -- safe to drop. All three added columns default to `NULL` and are not read by any code until migration 024+. To revert:
+  ```sql
+  ALTER TABLE users                  DROP COLUMN IF EXISTS default_tenant_id;
+  ALTER TABLE referential_audit_log  DROP COLUMN IF EXISTS acting_as_tenant_id;
+  ALTER TABLE governance_audit_log   DROP COLUMN IF EXISTS acting_as_tenant_id;
+  DROP INDEX IF EXISTS idx_users_default_tenant_id;
+  DROP INDEX IF EXISTS idx_referential_audit_log_acting_as_tenant;
+  DROP INDEX IF EXISTS idx_governance_audit_log_acting_as_tenant;
+  ```
+- **022_drop_dead_vector_columns.sql** -- columns were already unused. Reverting is not useful; re-run on clusters with leftover `VECTOR` columns is a no-op via `IF EXISTS`.
+
+## Checksum mismatches
+
+If bootstrap reports `checksum mismatch on migration NNN`, it means the applied SQL on disk differs from what was recorded when the migration first ran. Fix options, in order of preference:
+
+1. **Revert the local edit** to the migration file so it matches the historic bytes, and add a new migration for the new change.
+2. In dev databases: wipe the DB (`docker compose down -v`) and re-bootstrap from scratch.
+3. In prod: manually update `_aeterna_migrations.checksum` after carefully reviewing the diff. Only do this when you understand exactly what changed and why.
+
+## Testing
+
+Before shipping a migration:
+
+```bash
+# Apply against a clean DB
+docker compose up -d postgres
+cargo run --bin aeterna -- server bootstrap --skip-serve
+
+# Apply against a DB that already has it (idempotency check)
+cargo run --bin aeterna -- server bootstrap --skip-serve
+
+# Verify schema
+docker compose exec postgres psql -U aeterna -d aeterna -c '\\d+ <table>'
+```


### PR DESCRIPTION
Slice **1 of 5** for OpenSpec change `refactor-platform-admin-impersonation` (issue #44). Implements section 1 of tasks.md — pure additive schema, no code consumers yet.

## Scope

| Table | Column | FK | Index |
|---|---|---|---|
| `users` | `default_tenant_id UUID NULL` | `tenants(id) ON DELETE SET NULL` | `idx_users_default_tenant_id` (partial, NOT NULL AND NOT deleted) |
| `referential_audit_log` | `acting_as_tenant_id UUID NULL` | `tenants(id) ON DELETE SET NULL` | `idx_referential_audit_log_acting_as_tenant` (partial, NOT NULL) |
| `governance_audit_log` | `acting_as_tenant_id UUID NULL` | `tenants(id) ON DELETE SET NULL` | `idx_governance_audit_log_acting_as_tenant` (partial, NOT NULL) |

All `ADD COLUMN IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` — fully idempotent. No backfill required: every existing row correctly has `NULL` for all three columns.

## New doc: `storage/migrations/README.md`

First pass at documenting migration conventions (filename, idempotency, no-transaction rule, backfill separation), downgrade procedure (forward-only; no edits to applied files), and checksum-mismatch remediation. Per-migration revert notes included for 023 and 022.

## Why additive-only in this PR

The resolver, endpoints, and audit-log wiring all depend on these columns but ship in subsequent slices:

- **44.b** — `RequestContext` + `/api/v1/user/me/default-tenant` endpoints (consumes `users.default_tenant_id`).
- **44.c** — Retire legacy `authenticated_tenant_context` / `tenant_scoped_context` / `require_platform_admin` across ~81 call sites.
- **44.d** — Cross-tenant listing (`?tenant=*`) + audit-log impersonation wiring (consumes `acting_as_tenant_id`).
- **44.e** — Docs, OpenAPI, release notes.

Splitting this way keeps each PR reviewable and lets 44.a land ASAP so database changes are live before the code changes hit production.

## Verification

- `openspec validate refactor-platform-admin-impersonation --strict` → PASS.
- Tasks 1.1, 1.2, 1.4 ✅ in `tasks.md`.
- Task 1.3 (apply on prod-shape DB) deferred to PR CI bootstrap run — no local Postgres was available during authoring. CI run on this PR exercises migration 023 end-to-end against a fresh Postgres.

## Risk

Near-zero. Additive columns, all NULL, no existing code paths read them.