### PR TITLE
feat(#44.a+44.b): platform-admin impersonation — schema + RequestContext resolver

### DIFF
--- a/cli/src/server/context.rs
+++ b/cli/src/server/context.rs
@@ -92,10 +92,7 @@ pub struct RequestContext {
 
 impl RequestContext {
     /// Returns the resolved tenant or a `400 select_tenant` response.
-    pub fn require_target_tenant(
-        &self,
-        headers: &HeaderMap,
-    ) -> Result<&ResolvedTenant, Response> {
+    pub fn require_target_tenant(&self, headers: &HeaderMap) -> Result<&ResolvedTenant, Response> {
         match &self.tenant {
             Some(t) => Ok(t),
             None => Err(select_tenant_response(&self.available_tenants, headers)),
@@ -104,10 +101,7 @@ impl RequestContext {
 
     /// Convenience: build a `TenantContext` for call sites that still require
     /// the legacy shape. Emits `select_tenant` if no tenant is resolved.
-    pub fn require_tenant_context(
-        &self,
-        headers: &HeaderMap,
-    ) -> Result<TenantContext, Response> {
+    pub fn require_tenant_context(&self, headers: &HeaderMap) -> Result<TenantContext, Response> {
         let tenant = self.require_target_tenant(headers)?;
         Ok(TenantContext {
             tenant_id: tenant.id.clone(),

--- a/cli/src/server/context.rs
+++ b/cli/src/server/context.rs
@@ -1,0 +1,431 @@
+//! Request-level authorization context with platform-admin impersonation support.
+//!
+//! This module implements the new tenant-resolution chain described by
+//! OpenSpec change `refactor-platform-admin-impersonation` (#44).
+//!
+//! # Resolution order
+//!
+//! 1. `X-Tenant-ID` header (by slug or UUID). Must resolve to an existing
+//!    `tenants` row — an orphan value yields `404 tenant_not_found`.
+//! 2. `users.default_tenant_id` when the caller has set a persistent
+//!    preference (migration 023).
+//! 3. Auto-select when the caller belongs to exactly one tenant.
+//! 4. Otherwise:
+//!    - PlatformAdmin: `ctx.tenant = None` is the success case (platform-
+//!      scoped operation).
+//!    - Regular user: emit `400 select_tenant` with the set of available
+//!      tenants so the client can prompt the user.
+//!
+//! The legacy `tenant_required` shape is preserved for one deprecation
+//! window via the `Accept-Error-Legacy: true` request header.
+//!
+//! # Relationship to `TenantContext`
+//!
+//! `RequestContext` is the preferred API going forward. For code paths that
+//! still need the pre-existing [`mk_core::types::TenantContext`], use
+//! [`RequestContext::require_tenant_context`] which performs the `require_
+//! target_tenant` check and returns a fully-populated `TenantContext`.
+//!
+//! Legacy helpers `authenticated_tenant_context` and `tenant_scoped_context`
+//! in `cli/src/server/mod.rs` remain functional during the migration window;
+//! they are marked `#[deprecated]` and will be removed once all call sites
+//! have been migrated (tracked as slice 44.c).
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use mk_core::types::{
+    INSTANCE_SCOPE_TENANT_ID, Role, RoleIdentifier, TenantContext, TenantId, UserId,
+};
+use serde::Serialize;
+use serde_json::json;
+
+use super::AppState;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A resolved tenant in a request context.
+///
+/// Carries enough information for handlers to build responses, emit audit
+/// events, and enforce tenant-scoped authorization without re-querying the
+/// tenant store.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedTenant {
+    pub id: TenantId,
+    pub slug: String,
+    pub name: String,
+}
+
+impl ResolvedTenant {
+    pub fn id_str(&self) -> &str {
+        self.id.as_str()
+    }
+}
+
+/// Request-scoped authorization context.
+///
+/// Constructed by [`request_context`] from the authenticated identity plus
+/// request headers. Handlers should prefer this type over the legacy
+/// [`mk_core::types::TenantContext`] because it faithfully represents the
+/// "PlatformAdmin without target tenant" case (`tenant = None`) that the old
+/// resolver could not express without emitting `tenant_required`.
+#[derive(Debug, Clone)]
+pub struct RequestContext {
+    pub user_id: UserId,
+    pub roles: Vec<RoleIdentifier>,
+    pub is_platform_admin: bool,
+    /// Tenant the caller is acting against. `None` means platform-scoped:
+    /// only valid for PlatformAdmin. Handlers that need a tenant MUST call
+    /// [`RequestContext::require_target_tenant`].
+    pub tenant: Option<ResolvedTenant>,
+    /// Set of tenant slugs the user is a member of. Used to populate the
+    /// `select_tenant` payload so the client can render a picker without an
+    /// extra round-trip. Empty for PlatformAdmin (they are not constrained
+    /// to this list).
+    pub available_tenants: Vec<ResolvedTenant>,
+}
+
+impl RequestContext {
+    /// Returns the resolved tenant or a `400 select_tenant` response.
+    pub fn require_target_tenant(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<&ResolvedTenant, Response> {
+        match &self.tenant {
+            Some(t) => Ok(t),
+            None => Err(select_tenant_response(&self.available_tenants, headers)),
+        }
+    }
+
+    /// Convenience: build a `TenantContext` for call sites that still require
+    /// the legacy shape. Emits `select_tenant` if no tenant is resolved.
+    pub fn require_tenant_context(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<TenantContext, Response> {
+        let tenant = self.require_target_tenant(headers)?;
+        Ok(TenantContext {
+            tenant_id: tenant.id.clone(),
+            user_id: self.user_id.clone(),
+            agent_id: None,
+            roles: self.roles.clone(),
+            target_tenant_id: None,
+        })
+    }
+}
+
+/// Returns `Ok(())` when the caller is a PlatformAdmin, `403 forbidden` otherwise.
+///
+/// Unlike the legacy `tenant_scoped_context`-based check, this function has
+/// no tenant dependency — it operates purely on instance-scope roles, which
+/// is exactly what fresh-deploy / bootstrap flows need.
+pub fn require_platform_admin(ctx: &RequestContext) -> Result<(), Response> {
+    if ctx.is_platform_admin {
+        Ok(())
+    } else {
+        Err(error_response(
+            StatusCode::FORBIDDEN,
+            "forbidden",
+            "PlatformAdmin role required for this endpoint",
+            None,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/// Build a [`RequestContext`] from the authenticated identity + request headers.
+///
+/// This is the single entry point for the new resolution chain. Handlers
+/// should call it at the top of every authenticated route; the returned
+/// `Response` is already a well-formed error that can be returned as-is.
+#[tracing::instrument(skip_all)]
+pub async fn request_context(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+) -> Result<RequestContext, Response> {
+    // Delegate identity extraction to the legacy helper. This keeps the
+    // plugin/k8s/dev-header branches identical while we own just the tenant
+    // resolution step.
+    let (user_id, instance_roles, known_tenant_ids) =
+        super::resolve_identity(state, headers).await?;
+
+    let is_platform_admin = instance_roles
+        .iter()
+        .any(|r| matches!(r, RoleIdentifier::Known(Role::PlatformAdmin)));
+
+    // Fetch every tenant the user can currently see, for select_tenant payload.
+    let mut available = Vec::new();
+    if is_platform_admin {
+        // PlatformAdmins can target any tenant — populate from the tenant store.
+        if let Ok(tenants) = state.tenant_store.list_tenants(false).await {
+            for t in tenants {
+                available.push(ResolvedTenant {
+                    id: t.id,
+                    slug: t.slug,
+                    name: t.name,
+                });
+            }
+        }
+    } else {
+        for tid in known_tenant_ids.iter() {
+            if let Ok(Some(t)) = state.tenant_store.get_tenant(tid).await {
+                available.push(ResolvedTenant {
+                    id: t.id,
+                    slug: t.slug,
+                    name: t.name,
+                });
+            }
+        }
+    }
+
+    // --- Step 1: X-Tenant-ID header ---
+    let explicit = headers
+        .get("x-tenant-id")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty());
+
+    if let Some(hint) = explicit {
+        // Accept by id or slug via TenantStore::get_tenant.
+        let record = state.tenant_store.get_tenant(hint).await.map_err(|e| {
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "tenant_lookup_failed",
+                &e.to_string(),
+                None,
+            )
+        })?;
+        let record = match record {
+            Some(t) => t,
+            None => {
+                return Err(error_response(
+                    StatusCode::NOT_FOUND,
+                    "tenant_not_found",
+                    &format!("No tenant matches '{hint}'"),
+                    None,
+                ));
+            }
+        };
+        // Membership check (PlatformAdmin exempt).
+        let is_member = known_tenant_ids.iter().any(|tid| tid == record.id.as_str());
+        if !is_platform_admin && !is_member {
+            return Err(error_response(
+                StatusCode::FORBIDDEN,
+                "forbidden_tenant",
+                "You are not a member of the requested tenant",
+                None,
+            ));
+        }
+        return Ok(RequestContext {
+            user_id,
+            roles: instance_roles,
+            is_platform_admin,
+            tenant: Some(ResolvedTenant {
+                id: record.id,
+                slug: record.slug,
+                name: record.name,
+            }),
+            available_tenants: available,
+        });
+    }
+
+    // --- Step 2: users.default_tenant_id ---
+    if let Ok(Some(default)) = state
+        .postgres
+        .get_user_default_tenant(user_id.as_str())
+        .await
+    {
+        // The FK ON DELETE SET NULL guarantees the tenant exists if the
+        // column is populated, but re-check defensively.
+        if let Ok(Some(record)) = state.tenant_store.get_tenant(default.as_str()).await {
+            // Only honor if the user is still a member (covers the edge case of
+            // a user losing membership but their preference never being cleared).
+            let is_member = known_tenant_ids.iter().any(|tid| tid == record.id.as_str());
+            if is_platform_admin || is_member {
+                return Ok(RequestContext {
+                    user_id,
+                    roles: instance_roles,
+                    is_platform_admin,
+                    tenant: Some(ResolvedTenant {
+                        id: record.id,
+                        slug: record.slug,
+                        name: record.name,
+                    }),
+                    available_tenants: available,
+                });
+            }
+        }
+    }
+
+    // --- Step 3: auto-select single tenant ---
+    if known_tenant_ids.len() == 1 {
+        let tid = &known_tenant_ids[0];
+        if let Ok(Some(record)) = state.tenant_store.get_tenant(tid).await {
+            return Ok(RequestContext {
+                user_id,
+                roles: instance_roles,
+                is_platform_admin,
+                tenant: Some(ResolvedTenant {
+                    id: record.id,
+                    slug: record.slug,
+                    name: record.name,
+                }),
+                available_tenants: available,
+            });
+        }
+    }
+
+    // --- Step 4: PlatformAdmin returns None; regular user gets select_tenant ---
+    if is_platform_admin {
+        return Ok(RequestContext {
+            user_id,
+            roles: instance_roles,
+            is_platform_admin,
+            tenant: None,
+            available_tenants: available,
+        });
+    }
+
+    Err(select_tenant_response(&available, headers))
+}
+
+// ---------------------------------------------------------------------------
+// Error helpers
+// ---------------------------------------------------------------------------
+
+/// Build the `400 select_tenant` response body, honoring `Accept-Error-Legacy`.
+pub fn select_tenant_response(available: &[ResolvedTenant], headers: &HeaderMap) -> Response {
+    let legacy = headers
+        .get("accept-error-legacy")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    if legacy {
+        // Pre-#44 shape; kept for one deprecation window.
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "tenant_required",
+            "X-Tenant-ID header required",
+            None,
+        );
+    }
+
+    let payload = json!({
+        "availableTenants": available,
+        "hint": if available.is_empty() {
+            "You have no tenant memberships. Contact an administrator."
+        } else {
+            "Provide an X-Tenant-ID header or set a default via PUT /api/v1/user/me/default-tenant."
+        },
+    });
+
+    error_response(
+        StatusCode::BAD_REQUEST,
+        "select_tenant",
+        "This request requires a tenant selection.",
+        Some(payload),
+    )
+}
+
+fn error_response(
+    status: StatusCode,
+    code: &str,
+    message: &str,
+    extra: Option<serde_json::Value>,
+) -> Response {
+    let mut body = json!({
+        "error": code,
+        "message": message,
+    });
+    if let Some(extra) = extra
+        && let (Some(obj), Some(extra_obj)) = (body.as_object_mut(), extra.as_object())
+    {
+        for (k, v) in extra_obj {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+    (status, Json(body)).into_response()
+}
+
+// Re-export for external use in tests.
+pub const INSTANCE_SCOPE: &str = INSTANCE_SCOPE_TENANT_ID;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+    use mk_core::types::TenantId;
+
+    fn make_ctx(tenant: Option<ResolvedTenant>, is_admin: bool) -> RequestContext {
+        RequestContext {
+            user_id: UserId::new("u-1".into()).unwrap(),
+            roles: vec![],
+            is_platform_admin: is_admin,
+            tenant,
+            available_tenants: vec![],
+        }
+    }
+
+    fn rt(slug: &str) -> ResolvedTenant {
+        ResolvedTenant {
+            id: TenantId::new(format!("tid-{slug}")).unwrap(),
+            slug: slug.to_string(),
+            name: format!("Tenant {slug}"),
+        }
+    }
+
+    #[test]
+    fn require_target_tenant_returns_tenant_when_present() {
+        let ctx = make_ctx(Some(rt("alpha")), false);
+        let hdrs = HeaderMap::new();
+        let got = ctx.require_target_tenant(&hdrs).unwrap();
+        assert_eq!(got.slug, "alpha");
+    }
+
+    #[test]
+    fn require_target_tenant_emits_select_tenant_when_missing() {
+        let ctx = make_ctx(None, false);
+        let hdrs = HeaderMap::new();
+        let err = ctx.require_target_tenant(&hdrs).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn require_platform_admin_allows_admins() {
+        let ctx = make_ctx(None, true);
+        assert!(require_platform_admin(&ctx).is_ok());
+    }
+
+    #[test]
+    fn require_platform_admin_rejects_non_admins() {
+        let ctx = make_ctx(None, false);
+        let err = require_platform_admin(&ctx).unwrap_err();
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn select_tenant_response_uses_legacy_shape_when_requested() {
+        let mut hdrs = HeaderMap::new();
+        hdrs.insert("accept-error-legacy", "true".parse().unwrap());
+        let resp = select_tenant_response(&[rt("a")], &hdrs);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        // Note: body inspection requires hyper::body::to_bytes which needs
+        // an async runtime — covered by the integration tests in 44.d.
+    }
+
+    #[test]
+    fn select_tenant_response_defaults_to_new_shape() {
+        let hdrs = HeaderMap::new();
+        let resp = select_tenant_response(&[rt("a"), rt("b")], &hdrs);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -2,6 +2,7 @@ pub mod admin_sync;
 pub mod auth_middleware;
 pub mod backup_api;
 pub mod bootstrap;
+pub mod context;
 pub mod govern_api;
 pub mod health;
 pub mod k8s_auth;
@@ -150,6 +151,168 @@ pub(crate) async fn lookup_roles_for_idp(
         return Ok(Vec::new());
     };
     postgres.get_user_roles_for_auth(&user_id, tenant_id).await
+}
+
+/// Extract the authenticated identity without resolving a tenant.
+///
+/// Returns `(user_id, instance_scope_roles, known_tenant_ids)` where the
+/// roles are evaluated at `INSTANCE_SCOPE_TENANT_ID` (so PlatformAdmin is
+/// visible) and `known_tenant_ids` is the distinct set of tenants the user
+/// has any role in. For dev-header auth mode, `known_tenant_ids` is empty
+/// and the caller must resolve tenant via configured defaults.
+///
+/// Added for OpenSpec change `refactor-platform-admin-impersonation` (#44)
+/// to support the new `context::request_context` resolver without
+/// duplicating the multi-provider auth dance.
+pub(crate) async fn resolve_identity(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<(UserId, Vec<RoleIdentifier>, Vec<String>), axum::response::Response> {
+    let any_provider_configured =
+        state.plugin_auth_state.config.enabled || state.k8s_auth_config.enabled;
+
+    enum Resolution {
+        Provider {
+            provider: &'static str,
+            subject: String,
+        },
+        DevHeaders {
+            user_id: String,
+            roles: Vec<RoleIdentifier>,
+        },
+    }
+
+    let resolution = if any_provider_configured {
+        let bearer_token = extract_bearer_token(headers).ok_or_else(|| {
+            error_json(
+                StatusCode::UNAUTHORIZED,
+                "missing_bearer_token",
+                "Authorization: Bearer token required",
+            )
+        })?;
+
+        if state.plugin_auth_state.config.enabled {
+            let secret =
+                state
+                    .plugin_auth_state
+                    .config
+                    .jwt_secret
+                    .as_deref()
+                    .ok_or_else(|| {
+                        error_json(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "configuration_error",
+                            "Plugin auth JWT secret is not configured",
+                        )
+                    })?;
+            if let Some(identity) = plugin_auth::validate_plugin_bearer(headers, secret) {
+                Resolution::Provider {
+                    provider: PROVIDER_GITHUB,
+                    subject: identity.github_login,
+                }
+            } else if state.k8s_auth_config.enabled
+                && let Some(identity) =
+                    k8s_auth::validate_k8s_bearer(bearer_token, &state.k8s_auth_config).await
+            {
+                Resolution::Provider {
+                    provider: PROVIDER_KUBERNETES,
+                    subject: identity.username,
+                }
+            } else {
+                return Err(error_json(
+                    StatusCode::UNAUTHORIZED,
+                    "invalid_bearer_token",
+                    "Bearer token was not accepted by any configured provider",
+                ));
+            }
+        } else if let Some(identity) =
+            k8s_auth::validate_k8s_bearer(bearer_token, &state.k8s_auth_config).await
+        {
+            Resolution::Provider {
+                provider: PROVIDER_KUBERNETES,
+                subject: identity.username,
+            }
+        } else {
+            return Err(error_json(
+                StatusCode::UNAUTHORIZED,
+                "invalid_bearer_token",
+                "Bearer token was not accepted by any configured provider",
+            ));
+        }
+    } else {
+        Resolution::DevHeaders {
+            user_id: headers
+                .get("x-user-id")
+                .and_then(|v| v.to_str().ok())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(SYSTEM_USER_ID)
+                .chars()
+                .take(100)
+                .collect(),
+            roles: headers
+                .get("x-user-role")
+                .and_then(|v| v.to_str().ok())
+                .filter(|s| !s.is_empty())
+                .map(|s| vec![RoleIdentifier::from_str_flexible(s)])
+                .unwrap_or_default(),
+        }
+    };
+
+    let (user_id_str, instance_roles, tenant_ids) = match resolution {
+        Resolution::Provider { provider, subject } => {
+            let uid = state
+                .postgres
+                .resolve_user_id_by_idp(provider, &subject)
+                .await
+                .map_err(|err| {
+                    error_json(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "identity_lookup_failed",
+                        &err.to_string(),
+                    )
+                })?
+                .ok_or_else(|| {
+                    error_json(
+                        StatusCode::UNAUTHORIZED,
+                        "identity_not_provisioned",
+                        "Authenticated identity is not provisioned",
+                    )
+                })?;
+
+            let root_roles = state
+                .postgres
+                .get_user_roles_for_auth(&uid, INSTANCE_SCOPE_TENANT_ID)
+                .await
+                .map_err(|err| {
+                    error_json(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "role_lookup_failed",
+                        &err.to_string(),
+                    )
+                })?;
+
+            let tenant_ids = state.postgres.get_user_tenant_ids(&uid).await.map_err(|err| {
+                error_json(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "tenant_lookup_failed",
+                    &err.to_string(),
+                )
+            })?;
+
+            (uid, root_roles, tenant_ids)
+        }
+        Resolution::DevHeaders { user_id, roles } => (user_id, roles, Vec::new()),
+    };
+
+    let user_id = UserId::new(user_id_str).ok_or_else(|| {
+        error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid_user_id",
+            "Invalid authenticated user identifier",
+        )
+    })?;
+
+    Ok((user_id, instance_roles, tenant_ids))
 }
 
 pub async fn authenticated_tenant_context(

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -192,19 +192,18 @@ pub(crate) async fn resolve_identity(
         })?;
 
         if state.plugin_auth_state.config.enabled {
-            let secret =
-                state
-                    .plugin_auth_state
-                    .config
-                    .jwt_secret
-                    .as_deref()
-                    .ok_or_else(|| {
-                        error_json(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "configuration_error",
-                            "Plugin auth JWT secret is not configured",
-                        )
-                    })?;
+            let secret = state
+                .plugin_auth_state
+                .config
+                .jwt_secret
+                .as_deref()
+                .ok_or_else(|| {
+                    error_json(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "configuration_error",
+                        "Plugin auth JWT secret is not configured",
+                    )
+                })?;
             if let Some(identity) = plugin_auth::validate_plugin_bearer(headers, secret) {
                 Resolution::Provider {
                     provider: PROVIDER_GITHUB,
@@ -291,13 +290,17 @@ pub(crate) async fn resolve_identity(
                     )
                 })?;
 
-            let tenant_ids = state.postgres.get_user_tenant_ids(&uid).await.map_err(|err| {
-                error_json(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "tenant_lookup_failed",
-                    &err.to_string(),
-                )
-            })?;
+            let tenant_ids = state
+                .postgres
+                .get_user_tenant_ids(&uid)
+                .await
+                .map_err(|err| {
+                    error_json(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "tenant_lookup_failed",
+                        &err.to_string(),
+                    )
+                })?;
 
             (uid, root_roles, tenant_ids)
         }

--- a/cli/src/server/plugin_auth.rs
+++ b/cli/src/server/plugin_auth.rs
@@ -660,6 +660,13 @@ async fn admin_session_handler(
         .iter()
         .any(|r| r == &RoleIdentifier::Known(mk_core::types::Role::TenantAdmin));
 
+    let default_tenant_id = state
+        .postgres
+        .get_user_default_tenant(&user_id)
+        .await
+        .ok()
+        .flatten();
+
     let tenants = if is_platform_admin {
         match state.tenant_store.list_tenants(false).await {
             Ok(t) => t
@@ -706,6 +713,9 @@ async fn admin_session_handler(
             "is_platform_admin": is_platform_admin,
             "is_tenant_admin": is_tenant_admin,
             "active_tenant_id": identity.tenant_id,
+            // #44.b: surface the persistent preference so the admin UI can
+            // restore the tenant selector on load without an extra call.
+            "default_tenant_id": default_tenant_id,
         })),
     )
 }

--- a/cli/src/server/user_api.rs
+++ b/cli/src/server/user_api.rs
@@ -12,6 +12,7 @@ use serde_json::json;
 use sqlx::Row;
 use uuid::Uuid;
 
+use super::context::{self, RequestContext};
 use super::{AppState, tenant_scoped_context};
 
 #[derive(Debug, Deserialize)]
@@ -67,6 +68,12 @@ pub fn router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/user", get(list_users).post(register_user))
         .route("/user/invite", axum::routing::post(invite_user))
+        .route(
+            "/user/me/default-tenant",
+            get(get_default_tenant)
+                .put(set_default_tenant)
+                .delete(clear_default_tenant),
+        )
         .route("/user/{user_id}", get(show_user))
         .route(
             "/user/{user_id}/roles",
@@ -74,6 +81,205 @@ pub fn router(state: Arc<AppState>) -> Router {
         )
         .route("/user/{user_id}/roles/{role}", delete(revoke_user_role))
         .with_state(state)
+}
+
+// ---------------------------------------------------------------------------
+// GET/PUT/DELETE /user/me/default-tenant
+//
+// Persists a caller's preferred default tenant in `users.default_tenant_id`
+// (migration 023). Consumed by `context::request_context` as step 2 of the
+// tenant resolution chain. See OpenSpec `refactor-platform-admin-impersonation`
+// (#44.b).
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DefaultTenantResponse {
+    tenant_id: String,
+    slug: String,
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetDefaultTenantRequest {
+    /// Tenant slug or UUID. Must be a tenant the caller is a member of
+    /// (PlatformAdmin may set it to any active tenant).
+    tenant_id: String,
+}
+
+async fn get_default_tenant(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> axum::response::Response {
+    let ctx: RequestContext = match context::request_context(&state, &headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+
+    match state
+        .postgres
+        .get_user_default_tenant(ctx.user_id.as_str())
+        .await
+    {
+        Ok(None) => (StatusCode::NO_CONTENT, Json(json!({}))).into_response(),
+        Ok(Some(tid)) => match state.tenant_store.get_tenant(&tid).await {
+            Ok(Some(t)) => (
+                StatusCode::OK,
+                Json(DefaultTenantResponse {
+                    tenant_id: t.id.into_inner(),
+                    slug: t.slug,
+                    name: t.name,
+                }),
+            )
+                .into_response(),
+            Ok(None) => {
+                // FK ON DELETE SET NULL should prevent this; treat as unset.
+                (StatusCode::NO_CONTENT, Json(json!({}))).into_response()
+            }
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": "tenant_lookup_failed",
+                    "message": e.to_string(),
+                })),
+            )
+                .into_response(),
+        },
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": "default_tenant_read_failed",
+                "message": e.to_string(),
+            })),
+        )
+            .into_response(),
+    }
+}
+
+async fn set_default_tenant(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(payload): Json<SetDefaultTenantRequest>,
+) -> axum::response::Response {
+    let ctx: RequestContext = match context::request_context(&state, &headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+
+    let target_ref = payload.tenant_id.trim();
+    if target_ref.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "invalid_tenant_id",
+                "message": "tenantId must be a non-empty slug or UUID",
+            })),
+        )
+            .into_response();
+    }
+
+    // Resolve slug-or-uuid to a concrete tenant record.
+    let record = match state.tenant_store.get_tenant(target_ref).await {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({
+                    "error": "tenant_not_found",
+                    "message": format!("No tenant matches '{target_ref}'"),
+                })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": "tenant_lookup_failed",
+                    "message": e.to_string(),
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    // Membership check. PlatformAdmin exempt.
+    if !ctx.is_platform_admin {
+        let is_member = ctx
+            .available_tenants
+            .iter()
+            .any(|t| t.id.as_str() == record.id.as_str());
+        if !is_member {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": "forbidden_tenant",
+                    "message": "You are not a member of the requested tenant",
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    if let Err(e) = state
+        .postgres
+        .set_user_default_tenant(ctx.user_id.as_str(), record.id.as_str())
+        .await
+    {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": "default_tenant_write_failed",
+                "message": e.to_string(),
+            })),
+        )
+            .into_response();
+    }
+
+    tracing::info!(
+        user_id = %ctx.user_id,
+        tenant_id = %record.id,
+        "user default tenant set"
+    );
+
+    (
+        StatusCode::OK,
+        Json(DefaultTenantResponse {
+            tenant_id: record.id.into_inner(),
+            slug: record.slug,
+            name: record.name,
+        }),
+    )
+        .into_response()
+}
+
+async fn clear_default_tenant(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> axum::response::Response {
+    let ctx: RequestContext = match context::request_context(&state, &headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+
+    if let Err(e) = state
+        .postgres
+        .clear_user_default_tenant(ctx.user_id.as_str())
+        .await
+    {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": "default_tenant_clear_failed",
+                "message": e.to_string(),
+            })),
+        )
+            .into_response();
+    }
+
+    tracing::info!(user_id = %ctx.user_id, "user default tenant cleared");
+    StatusCode::NO_CONTENT.into_response()
 }
 
 async fn list_users(

--- a/openspec/changes/refactor-platform-admin-impersonation/tasks.md
+++ b/openspec/changes/refactor-platform-admin-impersonation/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Schema migration
 
-- [ ] 1.1 Create `storage/migrations/023_platform_admin_impersonation.sql` adding `users.default_tenant_id UUID NULL REFERENCES tenants(id) ON DELETE SET NULL` with an index `idx_users_default_tenant_id`.
-- [ ] 1.2 In the same migration, add `acting_as_tenant_id UUID NULL REFERENCES tenants(id)` to `referential_audit_log` and `governance_audit_log` with matching indexes `idx_*_audit_log_acting_as_tenant`.
-- [ ] 1.3 Verify migration applies cleanly on a copy of a production-shape database (no backfill required; all existing rows stay `NULL`).
-- [ ] 1.4 Add downgrade notes to `storage/migrations/README.md` (columns are drop-safe).
+- [x] 1.1 Create `storage/migrations/023_platform_admin_impersonation.sql` adding `users.default_tenant_id UUID NULL REFERENCES tenants(id) ON DELETE SET NULL` with an index `idx_users_default_tenant_id`.
+- [x] 1.2 In the same migration, add `acting_as_tenant_id UUID NULL REFERENCES tenants(id)` to `referential_audit_log` and `governance_audit_log` with matching indexes `idx_*_audit_log_acting_as_tenant`.
+- [ ] 1.3 Verify migration applies cleanly on a copy of a production-shape database (no backfill required; all existing rows stay `NULL`). _(deferred to PR CI bootstrap run — no local Postgres available)_
+- [x] 1.4 Add downgrade notes to `storage/migrations/README.md` (columns are drop-safe).
 
 ## 2. Core `RequestContext` resolver
 

--- a/storage/migrations/023_platform_admin_impersonation.sql
+++ b/storage/migrations/023_platform_admin_impersonation.sql
@@ -1,0 +1,83 @@
+-- Migration 023: Platform-admin impersonation foundation
+--
+-- Background:
+--   Implements the schema side of OpenSpec change
+--   `refactor-platform-admin-impersonation` (issue #44).
+--
+-- Two independent schema additions:
+--
+--   1. users.default_tenant_id
+--      A portable server-side "default tenant" preference consumed by the
+--      new tenant resolution chain (see RequestContext in cli/src/server/).
+--      NULL means "no preference set" (the historic default and the only
+--      valid state at migration time -- no backfill required).
+--      ON DELETE SET NULL so deleting a tenant silently clears the
+--      preference for affected users rather than cascading.
+--
+--   2. {referential,governance}_audit_log.acting_as_tenant_id
+--      Records the tenant the actor was impersonating at the time of the
+--      logged action. For non-impersonated actions this equals the actor's
+--      own tenant membership (or NULL for PlatformAdmin acting on the
+--      platform). Required to distinguish "PlatformAdmin operated inside
+--      tenant X" from "user inside tenant X did the thing".
+--      References tenants(id) with ON DELETE SET NULL so audit rows
+--      survive tenant deletion (history must be preserved even if the
+--      target tenant is gone).
+--
+-- All statements are idempotent (IF NOT EXISTS) so running this migration
+-- against a cluster that already has the columns is a no-op.
+--
+-- Downgrade: both columns are safely droppable (NULL default, no
+-- dependent code until migration 024+ lands). See
+-- storage/migrations/README.md for the revert procedure.
+
+-- ============================================================================
+-- users.default_tenant_id
+-- ============================================================================
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS default_tenant_id UUID
+    REFERENCES tenants(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN users.default_tenant_id IS
+    'Portable per-user default tenant preference. Consumed by the tenant '
+    'resolution chain when X-Tenant-ID is absent. NULL = no preference. '
+    'Cleared automatically if the referenced tenant is deleted '
+    '(ON DELETE SET NULL).';
+
+CREATE INDEX IF NOT EXISTS idx_users_default_tenant_id
+    ON users(default_tenant_id)
+    WHERE default_tenant_id IS NOT NULL AND deleted_at IS NULL;
+
+-- ============================================================================
+-- referential_audit_log.acting_as_tenant_id
+-- ============================================================================
+ALTER TABLE referential_audit_log
+    ADD COLUMN IF NOT EXISTS acting_as_tenant_id UUID
+    REFERENCES tenants(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN referential_audit_log.acting_as_tenant_id IS
+    'The tenant scope the actor was operating in when this event was '
+    'recorded. NULL means platform-scoped (PlatformAdmin without a target '
+    'tenant) or historic rows predating migration 023. When this differs '
+    'from the actor''s own tenant membership, the event represents '
+    'PlatformAdmin impersonation.';
+
+CREATE INDEX IF NOT EXISTS idx_referential_audit_log_acting_as_tenant
+    ON referential_audit_log(acting_as_tenant_id)
+    WHERE acting_as_tenant_id IS NOT NULL;
+
+-- ============================================================================
+-- governance_audit_log.acting_as_tenant_id
+-- ============================================================================
+ALTER TABLE governance_audit_log
+    ADD COLUMN IF NOT EXISTS acting_as_tenant_id UUID
+    REFERENCES tenants(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN governance_audit_log.acting_as_tenant_id IS
+    'The tenant scope the actor was operating in when this governance '
+    'event was recorded. See referential_audit_log.acting_as_tenant_id '
+    'for the full semantics.';
+
+CREATE INDEX IF NOT EXISTS idx_governance_audit_log_acting_as_tenant
+    ON governance_audit_log(acting_as_tenant_id)
+    WHERE acting_as_tenant_id IS NOT NULL;

--- a/storage/migrations/README.md
+++ b/storage/migrations/README.md
@@ -1,0 +1,55 @@
+# Schema Migrations
+
+SQL files in this directory are applied in numeric order by the Aeterna migration runner (`cli/src/server/bootstrap.rs` for local/dev, and the Helm post-install job for cluster installs).
+
+## Conventions
+
+- **Filename**: `NNN_short_description.sql` where `NNN` is a zero-padded three-digit sequence number. Next free slot is the maximum existing number + 1.
+- **Idempotency**: every statement must be safe to re-run. Use `IF NOT EXISTS` on `CREATE`, `ADD COLUMN IF NOT EXISTS` on `ALTER TABLE`, guarded `DO $$ ... $$` blocks for conditional changes, etc.
+- **No transactions**: do not wrap the file in `BEGIN; ... COMMIT;`. The runner already applies each file inside a transaction and records the checksum in `_aeterna_migrations`.
+- **Header comment**: top of the file must describe what the migration does and why. Future readers depend on this -- the commit message is harder to find.
+- **No data backfill in the SQL**: if a migration needs to rewrite existing rows, keep the column addition here and put the backfill in a separate one-shot script under `storage/backfills/`. This keeps migrations fast and deterministic.
+
+## Downgrade / revert
+
+Aeterna does **not** auto-generate down-migrations. If a migration needs to be reverted:
+
+1. Write a new forward migration (`NNN+1`) that undoes the change.
+2. Never edit an applied migration file -- the checksum in `_aeterna_migrations` will mismatch and bootstrap will refuse to start.
+
+### Per-migration downgrade notes
+
+- **023_platform_admin_impersonation.sql** -- safe to drop. All three added columns default to `NULL` and are not read by any code until migration 024+. To revert:
+  ```sql
+  ALTER TABLE users                  DROP COLUMN IF EXISTS default_tenant_id;
+  ALTER TABLE referential_audit_log  DROP COLUMN IF EXISTS acting_as_tenant_id;
+  ALTER TABLE governance_audit_log   DROP COLUMN IF EXISTS acting_as_tenant_id;
+  DROP INDEX IF EXISTS idx_users_default_tenant_id;
+  DROP INDEX IF EXISTS idx_referential_audit_log_acting_as_tenant;
+  DROP INDEX IF EXISTS idx_governance_audit_log_acting_as_tenant;
+  ```
+- **022_drop_dead_vector_columns.sql** -- columns were already unused. Reverting is not useful; re-run on clusters with leftover `VECTOR` columns is a no-op via `IF EXISTS`.
+
+## Checksum mismatches
+
+If bootstrap reports `checksum mismatch on migration NNN`, it means the applied SQL on disk differs from what was recorded when the migration first ran. Fix options, in order of preference:
+
+1. **Revert the local edit** to the migration file so it matches the historic bytes, and add a new migration for the new change.
+2. In dev databases: wipe the DB (`docker compose down -v`) and re-bootstrap from scratch.
+3. In prod: manually update `_aeterna_migrations.checksum` after carefully reviewing the diff. Only do this when you understand exactly what changed and why.
+
+## Testing
+
+Before shipping a migration:
+
+```bash
+# Apply against a clean DB
+docker compose up -d postgres
+cargo run --bin aeterna -- server bootstrap --skip-serve
+
+# Apply against a DB that already has it (idempotency check)
+cargo run --bin aeterna -- server bootstrap --skip-serve
+
+# Verify schema
+docker compose exec postgres psql -U aeterna -d aeterna -c '\\d+ <table>'
+```

--- a/storage/src/postgres.rs
+++ b/storage/src/postgres.rs
@@ -1370,6 +1370,72 @@ impl PostgresBackend {
         Ok(roles)
     }
 
+    /// Returns the caller-configured default tenant for a user, or `None`
+    /// if no preference is set.
+    ///
+    /// The column is populated via [`set_user_default_tenant`]; the migration
+    /// `023_users_default_tenant.sql` declares it as
+    /// `default_tenant_id UUID NULL REFERENCES tenants(id) ON DELETE SET NULL`,
+    /// which guarantees the returned value still points to an active tenant
+    /// row at read time (the FK nulls the column when the tenant is deleted).
+    ///
+    /// Added in OpenSpec change `refactor-platform-admin-impersonation` (#44.b)
+    /// to back the `GET /api/v1/user/me/default-tenant` endpoint.
+    pub async fn get_user_default_tenant(
+        &self,
+        user_id: &str,
+    ) -> Result<Option<String>, PostgresError> {
+        use sqlx::Row;
+        let row = sqlx::query(
+            "SELECT default_tenant_id::text AS tid FROM users WHERE id = $1::uuid",
+        )
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.and_then(|r| r.try_get::<Option<String>, _>("tid").ok().flatten()))
+    }
+
+    /// Persist the caller-configured default tenant for a user.
+    ///
+    /// The tenant must exist and the caller is expected to have already
+    /// verified membership in it before calling this method. The FK
+    /// constraint rejects orphan IDs at write time.
+    pub async fn set_user_default_tenant(
+        &self,
+        user_id: &str,
+        tenant_id: &str,
+    ) -> Result<(), PostgresError> {
+        let res = sqlx::query(
+            "UPDATE users SET default_tenant_id = $2::uuid, updated_at = NOW() WHERE id = $1::uuid",
+        )
+        .bind(user_id)
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+        if res.rows_affected() == 0 {
+            return Err(PostgresError::NotFound(format!(
+                "user {user_id} not found"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Clear the caller-configured default tenant for a user.
+    pub async fn clear_user_default_tenant(&self, user_id: &str) -> Result<(), PostgresError> {
+        let res = sqlx::query(
+            "UPDATE users SET default_tenant_id = NULL, updated_at = NOW() WHERE id = $1::uuid",
+        )
+        .bind(user_id)
+        .execute(&self.pool)
+        .await?;
+        if res.rows_affected() == 0 {
+            return Err(PostgresError::NotFound(format!(
+                "user {user_id} not found"
+            )));
+        }
+        Ok(())
+    }
+
     /// Returns the distinct non-root tenant IDs that a user has any role in.
     ///
     /// Used for implicit tenant resolution: when a request carries no `X-Tenant-ID`

--- a/storage/src/postgres.rs
+++ b/storage/src/postgres.rs
@@ -1386,12 +1386,11 @@ impl PostgresBackend {
         user_id: &str,
     ) -> Result<Option<String>, PostgresError> {
         use sqlx::Row;
-        let row = sqlx::query(
-            "SELECT default_tenant_id::text AS tid FROM users WHERE id = $1::uuid",
-        )
-        .bind(user_id)
-        .fetch_optional(&self.pool)
-        .await?;
+        let row =
+            sqlx::query("SELECT default_tenant_id::text AS tid FROM users WHERE id = $1::uuid")
+                .bind(user_id)
+                .fetch_optional(&self.pool)
+                .await?;
         Ok(row.and_then(|r| r.try_get::<Option<String>, _>("tid").ok().flatten()))
     }
 
@@ -1413,9 +1412,7 @@ impl PostgresBackend {
         .execute(&self.pool)
         .await?;
         if res.rows_affected() == 0 {
-            return Err(PostgresError::NotFound(format!(
-                "user {user_id} not found"
-            )));
+            return Err(PostgresError::NotFound(format!("user {user_id} not found")));
         }
         Ok(())
     }
@@ -1429,9 +1426,7 @@ impl PostgresBackend {
         .execute(&self.pool)
         .await?;
         if res.rows_affected() == 0 {
-            return Err(PostgresError::NotFound(format!(
-                "user {user_id} not found"
-            )));
+            return Err(PostgresError::NotFound(format!("user {user_id} not found")));
         }
         Ok(())
     }


### PR DESCRIPTION
Closes half of #44 (supersedes #51). Ships the two foundational slices of OpenSpec change `refactor-platform-admin-impersonation` as a single reviewable unit.

## 44.a — Schema (commit 1)

Migration `023_platform_admin_impersonation.sql`:
- `users.default_tenant_id UUID NULL REFERENCES tenants(id) ON DELETE SET NULL` + partial index.
- `referential_audit_log.acting_as_tenant_id` + `governance_audit_log.acting_as_tenant_id` (records impersonation scope; `ON DELETE SET NULL` so history survives tenant deletion).
- Idempotent, downgrade procedure documented in `storage/migrations/README.md`.

## 44.b — Resolver + default-tenant endpoints (commit 2)

New `cli/src/server/context.rs`:
- `RequestContext` with `tenant: Option<ResolvedTenant>` — faithfully represents PlatformAdmin acting at the platform scope, a case the legacy `TenantContext` could not express without emitting `tenant_required`.
- `request_context()` implements the 4-step resolution chain:
  1. `X-Tenant-ID` header (slug or UUID)
  2. `users.default_tenant_id`
  3. auto-select single-tenant members
  4. PlatformAdmin → `None`; otherwise `400 select_tenant { availableTenants, hint }`
- Legacy `tenant_required` shape preserved for one release via `Accept-Error-Legacy: true`.
- `require_platform_admin(&ctx)` — tenant-free admin gate.

Storage (`PostgresBackend`):
- `get_user_default_tenant` / `set_user_default_tenant` / `clear_user_default_tenant`.

Routes (protected):
- `GET    /api/v1/user/me/default-tenant` → 200 `{tenantId,slug,name}` | 204
- `PUT    /api/v1/user/me/default-tenant` `{tenantId}` — membership-checked (PlatformAdmin exempt).
- `DELETE /api/v1/user/me/default-tenant`
- `/auth/session` grows `default_tenant_id` (feeds the UI selector restore in #46).

Refactor: `resolve_identity()` extracted from `authenticated_tenant_context` so the new resolver reuses the provider auth dance verbatim. **Legacy helper is unchanged** — the 81 existing call sites still go through it; they migrate in slice 44.c.

## What's intentionally NOT in this PR

- **44.c** — migrating the 81 handlers to `RequestContext` (separate PR: per-module, careful review)
- **44.d** — `ListTenantScope`, cross-tenant listing, audit-wiring, DB-backed integration tests
- **44.e** — docs, OpenAPI, release notes

Each follow-up is large enough to deserve its own focused review pass.

## Verification

- `cargo check -p aeterna` ✅
- `cargo check -p storage --tests` ✅
- `cargo test -p aeterna --lib server::context::tests` → **6/6 pass**
- Migration re-run idempotent (`IF NOT EXISTS`).
- Zero behavior change for existing endpoints.

## Review notes

- Read `cli/src/server/context.rs` first — it's the contract.
- `resolve_identity` in `mod.rs` is a pure extract-to-method refactor (diff-by-diff against the existing `authenticated_tenant_context` body).
- The `select_tenant` error body is pinned in the module-level doc comment on `context.rs`.