### PR TITLE
fix(#57): scope RLS activation to a transaction (SET LOCAL)

### DIFF
--- a/cli/src/server/backup_api.rs
+++ b/cli/src/server/backup_api.rs
@@ -1592,14 +1592,17 @@ async fn run_export(
 
     let pool = state.postgres.pool();
 
-    // Set tenant context for RLS (if tenant-scoped)
-    if scope != "full" {
-        sqlx::query("SELECT set_config('app.tenant_id', $1, false)")
-            .bind(tenant_id)
-            .execute(pool)
-            .await
-            .ok();
-    }
+    // NOTE (issue #57): a previous `set_config('app.tenant_id', $1, false)`
+    // call lived here. It was broken in two ways: (a) it ran against the
+    // pool without pinning a connection, so it landed on a random connection
+    // and subsequent export queries using different connections never saw
+    // the setting; (b) with `false` (session-scoped) it leaked tenant
+    // context to the next user of that connection.
+    //
+    // The call has been removed because the export functions below do not
+    // rely on RLS — they all filter with an explicit `WHERE tenant_id = $1`
+    // clause. Proper RLS activation for cross-connection export paths
+    // requires the architectural decision in issue #58.
 
     // Build the export scope for the manifest
     let manifest_scope = if scope == "full" {

--- a/cli/src/server/sync.rs
+++ b/cli/src/server/sync.rs
@@ -116,19 +116,22 @@ async fn push_handler(
     };
     let pool = state.postgres.pool();
 
-    let mut conn = match pool.acquire().await {
-        Ok(c) => c,
+    // Begin an explicit transaction so that SET LOCAL app.tenant_id is scoped
+    // to this request only and cannot leak to the next user of this pooled
+    // connection (see issue #57).
+    let mut tx = match pool.begin().await {
+        Ok(t) => t,
         Err(e) => {
-            tracing::error!("Failed to acquire database connection: {e}");
+            tracing::error!("Failed to begin database transaction: {e}");
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "database_error",
-                "Failed to acquire database connection",
+                "Failed to begin database transaction",
             );
         }
     };
     if let Err(e) =
-        PostgresBackend::activate_tenant_context(&mut conn, ctx.tenant_id.as_str()).await
+        PostgresBackend::activate_tenant_context(&mut tx, ctx.tenant_id.as_str()).await
     {
         tracing::error!("Failed to activate tenant RLS context: {e}");
         return error_response(
@@ -151,7 +154,7 @@ async fn push_handler(
         )
         .bind(&entry.id)
         .bind(ctx.tenant_id.as_str())
-        .fetch_optional(&mut *conn)
+        .fetch_optional(&mut *tx)
         .await
         .unwrap_or(None);
 
@@ -179,7 +182,7 @@ async fn push_handler(
             .bind(&req.device_id)
             .bind(&entry.id)
             .bind(ctx.tenant_id.as_str())
-            .execute(&mut *conn)
+            .execute(&mut *tx)
             .await
             .ok();
         } else {
@@ -199,10 +202,19 @@ async fn push_handler(
             .bind(&req.device_id)
             .bind(created_at)
             .bind(updated_at)
-            .execute(&mut *conn)
+            .execute(&mut *tx)
             .await
             .ok();
         }
+    }
+
+    if let Err(e) = tx.commit().await {
+        tracing::error!("Failed to commit sync push transaction: {e}");
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "database_error",
+            "Failed to commit transaction",
+        );
     }
 
     let cursor = chrono::Utc::now().timestamp_millis().to_string();
@@ -241,19 +253,21 @@ async fn pull_handler(
     };
     let pool = state.postgres.pool();
 
-    let mut conn = match pool.acquire().await {
-        Ok(c) => c,
+    // See issue #57: SET LOCAL requires an active transaction so the setting
+    // cannot leak to the next user of this pooled connection.
+    let mut tx = match pool.begin().await {
+        Ok(t) => t,
         Err(e) => {
-            tracing::error!("Failed to acquire database connection: {e}");
+            tracing::error!("Failed to begin database transaction: {e}");
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "database_error",
-                "Failed to acquire database connection",
+                "Failed to begin database transaction",
             );
         }
     };
     if let Err(e) =
-        PostgresBackend::activate_tenant_context(&mut conn, ctx.tenant_id.as_str()).await
+        PostgresBackend::activate_tenant_context(&mut tx, ctx.tenant_id.as_str()).await
     {
         tracing::error!("Failed to activate tenant RLS context: {e}");
         return error_response(
@@ -296,9 +310,13 @@ async fn pull_handler(
         .bind(ctx.tenant_id.as_str())
         .bind(since_cursor)
         .bind(fetch_limit * 2)
-        .fetch_all(&mut *conn)
+        .fetch_all(&mut *tx)
         .await
         .unwrap_or_default();
+
+    // Pull is read-only: rollback instead of commit. The SET LOCAL is
+    // discarded either way, so correctness is unaffected.
+    let _ = tx.rollback().await;
 
     let layer_set: HashSet<&str> = layers.iter().map(String::as_str).collect();
     let all_matching: Vec<_> = rows

--- a/cli/src/server/sync.rs
+++ b/cli/src/server/sync.rs
@@ -130,8 +130,7 @@ async fn push_handler(
             );
         }
     };
-    if let Err(e) =
-        PostgresBackend::activate_tenant_context(&mut tx, ctx.tenant_id.as_str()).await
+    if let Err(e) = PostgresBackend::activate_tenant_context(&mut tx, ctx.tenant_id.as_str()).await
     {
         tracing::error!("Failed to activate tenant RLS context: {e}");
         return error_response(
@@ -266,8 +265,7 @@ async fn pull_handler(
             );
         }
     };
-    if let Err(e) =
-        PostgresBackend::activate_tenant_context(&mut tx, ctx.tenant_id.as_str()).await
+    if let Err(e) = PostgresBackend::activate_tenant_context(&mut tx, ctx.tenant_id.as_str()).await
     {
         tracing::error!("Failed to activate tenant RLS context: {e}");
         return error_response(

--- a/storage/src/postgres.rs
+++ b/storage/src/postgres.rs
@@ -4,7 +4,6 @@ use mk_core::types::{
     INSTANCE_SCOPE_TENANT_ID, OrganizationalUnit, RoleIdentifier, SYSTEM_USER_ID, TenantContext,
     UnitType,
 };
-use sqlx::pool::PoolConnection;
 use sqlx::{Pool, Postgres, Row};
 use thiserror::Error;
 
@@ -45,24 +44,38 @@ impl PostgresBackend {
         Ok(Self { pool })
     }
 
-    /// Arm the Postgres session-level RLS context for the given tenant.
+    /// Arm the Postgres transaction-level RLS context for the given tenant.
     ///
-    /// This sets the `app.tenant_id` configuration parameter on the provided
-    /// connection so that any RLS policies keyed on
-    /// `current_setting('app.tenant_id', true)` will evaluate correctly.
+    /// Uses `set_config('app.tenant_id', $1, true)` — the `true` argument is
+    /// equivalent to `SET LOCAL`, scoping the setting to the **current
+    /// transaction only**. On `COMMIT` or `ROLLBACK` the setting is discarded,
+    /// so a returned-to-pool connection can never leak tenant context to a
+    /// subsequent request.
     ///
-    /// The setting is scoped to the current transaction (`SET LOCAL`) when
-    /// called inside a transaction, or to the session otherwise.  Callers
-    /// that issue multiple tenant-scoped queries SHOULD acquire a single
-    /// connection, call this method once, and then execute all queries on
-    /// that connection.
+    /// # Contract
+    ///
+    /// - Caller MUST be inside an active transaction. Outside a transaction,
+    ///   `SET LOCAL` applies only to the statement itself and is immediately
+    ///   discarded — resulting in a silent no-op. This function takes a
+    ///   `&mut Transaction` rather than a `PoolConnection` to make that
+    ///   requirement compile-time enforced.
+    /// - After this call returns, every tenant-scoped RLS policy keyed on
+    ///   `current_setting('app.tenant_id', true)` will evaluate correctly for
+    ///   the remainder of the transaction.
+    ///
+    /// # See also
+    ///
+    /// - Issue #57: previous session-scoped version leaked tenant context
+    ///   across pooled connections.
+    /// - Issue #58: policies may still be a no-op in prod if the connection
+    ///   role has `BYPASSRLS` — orthogonal, deferred.
     pub async fn activate_tenant_context(
-        conn: &mut PoolConnection<Postgres>,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
         tenant_id: &str,
     ) -> Result<(), PostgresError> {
-        sqlx::query("SELECT set_config('app.tenant_id', $1, false)")
+        sqlx::query("SELECT set_config('app.tenant_id', $1, true)")
             .bind(tenant_id)
-            .execute(&mut **conn)
+            .execute(&mut **tx)
             .await?;
         Ok(())
     }

--- a/storage/tests/rls_policy_test.rs
+++ b/storage/tests/rls_policy_test.rs
@@ -59,4 +59,59 @@ mod tests {
             .await
             .expect("Schema init failed");
     }
+
+    /// Regression for issue #57.
+    ///
+    /// Before the fix, `activate_tenant_context` used
+    /// `set_config('app.tenant_id', $1, false)` (session-scoped). If a
+    /// connection was returned to the pool and re-acquired, the tenant
+    /// context leaked to the next request. After the fix,
+    /// `activate_tenant_context` requires a transaction and uses
+    /// `set_config(..., true)` (transaction-scoped), so the setting is
+    /// discarded on COMMIT/ROLLBACK.
+    #[tokio::test]
+    async fn test_tenant_context_does_not_leak_across_pool_acquisitions() {
+        let Some(pg_fixture) = postgres().await else {
+            eprintln!("Skipping test: Docker not available");
+            return;
+        };
+
+        let backend = PostgresBackend::new(pg_fixture.url())
+            .await
+            .expect("Database connection required");
+        backend
+            .initialize_schema()
+            .await
+            .expect("Schema init failed");
+
+        let pool = backend.pool();
+
+        // Acquisition 1: activate tenant-a inside a transaction, commit, return.
+        {
+            let mut tx = pool.begin().await.expect("begin tx");
+            PostgresBackend::activate_tenant_context(&mut tx, "tenant-a")
+                .await
+                .expect("activate tenant-a");
+            let (seen,): (String,) =
+                sqlx::query_as("SELECT current_setting('app.tenant_id', true)")
+                    .fetch_one(&mut *tx)
+                    .await
+                    .expect("fetch current_setting inside tx");
+            assert_eq!(seen, "tenant-a", "setting must be visible inside its tx");
+            tx.commit().await.expect("commit tx");
+        }
+
+        // Acquisition 2: NEW transaction on a fresh (or recycled) connection.
+        // The previous tenant-a context MUST NOT leak. Expected value: empty.
+        let (leaked,): (String,) =
+            sqlx::query_as("SELECT current_setting('app.tenant_id', true)")
+                .fetch_one(pool)
+                .await
+                .expect("fetch current_setting after commit");
+        assert_eq!(
+            leaked, "",
+            "tenant context leaked across pool acquisitions \
+             (regression of issue #57)"
+        );
+    }
 }

--- a/storage/tests/rls_policy_test.rs
+++ b/storage/tests/rls_policy_test.rs
@@ -103,11 +103,10 @@ mod tests {
 
         // Acquisition 2: NEW transaction on a fresh (or recycled) connection.
         // The previous tenant-a context MUST NOT leak. Expected value: empty.
-        let (leaked,): (String,) =
-            sqlx::query_as("SELECT current_setting('app.tenant_id', true)")
-                .fetch_one(pool)
-                .await
-                .expect("fetch current_setting after commit");
+        let (leaked,): (String,) = sqlx::query_as("SELECT current_setting('app.tenant_id', true)")
+            .fetch_one(pool)
+            .await
+            .expect("fetch current_setting after commit");
         assert_eq!(
             leaked, "",
             "tenant context leaked across pool acquisitions \


### PR DESCRIPTION
Closes #57.

## Problem

`PostgresBackend::activate_tenant_context` used `set_config(app.tenant_id, $1, false)` — session-scoped. A pooled connection returning to the pool with `app.tenant_id` still set leaked tenant context to the next request.

Second instance at `cli/src/server/backup_api.rs:1597` had the same bug + ran on the pool without pinning a connection + swallowed errors with `.ok()`.

## Fix

### `storage/src/postgres.rs`
- Signature change: `activate_tenant_context(tx: &mut Transaction<Postgres>, tenant_id: &str)` — compile-time enforcement that a transaction exists.
- `set_config(..., true)` ≡ `SET LOCAL` — transaction-scoped, discarded on COMMIT/ROLLBACK.

### `cli/src/server/sync.rs` (2 sites)
- `push_handler`: `begin()` → activate → run writes → `commit()`. Errors on commit return 500.
- `pull_handler`: `begin()` → activate → run read → `rollback()` (read-only path).

### `cli/src/server/backup_api.rs`
- Removed `set_config` call entirely. It was dead code: exports use explicit `WHERE tenant_id = $1` and do not rely on RLS. Replaced with a comment pointing to #58 for the architectural follow-up.

### `storage/tests/rls_policy_test.rs`
- New integration test `test_tenant_context_does_not_leak_across_pool_acquisitions` — activates tenant-a in a tx, commits, verifies a subsequent pool query sees empty `app.tenant_id`. Fails hard if the leak regresses.

## Verification

- `cargo check --workspace --tests` → clean
- Unused `PoolConnection` import removed
- Test infra: gated behind `postgres().await` Docker-presence check (same pattern as existing `test_rls_cross_tenant_access_blocked`)

## Out of scope (flagged)

`storage/src/gdpr.rs` has `set_config(..., true)` on `&self.pool` (naked pool, no transaction) — the setting is discarded immediately after the `set_config` statement. Same bug class, different failure mode. Fixing requires either wrapping all gdpr ops in explicit txns or removing the calls since GDPR already filters with explicit tenant_id. Left for a follow-up PR to keep this one reviewable.

## Related

Split from #44.d RFC (#56). Sibling PR #60 addresses #59 (variable naming). Issue #58 (RLS not activated on most paths) is architectural and deferred pending an RFC.