### PR TITLE
RFC(#44.d): cross-tenant admin listing design

### DIFF
--- a/openspec/changes/add-cross-tenant-admin-listing/proposal.md
+++ b/openspec/changes/add-cross-tenant-admin-listing/proposal.md
@@ -1,0 +1,152 @@
+# Cross-Tenant Admin Listing (#44.d)
+
+**Status**: Proposed
+**Depends on**: #44.a (schema), #44.b (`RequestContext` resolver), #44.c (handler shim) — all merged on `master` as of PR #52 and #55.
+**Blocks**: #44.e (`X-Target-Tenant-Id` header removal).
+
+## Why
+
+`#44.c` (PR #55) migrated every legacy handler to the new `RequestContext` resolver transparently. That was the 80% win. But it preserved the `TenantContext` API, which **cannot express two things** PlatformAdmins genuinely need:
+
+1. **"No target tenant"** — e.g. `GET /admin/tenants` lists every tenant and must not require the caller to pick one first.
+2. **"Every tenant"** — e.g. audit search across the whole instance, user listing during incident response, cross-tenant billing roll-ups.
+
+Today the codebase fakes #1 by silently accepting any `X-Tenant-ID` (now fixed by #44.b's existence check, which *breaks* the silent path — another reason this PR is necessary), and has no way to do #2 at all. The `X-Target-Tenant-Id` legacy header is a third shape of confusion used by some CLI paths.
+
+We need a **single explicit vocabulary** for tenant scope on admin endpoints so handlers stop guessing.
+
+## What Changes
+
+### 1. Introduce `ListTenantScope` (server-side enum)
+
+```rust
+// cli/src/server/context.rs — additive
+
+/// Declared tenant scope for a list/search handler. Derived from the
+/// request's `?tenant=` query parameter by `RequestContext::list_scope()`.
+pub enum ListTenantScope {
+    /// Exactly one tenant (caller's resolved tenant, or path/query-specified).
+    Single(ResolvedTenant),
+    /// All tenants on the instance. PlatformAdmin only — non-admins get 403.
+    All,
+}
+
+impl RequestContext {
+    /// Parse `?tenant=<slug|uuid|*>` into `ListTenantScope`.
+    /// - `?tenant=*` → `All` (requires PlatformAdmin)
+    /// - `?tenant=<ref>` → `Single` (membership-checked unless admin)
+    /// - omitted → `Single(self.require_target_tenant(headers)?)`
+    pub async fn list_scope(
+        &self,
+        state: &AppState,
+        headers: &HeaderMap,
+        query_tenant: Option<&str>,
+    ) -> Result<ListTenantScope, Response>;
+}
+```
+
+### 2. New query-parameter convention: `?tenant=<value>`
+
+| Value       | Meaning                              | Auth                       |
+|-------------|--------------------------------------|----------------------------|
+| (omitted)   | Resolved tenant (header/default/auto) | Standard membership        |
+| `<slug>`    | That specific tenant                  | Membership or PlatformAdmin |
+| `<uuid>`    | That specific tenant (canonical ID)   | Same                       |
+| `*`         | **All tenants**                       | **PlatformAdmin required** |
+
+Response envelope for `*` mode includes `tenantId` + `tenantSlug` on every item.
+
+### 3. Migrate these handlers to `RequestContext` **directly** (not the shim)
+
+| Handler                              | File                    | Today                              | After                             |
+|--------------------------------------|-------------------------|------------------------------------|-----------------------------------|
+| `GET /admin/tenants`                 | `tenant_api.rs:924`     | `require_platform_admin` (local)   | `RequestContext` + `list_scope`   |
+| `GET /admin/users`                   | `user_api.rs`           | `tenant_scoped_context`            | `RequestContext::list_scope`      |
+| `GET /admin/projects`                | `project_api.rs`        | `tenant_scoped_context`            | `RequestContext::list_scope`      |
+| `GET /admin/orgs`                    | `org_api.rs`            | `tenant_scoped_context`            | `RequestContext::list_scope`      |
+| `GET /admin/audit`                   | `govern_api.rs`         | `tenant_scoped_context`            | `RequestContext::list_scope`      |
+
+These are the only 5. Every other list endpoint stays on the #44.c shim.
+
+### 4. Cross-tenant response shape (consistent across all 5)
+
+```json
+{
+  "success": true,
+  "scope": "all" | "single",
+  "tenant": { "id": "...", "slug": "..." } | null,    // null iff scope="all"
+  "items": [
+    { "id": "...", "tenantId": "...", "tenantSlug": "...", ... }
+  ],
+  "pagination": { ... }
+}
+```
+
+**Rule**: in `scope="all"` mode, every item **must** carry `tenantId` + `tenantSlug` (non-negotiable — tested by a trait-level contract test).
+
+### 5. Retire `X-Target-Tenant-Id` header (feeds #44.e)
+
+Currently used by 6 CLI code paths and 20 handler-side reads. After #44.d:
+
+- CLI `AeternaClient` stops emitting `x-target-tenant-id` on new calls. The preferred pattern is `X-Tenant-ID` for tenant-targeted ops + `?tenant=<slug|*>` for cross-tenant listing.
+- Legacy handlers continue to read the header for one release (compat window); remove in #44.e with the deprecation warning structured log already landed in #44.b.
+
+## Non-goals (explicitly out of scope)
+
+- **Audit impersonation tracking** (section 6 of the original proposal). Separate PR — the schema columns already exist, just need to populate them.
+- **Tenant wildcards with filters** (e.g. `?tenant=eu-*`). No demand signal yet. Revisit if/when multi-region becomes reality.
+- **Writes across tenants**. Bulk `PATCH`/`DELETE` with `?tenant=*` is explicitly forbidden — use per-tenant batch endpoints.
+
+## Alternatives considered
+
+### A. Separate `/admin/cross-tenant/users` etc. endpoints
+
+**Rejected** — doubles the API surface, duplicates pagination/filter logic, and clients must pick a URL statically. Query-param scope preserves a single URL shape with runtime scope selection.
+
+### B. Keep `X-Target-Tenant-Id` as the admin vocabulary
+
+**Rejected** — headers are invisible in URLs, request logs, HAR files. Debugging cross-tenant issues in production means reading full headers on every trace. A query param is self-documenting and cache-friendly (though these endpoints are not cached today).
+
+### C. Implicit "no header = list all" for PlatformAdmin
+
+**Rejected** — silent mode-switching. Today's code already suffers from this (an admin forgets a header and accidentally gets a cross-tenant view when they meant to target a specific tenant). Explicit `?tenant=*` is opt-in.
+
+### D. GraphQL-style scope object
+
+**Rejected** — we don't ship GraphQL, and inventing a JSON-body scope for GET requests is hostile to CLI/curl workflows.
+
+## Open questions
+
+1. **Q**: Should `?tenant=*` be spelled `?tenant=all` instead?
+   **Proposal**: keep `*` — matches Unix/SQL convention, no confusion with a tenant actually named `all`. Document both if we want.
+
+2. **Q**: Do we need a `?tenants=t1,t2,t3` multi-scope (not `*`, not single)?
+   **Proposal**: no. YAGNI. Every real-world motivator is either single-tenant or all-tenants. Revisit on demand.
+
+3. **Q**: Does `?tenant=*` paginate across tenants, or per-tenant with a continuation token?
+   **Proposal**: flat pagination across the union (sort by `(tenantId, id)` for stable ordering). Per-tenant continuation is a premature optimisation.
+
+4. **Q**: What error code for a non-admin calling `?tenant=*`?
+   **Proposal**: `403 forbidden_scope` (new code) with `required_role: "PlatformAdmin"` in the body. Distinct from `forbidden_tenant` so clients can differentiate.
+
+## Implementation plan (sketch — full tasks.md follows in the PR)
+
+1. Add `ListTenantScope` + `RequestContext::list_scope` (~80 LOC in `context.rs`) + 8 unit tests.
+2. Migrate each of the 5 handlers one commit at a time. Each commit self-contained, each adds an integration test.
+3. Stop emitting `x-target-tenant-id` in `AeternaClient` (kept as read-only server-side for compat window).
+4. Add contract test: "every item in a `scope=all` response has `tenantId` + `tenantSlug`".
+5. Update OpenAPI/Redoc schema for the 5 endpoints.
+
+**Estimated size**: ~600 LOC added, ~100 LOC removed. Single PR is feasible; two PRs acceptable if reviewers prefer (split: context resolver + per-handler migration).
+
+## Impact
+
+- **API surface**: additive `?tenant=*` on 5 endpoints. No breaking changes. New error code `forbidden_scope`.
+- **Wire compat**: old clients continuing to call these 5 endpoints without `?tenant` get identical behaviour to today.
+- **Schema**: none. Uses #44.a columns.
+- **CLI**: new `--all-tenants` flag on `aeterna admin users list` (etc.), implemented in a CLI-only follow-up once server side ships.
+- **Admin UI**: tenant picker gains an "All tenants" option on list views — UI-only follow-up.
+
+## Rollout
+
+Single-step rollout behind no feature flag. The feature is opt-in per-request (client must pass `?tenant=*`), so landing the code on `master` has zero behavioural impact until a client uses it. No migration, no data backfill, no kill-switch needed.

--- a/openspec/changes/add-cross-tenant-admin-listing/proposal.md
+++ b/openspec/changes/add-cross-tenant-admin-listing/proposal.md
@@ -115,19 +115,22 @@ Currently used by 6 CLI code paths and 20 handler-side reads. After #44.d:
 
 **Rejected** — we don't ship GraphQL, and inventing a JSON-body scope for GET requests is hostile to CLI/curl workflows.
 
-## Open questions
+## Decisions locked
 
-1. **Q**: Should `?tenant=*` be spelled `?tenant=all` instead?
-   **Proposal**: keep `*` — matches Unix/SQL convention, no confusion with a tenant actually named `all`. Document both if we want.
+1. **`?tenant=*` is the canonical wildcard spelling.** `?tenant=all` is accepted as a deprecated alias that emits a structured warning log to steer clients toward `*`. Removal of the alias is a separate future change.
+2. **No multi-scope `?tenants=t1,t2,t3`.** If demand emerges, the correct response is first-class **Tenant Groups** (`?group=<slug>`) as a separate feature, not URL-param set enumeration. Clients needing multi-tenant reads today use `?tenant=*` with client-side filtering or a client-side loop over `?tenant=<slug>`.
+3. **Flat pagination across the union**, keyset cursor over `(tenant_id, id)`. Per-tenant continuation tokens are explicitly rejected (complex client API, undefined cross-tenant ordering, 3 of 4 real-world workflows want a single flat stream). Workflows needing per-tenant bucketing will get dedicated endpoints (e.g. `/admin/errors/top-per-tenant?limit=10`).
+4. **`403 forbidden_scope`** is a new distinct error code for non-admins attempting `?tenant=*`. Kept separate from `forbidden_tenant` so clients can differentiate "you can't see *any* tenant besides yours" from "you can't do cross-tenant operations at all". Response body carries `required_role: "PlatformAdmin"`.
 
-2. **Q**: Do we need a `?tenants=t1,t2,t3` multi-scope (not `*`, not single)?
-   **Proposal**: no. YAGNI. Every real-world motivator is either single-tenant or all-tenants. Revisit on demand.
+## RLS interaction
 
-3. **Q**: Does `?tenant=*` paginate across tenants, or per-tenant with a continuation token?
-   **Proposal**: flat pagination across the union (sort by `(tenantId, id)` for stable ordering). Per-tenant continuation is a premature optimisation.
+This change intentionally operates on **non-RLS tables**: `users`, `projects`, `orgs`, `tenants`, `referential_audit_log`, `governance_audit_log`. Those tables isolate tenants via application-level `WHERE tenant_id = ?` clauses only. Therefore the flat cross-tenant `SELECT ... FROM <table> ORDER BY (tenant_id, id)` design is valid.
 
-4. **Q**: What error code for a non-admin calling `?tenant=*`?
-   **Proposal**: `403 forbidden_scope` (new code) with `required_role: "PlatformAdmin"` in the body. Distinct from `forbidden_tenant` so clients can differentiate.
+**22 other tables** in the schema **do** have RLS enabled (see `storage/migrations/006,008,016` and `storage/src/rls_migration.rs`). These are not in scope for `?tenant=*` and the 5 migrated endpoints never union them in. This is a deliberate boundary.
+
+**Regression guard** (tasks.md 4.2): a compile-time test asserts the 5 target tables are not RLS-protected. If a future migration RLS-enables one of them, the test fails and forces a redesign decision (add `BYPASSRLS` role? parallel admin view? drop RLS?) before the endpoint silently returns empty results.
+
+**Future work** (out of scope): when an admin endpoint genuinely needs to cross-tenant-read an RLS-protected table, we will have to pick between a `BYPASSRLS` Postgres role (my preference — clean separation + pg-level auditability), policy-level platform-admin escape clauses (uniform but bloats every policy), or `SECURITY DEFINER` views. Documented here for traceability; decision deferred.
 
 ## Implementation plan (sketch — full tasks.md follows in the PR)
 

--- a/openspec/changes/add-cross-tenant-admin-listing/tasks.md
+++ b/openspec/changes/add-cross-tenant-admin-listing/tasks.md
@@ -31,9 +31,10 @@
 - [ ] 3.2 Stable sort key `(tenant_id, id)` for deterministic pagination across the union.
 - [ ] 3.3 Ensure `SELECT ... FROM table` does NOT implicitly filter by tenant (these are the *only* queries on the entire codebase allowed to read across tenant boundaries — add a `#[doc(hidden)]` marker and a comment flagging the audit requirement).
 
-## 4. Contract test
+## 4. Contract tests
 
 - [ ] 4.1 Add `cli/tests/cross_tenant_contract_test.rs`: for every `scope=all` response across the 5 endpoints, every item MUST contain non-empty `tenantId` and `tenantSlug`. Failing this test gates the PR.
+- [ ] 4.2 Add RLS regression guard `storage/tests/rls_boundary_test.rs`: asserts each of `users`, `projects`, `orgs`, `tenants`, `referential_audit_log`, `governance_audit_log` has `relrowsecurity = false` in `pg_class`. If a future migration RLS-enables one of these, this test fails and forces a redesign of the cross-tenant reader.
 
 ## 5. Integration tests
 

--- a/openspec/changes/add-cross-tenant-admin-listing/tasks.md
+++ b/openspec/changes/add-cross-tenant-admin-listing/tasks.md
@@ -1,0 +1,66 @@
+# Tasks — Cross-Tenant Admin Listing (#44.d)
+
+## 1. Core scope resolver
+
+- [ ] 1.1 Add `ListTenantScope` enum to `cli/src/server/context.rs` with `Single(ResolvedTenant)` and `All` variants. Derive `Debug`.
+- [ ] 1.2 Implement `RequestContext::list_scope(&self, state, headers, query_tenant: Option<&str>) -> Result<ListTenantScope, Response>` with the resolution rules documented in the proposal.
+- [ ] 1.3 Implement a new error builder `forbidden_scope_response(required_role)` emitting `403 { error: "forbidden_scope", required_role: "PlatformAdmin", message: "..." }`.
+- [ ] 1.4 Accept both `?tenant=*` and `?tenant=all` in the parser; emit a deprecation warning log for `all` to steer toward `*`.
+- [ ] 1.5 Unit tests (8, all in `context.rs::tests`):
+  - [ ] `list_scope_omitted_resolves_to_single_via_context`
+  - [ ] `list_scope_explicit_slug_resolves_to_single`
+  - [ ] `list_scope_uuid_resolves_to_single`
+  - [ ] `list_scope_star_as_admin_returns_all`
+  - [ ] `list_scope_star_as_non_admin_returns_forbidden_scope`
+  - [ ] `list_scope_alias_all_accepted_with_warning`
+  - [ ] `list_scope_single_cross_tenant_requires_membership_or_admin`
+  - [ ] `list_scope_nonexistent_tenant_returns_404`
+
+## 2. Handler migration (one commit per handler)
+
+- [ ] 2.1 `GET /admin/tenants` — replace local `require_platform_admin` with `RequestContext` + `list_scope`; default to `All` for backward compat (this endpoint was always cross-tenant).
+- [ ] 2.2 `GET /admin/users` — accept `?tenant=<slug|uuid|*>`; return `scope`+`tenant`+`items[]` envelope; decorate each item with `tenantId`+`tenantSlug` in `scope=all` mode.
+- [ ] 2.3 `GET /admin/projects` — same treatment.
+- [ ] 2.4 `GET /admin/orgs` — same treatment.
+- [ ] 2.5 `GET /admin/audit` — same treatment, plus ensure audit filters (`?actor`, `?since`) compose with `?tenant=*`.
+- [ ] 2.6 Add `tenant_filter` param + new envelope to OpenAPI/Redoc schema for each of the 5.
+
+## 3. Cross-tenant repository layer
+
+- [ ] 3.1 Each of the 5 stores (`user_store`, `project_store`, `org_store`, `tenant_store`, `audit_store`) gains a `list_all(pagination) -> Result<Vec<Row>, StorageError>` method returning rows with `tenant_id` joined in.
+- [ ] 3.2 Stable sort key `(tenant_id, id)` for deterministic pagination across the union.
+- [ ] 3.3 Ensure `SELECT ... FROM table` does NOT implicitly filter by tenant (these are the *only* queries on the entire codebase allowed to read across tenant boundaries — add a `#[doc(hidden)]` marker and a comment flagging the audit requirement).
+
+## 4. Contract test
+
+- [ ] 4.1 Add `cli/tests/cross_tenant_contract_test.rs`: for every `scope=all` response across the 5 endpoints, every item MUST contain non-empty `tenantId` and `tenantSlug`. Failing this test gates the PR.
+
+## 5. Integration tests
+
+- [ ] 5.1 PlatformAdmin + `GET /admin/users?tenant=*` → 200, items span ≥2 tenants, every item has `tenantId`/`tenantSlug`.
+- [ ] 5.2 Regular user + `GET /admin/users?tenant=*` → 403 `forbidden_scope`.
+- [ ] 5.3 PlatformAdmin + `GET /admin/users` (no `?tenant`) → behaves as today (single tenant from `X-Tenant-ID`/default).
+- [ ] 5.4 PlatformAdmin + `GET /admin/users?tenant=foreign-slug` → 200, items are from `foreign-slug` only.
+- [ ] 5.5 PlatformAdmin + `GET /admin/users?tenant=nonexistent` → 404 `tenant_not_found`.
+- [ ] 5.6 `GET /admin/users?tenant=all` → 200 + deprecation log line (caught with `tracing-test`).
+- [ ] 5.7 Pagination with `?tenant=*` yields consistent ordering across pages (snapshot test with seeded data).
+- [ ] 5.8 `POST /admin/users` with `?tenant=*` → 400 `scope_not_allowed_for_write` (writes explicitly forbidden in `All` scope).
+
+## 6. CLI updates (separate PR, tracked here for cross-reference)
+
+- [ ] 6.1 Stop emitting `x-target-tenant-id` in `AeternaClient::get/post/put/delete`. Remove the `target_tenant` field from the client builder.
+- [ ] 6.2 Add `--all-tenants` flag to `aeterna admin users list`, `projects list`, `orgs list`, `audit list` (maps to `?tenant=*`).
+- [ ] 6.3 Add `--tenant <slug>` flag to the same commands (maps to `?tenant=<slug>`). Mutually exclusive with `--all-tenants`.
+- [ ] 6.4 Decorate CLI table output with a `TENANT` column when in `--all-tenants` mode.
+
+## 7. Documentation
+
+- [ ] 7.1 Update `docs/api/admin.md` (or create if absent) with the `?tenant=` convention table from the proposal.
+- [ ] 7.2 Add a "Cross-tenant operations" section to `USER_GUIDE.md` / `DEVELOPER_GUIDE.md` describing when to use `--all-tenants`.
+- [ ] 7.3 Update the 7-stage framework proposal README for `refactor-platform-admin-impersonation` to mark section 5 delegated to this change.
+
+## 8. Cleanup (feeds #44.e)
+
+- [ ] 8.1 Add `#[deprecated(note = "Use ?tenant=<slug> or ?tenant=* instead")]` to the header-reading code path in `authenticated_tenant_context`.
+- [ ] 8.2 Structured log every `X-Target-Tenant-Id` read with `warn!(target: "compat", header = "x-target-tenant-id", ...)` so observability can tally remaining clients.
+- [ ] 8.3 Ship one minor release with deprecation warnings active; #44.e removes the code path entirely.


### PR DESCRIPTION
**Request for Comments** — design doc only, no code changes. Looking for sign-off before implementation.

## TL;DR

#44.c (PR #55) shimmed every handler onto the new `RequestContext` resolver, preserving the `TenantContext` API. That handles the 80% case. This RFC proposes the **remaining 20%**: the 5 admin list endpoints that genuinely need to express "no target tenant" or "every tenant" — cases `TenantContext` structurally cannot represent.

## Core design decision

New query-parameter convention on admin list endpoints:

| Query | Scope | Auth |
|---|---|---|
| *(omitted)* | Current tenant (header/default/auto) | Standard |
| `?tenant=<slug>` | That specific tenant | Member or PlatformAdmin |
| `?tenant=*` | **All tenants** | **PlatformAdmin** |

Backed by a new server-side enum `ListTenantScope { Single(ResolvedTenant), All }` on `RequestContext`.

## Scope

5 endpoints migrate to `RequestContext` directly (the rest stay on the #44.c shim):
- `GET /admin/tenants`
- `GET /admin/users`
- `GET /admin/projects`
- `GET /admin/orgs`
- `GET /admin/audit`

## What I want feedback on

1. **`*` vs `all`** — I propose `*` (Unix/SQL convention, no collision with a literal tenant named "all"). Accept both with deprecation on `all`. OK?
2. **Multi-tenant scope `?tenants=t1,t2`** — I proposed dropping this as YAGNI. Any real use case I'm missing?
3. **Flat pagination across union** vs per-tenant continuation — I chose flat (sorted by `(tenant_id, id)`). Anyone has a hotter opinion?
4. **`forbidden_scope` as a new error code** — distinct from `forbidden_tenant`. OK or fold into the existing code?

## What's explicitly NOT in this RFC

- Audit impersonation tracking (separate PR, schema already landed in #44.a)
- Tenant wildcards like `?tenant=eu-*` (no demand signal)
- Writes across tenants (forbidden by design; 400 `scope_not_allowed_for_write`)

## Alternatives I considered and rejected

See proposal.md for full rationale:
- Separate `/admin/cross-tenant/users` endpoints (API bloat)
- Keep `X-Target-Tenant-Id` as the vocabulary (debugging hostile)
- Implicit "no header = list all" for admins (silent mode-switching footgun)
- GraphQL-style scope object (we don't ship GraphQL)

## Rollout

Pure additive. No feature flag. No migration. No kill switch. Landing the code is a no-op until a client passes `?tenant=<value>`.

## Estimated size

~600 LOC added, ~100 LOC removed. Single PR feasible; two PRs acceptable (split: resolver + per-handler migration).

---

Review the two files:
- [`proposal.md`](https://github.com/kikokikok/aeterna/blob/docs/44d-cross-tenant-rfc/openspec/changes/add-cross-tenant-admin-listing/proposal.md) — full design, alternatives, open questions
- [`tasks.md`](https://github.com/kikokikok/aeterna/blob/docs/44d-cross-tenant-rfc/openspec/changes/add-cross-tenant-admin-listing/tasks.md) — concrete checkbox breakdown (8 sections, ~40 tasks)

Once approved, I'll start implementation in a new branch `impl/44d-cross-tenant-listing`.
