### PR TITLE
fix(#47): serve /admin SPA fallback as 200 instead of 404

### DIFF
--- a/cli/src/server/router.rs
+++ b/cli/src/server/router.rs
@@ -2,15 +2,16 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
+use axum::body::Body;
 use axum::extract::Request;
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use axum::{Json, Router};
 use metrics::{counter, histogram};
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
-use tower_http::services::{ServeDir, ServeFile};
+use tower_http::services::ServeDir;
 use tower_http::trace::TraceLayer;
 
 use super::auth_middleware::AuthenticationLayer;
@@ -79,14 +80,52 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     }
 
     // Admin UI static asset serving (optional — skipped if dist directory does not exist).
+    //
+    // SPA fallback policy (see OpenSpec change `fix-spa-fallback-status-code`, #47):
+    //   - Real static assets (main.js, styles.css, favicon, ...) are served
+    //     by ServeDir with their correct status codes.
+    //   - Unknown /admin/* paths fall through to an index.html payload served
+    //     with HTTP 200, not the historic 404. The React Router inside the SPA
+    //     is authoritative for "page not found" rendering — the server has no
+    //     way to know whether /admin/things/42 corresponds to a real client-
+    //     side route without executing the bundle.
+    //   - Serving index.html with 200 matches the behavior of every mainstream
+    //     static host (Netlify, Cloudflare Pages, S3 + CloudFront "SPA mode")
+    //     and fixes false positives on monitoring dashboards.
+    //
+    // The index.html body is read exactly once at startup and cached in an
+    // Arc<Bytes> to avoid per-request disk IO.
     let admin_ui_path =
         std::env::var("AETERNA_ADMIN_UI_PATH").unwrap_or_else(|_| "./admin-ui/dist".to_string());
     let admin_ui_dir = PathBuf::from(&admin_ui_path);
     if admin_ui_dir.is_dir() {
-        let index_html = admin_ui_dir.join("index.html");
-        let serve_dir = ServeDir::new(&admin_ui_dir).not_found_service(ServeFile::new(&index_html));
-        app = app.nest_service("/admin", serve_dir);
-        tracing::info!(path = %admin_ui_path, "Admin UI serving enabled at /admin");
+        let index_path = admin_ui_dir.join("index.html");
+        match std::fs::read(&index_path) {
+            Ok(bytes) => {
+                let cached: Arc<Vec<u8>> = Arc::new(bytes);
+                let spa_fallback = {
+                    let cached = cached.clone();
+                    axum::routing::any(move || {
+                        let body = cached.clone();
+                        async move { spa_index_response(body) }
+                    })
+                };
+                let serve_dir = ServeDir::new(&admin_ui_dir).fallback(spa_fallback);
+                app = app.nest_service("/admin", serve_dir);
+                tracing::info!(
+                    path = %admin_ui_path,
+                    index_bytes = cached.len(),
+                    "Admin UI serving enabled at /admin (SPA fallback -> 200)"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %admin_ui_path,
+                    error = %e,
+                    "Admin UI dist directory present but index.html unreadable — /admin route not registered"
+                );
+            }
+        }
     } else {
         tracing::info!(path = %admin_ui_path, "Admin UI dist directory not found — /admin route not registered");
     }
@@ -137,13 +176,146 @@ async fn not_found() -> impl IntoResponse {
     )
 }
 
+/// Build the SPA fallback response: 200 OK, `text/html; charset=utf-8`, and
+/// the cached `index.html` payload. See OpenSpec `fix-spa-fallback-status-code`.
+fn spa_index_response(body: Arc<Vec<u8>>) -> Response {
+    // Body::from(Vec<u8>) clones into the body; since the cache is an Arc
+    // we deref-clone the inner Vec here. For a ~5-20 KiB index.html shell
+    // this is negligible; we can swap to Bytes later if index.html ever
+    // grows to hundreds of KiB.
+    let mut resp = Response::new(Body::from((*body).clone()));
+    resp.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/html; charset=utf-8"),
+    );
+    // Do NOT cache the shell — ETag-free so clients always re-fetch to pick
+    // up new hashed asset URLs referenced from within.
+    resp.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-cache"),
+    );
+    resp
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::body::Body;
+    use axum::body::{Body, to_bytes};
     use axum::http::Request;
     use metrics_exporter_prometheus::PrometheusBuilder;
+    use tempfile::TempDir;
     use tower::ServiceExt;
+
+    /// Build a minimal router that mirrors the `/admin` nest in `build_router`.
+    /// Keeps the integration tests independent of full `AppState` plumbing.
+    fn admin_router(admin_ui_dir: &std::path::Path) -> Router {
+        let index_path = admin_ui_dir.join("index.html");
+        let cached: Arc<Vec<u8>> =
+            Arc::new(std::fs::read(&index_path).expect("index.html readable"));
+        let spa_fallback = {
+            let cached = cached.clone();
+            axum::routing::any(move || {
+                let body = cached.clone();
+                async move { spa_index_response(body) }
+            })
+        };
+        let serve_dir = ServeDir::new(admin_ui_dir).fallback(spa_fallback);
+        Router::new()
+            .nest_service("/admin", serve_dir)
+            .fallback(not_found)
+    }
+
+    fn seed_admin_dist() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("index.html"),
+            b"<!DOCTYPE html>\n<html><body>aeterna admin</body></html>\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("main.js"), b"console.log('aeterna');").unwrap();
+        dir
+    }
+
+    #[tokio::test]
+    async fn admin_spa_fallback_returns_200_html_for_deep_path() {
+        let dir = seed_admin_dist();
+        let app = admin_router(dir.path());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/admin/nonexistent/deep/path")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/html; charset=utf-8")
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(
+            body.starts_with(b"<!DOCTYPE html>"),
+            "SPA fallback body must start with <!DOCTYPE html>; got {:?}",
+            std::str::from_utf8(&body).unwrap_or("<binary>")
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_real_static_file_served_with_correct_content_type() {
+        let dir = seed_admin_dist();
+        let app = admin_router(dir.path());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/admin/main.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let ct = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.starts_with("application/javascript") || ct.starts_with("text/javascript"),
+            "main.js should be served as JavaScript, got {ct:?}"
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(
+            body.starts_with(b"console.log"),
+            "real static file must be returned, not the SPA shell"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_admin_paths_get_default_404() {
+        let dir = seed_admin_dist();
+        let app = admin_router(dir.path());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/nonexistent-top-level-path")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
 
     #[tokio::test]
     async fn fallback_returns_json_404() {

--- a/cli/src/server/router.rs
+++ b/cli/src/server/router.rs
@@ -190,10 +190,8 @@ fn spa_index_response(body: Arc<Vec<u8>>) -> Response {
     );
     // Do NOT cache the shell — ETag-free so clients always re-fetch to pick
     // up new hashed asset URLs referenced from within.
-    resp.headers_mut().insert(
-        header::CACHE_CONTROL,
-        HeaderValue::from_static("no-cache"),
-    );
+    resp.headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-cache"));
     resp
 }
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,43 @@
+# Deployment notes
+
+## Admin UI routing (`/admin/*`)
+
+The Aeterna server optionally serves a compiled React admin UI at `/admin`
+when `AETERNA_ADMIN_UI_PATH` points to a directory containing `index.html`
+(default `./admin-ui/dist`).
+
+Routing policy:
+
+| Request | Response |
+|---|---|
+| `GET /admin/main.js` (or any real file in `dist/`) | `200` with the file's actual content type |
+| `GET /admin/nonexistent/deep/path` (no matching static file) | **`200 text/html; charset=utf-8`** with the cached `index.html` shell |
+| `GET /nonexistent-top-level-path` (outside `/admin`) | `404` JSON |
+
+Serving the SPA shell with `200` (rather than the historic `404`) mirrors
+the behavior of every mainstream static host (Netlify, Cloudflare Pages,
+S3 + CloudFront "SPA mode"). The React Router inside the bundle is
+authoritative for "page not found" rendering — the server has no way to
+know whether `/admin/things/42` maps to a real client-side route without
+executing the bundle.
+
+### Monitoring
+
+Dashboards that alert on `http_requests_total{status="404"}` should
+**exclude `/admin/*` paths**. Prior to this change, missing client-side
+routes (e.g. after a user pasted a stale URL into the browser) showed up
+as server 404s and inflated error-rate SLOs. Those requests now render as
+`200` with the SPA shell as intended.
+
+### Cache semantics
+
+The SPA shell is served with `Cache-Control: no-cache` so clients always
+revalidate and pick up updated hashed asset URLs. The hashed assets
+referenced from inside the shell (`main.<hash>.js`, `styles.<hash>.css`)
+are served by `ServeDir` with tower-http's default strong caching.
+
+### Opting out
+
+Unset `AETERNA_ADMIN_UI_PATH`, or point it at a directory that does not
+contain an `index.html`. The `/admin` route is then not registered and
+all `/admin/*` requests fall through to the top-level `404`.


### PR DESCRIPTION
Closes #47. Implements OpenSpec change `fix-spa-fallback-status-code`.

## Problem

`ServeDir::not_found_service(ServeFile::new(\"index.html\"))` returned `index.html` with HTTP 404. Every legitimate React Router deep-link (user pasting `/admin/projects/42` into a fresh tab) counted as a server 404, which:

- inflated `http_requests_total{status=\"404\"}` and noised up dashboards
- made browser devtools flag every route transition as a failure
- blocked some CDN/proxy configs from caching the shell (many refuse 4xx)

## Fix

Replace the `not_found_service` with a custom `axum::routing::any` fallback that returns the cached `index.html` as:

- `200 OK`
- `Content-Type: text/html; charset=utf-8`
- `Cache-Control: no-cache` (shell revalidates; the hashed assets it references keep ServeDir's strong caching)

The bytes are read **once at startup** into an `Arc<Vec<u8>>` — no per-request disk IO. Real static files (`main.js`, `styles.css`, favicon, ...) continue to be served by `ServeDir` with their correct content types, so hits short-circuit before the fallback.

This matches Netlify, Cloudflare Pages, S3+CloudFront \"SPA mode\" — the React Router inside the bundle is the only party that can decide whether a path is a real client-side route.

## Scope

- Only `/admin/*`. Top-level `404` JSON is unchanged.
- Opt-out: unset `AETERNA_ADMIN_UI_PATH` or point it at a directory without `index.html` — the `/admin` route is then not registered and `/admin/*` falls through to the top-level 404.

## Tests (5/5 green)

- `admin_spa_fallback_returns_200_html_for_deep_path` — deep path -> 200 + `text/html` + `<!DOCTYPE html>` body
- `admin_real_static_file_served_with_correct_content_type` — `main.js` returns actual JS, not the SPA shell
- `non_admin_paths_get_default_404` — `/nonexistent-top-level-path` still 404
- `fallback_returns_json_404` (existing) still passes
- `request_metrics_middleware_records_metrics` (existing) still passes

## Docs

New `docs/deployment.md` with:
- Routing table (real files vs. SPA fallback vs. top-level 404)
- Monitoring guidance: **exclude `/admin/*` from 404 alerting dashboards**
- Cache-Control semantics
- Opt-out instructions

## Verification

- `cargo check -p aeterna` ✅
- `cargo test -p aeterna --lib server::router::tests` → 5/5 pass