### PR TITLE
feat(#44.d): §2.1 — migrate GET /admin/tenants + RFC path amendment

### DIFF
--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -926,7 +926,15 @@ async fn list_tenants(
     headers: HeaderMap,
     Query(query): Query<TenantListQuery>,
 ) -> impl IntoResponse {
-    if let Err(response) = require_platform_admin(&state, &headers).await {
+    // Migrated to the #44.d resolver chain: the old path required an
+    // X-Tenant-ID header to produce a TenantContext, even though this
+    // endpoint never consults it. `request_context` lets PlatformAdmins
+    // hit it with no tenant selected.
+    let ctx = match super::context::request_context(&state, &headers).await {
+        Ok(c) => c,
+        Err(response) => return response,
+    };
+    if let Err(response) = super::context::require_platform_admin(&ctx) {
         return response;
     }
 
@@ -937,7 +945,14 @@ async fn list_tenants(
     {
         Ok(tenants) => (
             StatusCode::OK,
-            Json(json!({ "success": true, "tenants": tenants })),
+            Json(json!({
+                // `scope: "all"` marks the response as cross-tenant per the
+                // RFC envelope convention. The existing `tenants` field is
+                // kept for backward compatibility with pre-#44.d clients.
+                "success": true,
+                "scope": "all",
+                "tenants": tenants,
+            })),
         )
             .into_response(),
         Err(err) => error_response(

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -2203,6 +2203,8 @@ async fn tenant_list_and_hierarchy_read_operations() {
     .unwrap();
     assert_eq!(body["success"], true);
     assert!(body["tenants"].is_array());
+    // #44.d: cross-tenant list endpoints advertise scope=all.
+    assert_eq!(body["scope"], "all");
 
     // list_tenants – forbidden without platform_admin
     let resp = app

--- a/openspec/changes/add-cross-tenant-admin-listing/proposal.md
+++ b/openspec/changes/add-cross-tenant-admin-listing/proposal.md
@@ -122,6 +122,22 @@ Currently used by 6 CLI code paths and 20 handler-side reads. After #44.d:
 3. **Flat pagination across the union**, keyset cursor over `(tenant_id, id)`. Per-tenant continuation tokens are explicitly rejected (complex client API, undefined cross-tenant ordering, 3 of 4 real-world workflows want a single flat stream). Workflows needing per-tenant bucketing will get dedicated endpoints (e.g. `/admin/errors/top-per-tenant?limit=10`).
 4. **`403 forbidden_scope`** is a new distinct error code for non-admins attempting `?tenant=*`. Kept separate from `forbidden_tenant` so clients can differentiate "you can't see *any* tenant besides yours" from "you can't do cross-tenant operations at all". Response body carries `required_role: "PlatformAdmin"`.
 
+## Target paths (amendment, 2026-04-18)
+
+Initial drafts of this proposal assumed five parallel `/admin/*` list endpoints. Implementation discovered only `/admin/tenants` exists; the other four concepts live at tenant-scoped routes. Creating parallel `/admin/{users,projects,orgs,audit}` endpoints would double the surface area without adding capability.
+
+**Locked decision:** extend the existing list endpoints to accept `?tenant=<slug|*>` when the caller is a `PlatformAdmin`. The distinguishing axis for cross-tenant reads is the query parameter, **not** the URL prefix.
+
+| Resource  | Route                | Migration target                            |
+|-----------|----------------------|---------------------------------------------|
+| Tenants   | `GET /admin/tenants` | Refactor to `list_scope` (already cross-tenant) |
+| Users     | `GET /user`          | Add `?tenant=<slug\|*>` via `list_scope`    |
+| Projects  | `GET /project`       | Add `?tenant=<slug\|*>` via `list_scope`    |
+| Orgs      | `GET /org`           | Add `?tenant=<slug\|*>` via `list_scope`    |
+| Audit     | `GET /govern/audit`  | Add `?tenant=<slug\|*>` via `list_scope`    |
+
+Backward compatibility: tenant-scoped calls (no `?tenant`, or `?tenant=<own-slug>`) return the existing response body unchanged. The new `scope` + `tenant` envelope is emitted **only** when `?tenant=*` is used.
+
 ## RLS interaction
 
 This change intentionally operates on **non-RLS tables**: `users`, `projects`, `orgs`, `tenants`, `referential_audit_log`, `governance_audit_log`. Those tables isolate tenants via application-level `WHERE tenant_id = ?` clauses only. Therefore the flat cross-tenant `SELECT ... FROM <table> ORDER BY (tenant_id, id)` design is valid.

--- a/openspec/changes/add-cross-tenant-admin-listing/tasks.md
+++ b/openspec/changes/add-cross-tenant-admin-listing/tasks.md
@@ -19,10 +19,10 @@
 ## 2. Handler migration (one commit per handler)
 
 - [ ] 2.1 `GET /admin/tenants` — replace local `require_platform_admin` with `RequestContext` + `list_scope`; default to `All` for backward compat (this endpoint was always cross-tenant).
-- [ ] 2.2 `GET /admin/users` — accept `?tenant=<slug|uuid|*>`; return `scope`+`tenant`+`items[]` envelope; decorate each item with `tenantId`+`tenantSlug` in `scope=all` mode.
-- [ ] 2.3 `GET /admin/projects` — same treatment.
-- [ ] 2.4 `GET /admin/orgs` — same treatment.
-- [ ] 2.5 `GET /admin/audit` — same treatment, plus ensure audit filters (`?actor`, `?since`) compose with `?tenant=*`.
+- [ ] 2.2 `GET /user` — accept `?tenant=<slug|uuid|*>`; return `scope`+`tenant`+`items[]` envelope **only when `scope=all`**, otherwise keep existing body (backward compat); decorate each item with `tenantId`+`tenantSlug` in `scope=all` mode.
+- [ ] 2.3 `GET /project` — same treatment.
+- [ ] 2.4 `GET /org` — same treatment.
+- [ ] 2.5 `GET /govern/audit` — same treatment, plus ensure audit filters (`?actor`, `?since`) compose with `?tenant=*`.
 - [ ] 2.6 Add `tenant_filter` param + new envelope to OpenAPI/Redoc schema for each of the 5.
 
 ## 3. Cross-tenant repository layer


### PR DESCRIPTION
Implements task **2.1** of the cross-tenant admin listing RFC, plus a small RFC amendment.

## Commits

**1. `RFC(#44.d): amend — target existing list routes, not parallel /admin/* paths`**

During implementation I discovered only `/admin/tenants` exists; the other four endpoints the RFC sketched (`/admin/{users,projects,orgs,audit}`) were aspirational. Users live at `/user`, projects at `/project`, orgs at `/org`, audit at `/govern/audit`. Creating parallel `/admin/*` routes would double the surface area with no capability gain.

**Locked decision:** the `?tenant=<slug|*>` query parameter is the distinguishing axis, not the URL prefix. The 5 migration targets are therefore `/admin/tenants`, `/user`, `/project`, `/org`, `/govern/audit`.

The new `scope+tenant` envelope is emitted **only when `?tenant=*`**; tenant-scoped calls keep their existing response body unchanged. See the amendment section of `openspec/changes/add-cross-tenant-admin-listing/proposal.md`.

**2. `feat(#44.d): migrate GET /admin/tenants to list_scope resolver`**

- Switches from the legacy `require_platform_admin(&state, &headers).await` (which required an `X-Tenant-ID` header even though this endpoint never consults it) to `request_context` + `require_platform_admin(&ctx)` from #44.b + #44.d§1.
- PlatformAdmins can now hit the endpoint without a selected tenant — that is the whole point of this migration.
- Response now includes `"scope": "all"` per the RFC envelope; existing `"tenants"` field stays for backward compat.
- Only the `GET` handler; `POST /admin/tenants` and per-tenant handlers are out of scope for this PR.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo check -p aeterna --tests` ✅
- Unit tests: `cargo test -p aeterna --lib server::context::` → 11/11 pass
- Runtime test: `cargo test -p aeterna --test server_runtime_test tenant_list_and_hierarchy_read_operations` → pass (augmented with `scope=all` assertion)

## Out of scope (follow-up PRs)

- `/user`, `/project`, `/org`, `/govern/audit` migrations (tasks 2.2–2.5) — each a separate PR for digestible review.
- OpenAPI/Redoc schema update (task 2.6) — lands with task 2.5.
- Integration tests for IO-bound `list_scope` paths (tasks 4+5) — after all 5 handlers are migrated.

## Refs

- Tracking: #44
- Parent feature: #44.d (RFC #56, merged)
- Section 1 resolver: #62 (merged)
- Tasks document: `openspec/changes/add-cross-tenant-admin-listing/tasks.md` §2.1