### PR TITLE
fix(#59): normalize RLS session variable to app.tenant_id

### DIFF
--- a/storage/migrations/024_normalize_rls_session_variables.sql
+++ b/storage/migrations/024_normalize_rls_session_variables.sql
@@ -1,0 +1,46 @@
+-- Migration 024 — Normalize RLS session variable names
+--
+-- Context (see issue #59):
+-- Three different Postgres session variables are used across RLS policies:
+--   - app.tenant_id          : migrations 008, 009, 010, 013, 017, 020, GDPR runtime (canonical)
+--   - app.current_tenant_id  : migration 006 only (pure naming inconsistency — same concept)
+--   - app.company_id         : migration 016 (DIFFERENT scoping axis — NOT renamed)
+--
+-- This migration rewrites the three policies from migration 006 to use the
+-- canonical `app.tenant_id` so a single `activate_tenant_context` call can
+-- satisfy every tenant-scoped RLS policy in the schema.
+--
+-- No Rust code reads `app.current_tenant_id` today (verified via grep), so
+-- this is migration-only with zero runtime impact.
+--
+-- Related issues:
+--   #57 — pool leak in set_config (orthogonal, fixed separately)
+--   #58 — RLS not activated on most query paths (architectural, deferred)
+
+BEGIN;
+
+-- governance_events
+DROP POLICY IF EXISTS governance_events_tenant_isolation ON governance_events;
+CREATE POLICY governance_events_tenant_isolation ON governance_events
+    FOR ALL
+    USING (tenant_id = current_setting('app.tenant_id', true));
+
+-- event_delivery_metrics
+DROP POLICY IF EXISTS event_metrics_tenant_isolation ON event_delivery_metrics;
+CREATE POLICY event_metrics_tenant_isolation ON event_delivery_metrics
+    FOR ALL
+    USING (tenant_id = current_setting('app.tenant_id', true));
+
+-- event_consumer_state
+DROP POLICY IF EXISTS consumer_state_tenant_isolation ON event_consumer_state;
+CREATE POLICY consumer_state_tenant_isolation ON event_consumer_state
+    FOR ALL
+    USING (tenant_id = current_setting('app.tenant_id', true));
+
+COMMIT;
+
+-- Verification query (run post-migration to confirm zero remaining references):
+--   SELECT schemaname, tablename, policyname, qual
+--     FROM pg_policies
+--    WHERE qual LIKE '%app.current_tenant_id%';
+-- Expected: 0 rows.

--- a/storage/migrations/README.md
+++ b/storage/migrations/README.md
@@ -19,6 +19,7 @@ Aeterna does **not** auto-generate down-migrations. If a migration needs to be r
 
 ### Per-migration downgrade notes
 
+- **024_normalize_rls_session_variables.sql** -- rewrites three RLS policies from `app.current_tenant_id` to `app.tenant_id`. To revert, re-run the original `CREATE POLICY` blocks from `006_event_streaming.sql:120-138` after `DROP POLICY IF EXISTS`. No data change; policies are metadata only. See issue #59 for context.
 - **023_platform_admin_impersonation.sql** -- safe to drop. All three added columns default to `NULL` and are not read by any code until migration 024+. To revert:
   ```sql
   ALTER TABLE users                  DROP COLUMN IF EXISTS default_tenant_id;


### PR DESCRIPTION
Closes #59.

## What

Migration 024 rewrites three RLS policies from migration 006 (`governance_events`, `event_delivery_metrics`, `event_consumer_state`) to use the canonical `app.tenant_id` session variable instead of the one-off `app.current_tenant_id`.

## Why

Three variable names exist across the schema:
- `app.tenant_id` — 15+ policies (canonical)
- `app.current_tenant_id` — 3 policies in migration 006 only (inconsistency)
- `app.company_id` — 5 policies in migration 016 (**different scoping axis, kept**)

Before this PR, a query joining `governance_events` with any other RLS-protected table would require setting both session variables — which nothing in the codebase does. Latent footgun.

## Verification

- `grep -rn app.current_tenant_id storage/src cli/src` → empty (no Rust code reads it)
- `cargo check -p storage` → passes
- Migration is pure metadata (CREATE POLICY after DROP POLICY IF EXISTS). Idempotent. Downgrade documented in README.

## Related

Split from #44.d RFC (#56) investigation. Sibling PRs address #57 (pool leak) separately. #58 (RLS not activated on most paths) is architectural and deferred.