### PR TITLE
feat(#44.d): §2.2 — add ?tenant=* to GET /user

### DIFF
--- a/cli/src/server/user_api.rs
+++ b/cli/src/server/user_api.rs
@@ -20,6 +20,14 @@ struct UserListQuery {
     org: Option<String>,
     team: Option<String>,
     role: Option<String>,
+    /// `?tenant=` parameter (see #44.d RFC):
+    /// - omitted → tenant-scoped (backward compat, returns bare array)
+    /// - `*`     → cross-tenant (PlatformAdmin only, returns envelope)
+    /// - `all`   → deprecated alias for `*`
+    /// - `<slug>` → NotImplemented for now (deferred to PR #65)
+    tenant: Option<String>,
+    /// Retained for backward compatibility with pre-RFC experimental clients.
+    /// Not read; deprecated in favor of `?tenant=*`.
     #[allow(dead_code)]
     all: Option<bool>,
 }
@@ -287,6 +295,40 @@ async fn list_users(
     headers: HeaderMap,
     Query(query): Query<UserListQuery>,
 ) -> impl IntoResponse {
+    // #44.d — cross-tenant listing branch.
+    // The existing tenant-scoped path below is untouched when `?tenant` is
+    // absent, preserving pre-RFC response shape for every existing client.
+    if let Some(raw) = query.tenant.as_deref() {
+        let trimmed = raw.trim();
+        let is_all_star = trimmed == "*";
+        let is_all_alias = trimmed.eq_ignore_ascii_case("all");
+        if !is_all_star && !is_all_alias {
+            // `?tenant=<slug>` is part of the RFC but its wiring for /user
+            // is deferred to PR #65 so this change stays reviewable.
+            return error_response(
+                StatusCode::NOT_IMPLEMENTED,
+                "scope_not_implemented",
+                "?tenant=<slug> is not yet supported on /user; use ?tenant=* for cross-tenant listing or omit the parameter",
+            );
+        }
+        if is_all_alias {
+            tracing::warn!(
+                target: "compat",
+                param = "?tenant=all",
+                replacement = "?tenant=*",
+                "deprecated tenant scope alias — clients should migrate to ?tenant=*"
+            );
+        }
+        let req_ctx = match context::request_context(&state, &headers).await {
+            Ok(c) => c,
+            Err(r) => return r,
+        };
+        if !req_ctx.is_platform_admin {
+            return context::forbidden_scope_response("PlatformAdmin");
+        }
+        return list_users_cross_tenant(&state, &query).await;
+    }
+
     let ctx = match require_admin_context(&state, &headers).await {
         Ok(ctx) => ctx,
         Err(response) => return response,
@@ -420,6 +462,163 @@ async fn list_users(
     }
 
     Json(users).into_response()
+}
+
+/// Cross-tenant user listing (`?tenant=*`, PlatformAdmin only).
+///
+/// Returns one item per `(user, tenant)` pair for every tenant the user
+/// holds roles in. The same user can appear multiple times when they are
+/// members of multiple tenants — this is the intended "who has access
+/// where" semantics for platform admin views.
+///
+/// NOTE: roles are currently returned as `[]` in this mode. Proper per-
+/// tenant role aggregation is deferred to a follow-up (PR #66) to keep
+/// this change reviewable. Callers that need role data today should
+/// issue a tenant-scoped call per row.
+async fn list_users_cross_tenant(
+    state: &AppState,
+    query: &UserListQuery,
+) -> axum::response::Response {
+    let variant = match detect_user_table_variant(state).await {
+        Ok(variant) => variant,
+        Err(response) => return response,
+    };
+
+    // Filter application: each filter is scoped to the SAME tenant as the
+    // (user, tenant) row being considered — preserving the per-tenant
+    // meaning of `?org=&team=&role=` from the existing tenant-scoped path.
+    let rows = match variant {
+        UserTableVariant::Main => sqlx::query(
+            r"
+            SELECT DISTINCT
+                u.id::text         AS user_id,
+                u.email            AS email,
+                COALESCE(u.name, u.email) AS display_name,
+                u.status           AS status,
+                u.avatar_url       AS avatar_url,
+                u.settings         AS settings,
+                u.created_at       AS created_at,
+                u.updated_at       AS updated_at,
+                ur.tenant_id       AS tenant_id,
+                t.slug             AS tenant_slug,
+                t.name             AS tenant_name
+            FROM users u
+            INNER JOIN user_roles ur ON ur.user_id IN (u.id::text, u.email)
+            INNER JOIN tenants   t  ON t.id = ur.tenant_id
+            WHERE u.deleted_at IS NULL
+              AND ($1::text IS NULL OR EXISTS (
+                    SELECT 1 FROM user_roles ur2
+                    WHERE ur2.tenant_id = ur.tenant_id
+                      AND ur2.unit_id   = $1
+                      AND ur2.user_id IN (u.id::text, u.email)
+              ))
+              AND ($2::text IS NULL OR EXISTS (
+                    SELECT 1 FROM user_roles ur3
+                    WHERE ur3.tenant_id = ur.tenant_id
+                      AND ur3.unit_id   = $2
+                      AND ur3.user_id IN (u.id::text, u.email)
+              ))
+              AND ($3::text IS NULL OR EXISTS (
+                    SELECT 1 FROM user_roles ur4
+                    WHERE ur4.tenant_id      = ur.tenant_id
+                      AND lower(ur4.role)    = lower($3)
+                      AND ur4.user_id IN (u.id::text, u.email)
+              ))
+            ORDER BY ur.tenant_id, u.created_at DESC
+            ",
+        )
+        .bind(query.org.as_deref())
+        .bind(query.team.as_deref())
+        .bind(query.role.as_deref())
+        .fetch_all(state.postgres.pool())
+        .await,
+        UserTableVariant::IdpSync => sqlx::query(
+            r"
+            SELECT DISTINCT
+                u.id::text         AS user_id,
+                u.email            AS email,
+                COALESCE(u.display_name, NULLIF(CONCAT_WS(' ', u.first_name, u.last_name), ''), u.email) AS display_name,
+                CASE WHEN u.is_active THEN 'active' ELSE 'inactive' END AS status,
+                NULL::text         AS avatar_url,
+                '{}'::jsonb        AS settings,
+                u.created_at       AS created_at,
+                u.updated_at       AS updated_at,
+                ur.tenant_id       AS tenant_id,
+                t.slug             AS tenant_slug,
+                t.name             AS tenant_name
+            FROM users u
+            INNER JOIN user_roles ur ON ur.user_id IN (u.id::text, u.email)
+            INNER JOIN tenants   t  ON t.id = ur.tenant_id
+            WHERE TRUE
+              AND ($1::text IS NULL OR EXISTS (
+                    SELECT 1 FROM user_roles ur2
+                    WHERE ur2.tenant_id = ur.tenant_id
+                      AND ur2.unit_id   = $1
+                      AND ur2.user_id IN (u.id::text, u.email)
+              ))
+              AND ($2::text IS NULL OR EXISTS (
+                    SELECT 1 FROM user_roles ur3
+                    WHERE ur3.tenant_id = ur.tenant_id
+                      AND ur3.unit_id   = $2
+                      AND ur3.user_id IN (u.id::text, u.email)
+              ))
+              AND ($3::text IS NULL OR EXISTS (
+                    SELECT 1 FROM user_roles ur4
+                    WHERE ur4.tenant_id      = ur.tenant_id
+                      AND lower(ur4.role)    = lower($3)
+                      AND ur4.user_id IN (u.id::text, u.email)
+              ))
+            ORDER BY ur.tenant_id, u.created_at DESC
+            ",
+        )
+        .bind(query.org.as_deref())
+        .bind(query.team.as_deref())
+        .bind(query.role.as_deref())
+        .fetch_all(state.postgres.pool())
+        .await,
+    };
+
+    let rows = match rows {
+        Ok(rows) => rows,
+        Err(err) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "user_list_failed",
+                &err.to_string(),
+            );
+        }
+    };
+
+    let items: Vec<serde_json::Value> = rows
+        .into_iter()
+        .map(|row| {
+            json!({
+                "id":          row.get::<String, _>("user_id"),
+                "email":       row.get::<String, _>("email"),
+                "name":        row.get::<String, _>("display_name"),
+                "status":      row.get::<String, _>("status"),
+                "avatarUrl":   row.get::<Option<String>, _>("avatar_url"),
+                "settings":    row.get::<serde_json::Value, _>("settings"),
+                "createdAt":   row.get::<chrono::DateTime<chrono::Utc>, _>("created_at"),
+                "updatedAt":   row.get::<chrono::DateTime<chrono::Utc>, _>("updated_at"),
+                "tenantId":    row.get::<String, _>("tenant_id"),
+                "tenantSlug":  row.get::<String, _>("tenant_slug"),
+                "tenantName":  row.get::<String, _>("tenant_name"),
+                // See docstring: per-tenant role aggregation deferred to PR #66.
+                "roles":       Vec::<serde_json::Value>::new(),
+            })
+        })
+        .collect();
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "success": true,
+            "scope":   "all",
+            "items":   items,
+        })),
+    )
+        .into_response()
 }
 
 async fn show_user(

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -3745,3 +3745,108 @@ async fn govern_approve_reject_path_order() {
     assert_ne!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
     assert_ne!(resp.status(), StatusCode::NOT_FOUND);
 }
+
+/// #44.d §2.2 — GET /user with `?tenant=*` / `?tenant=all` / `?tenant=<slug>`:
+/// verifies the authorization and scope-resolution branches that fire
+/// BEFORE any database work. This test is schema-independent — it covers
+/// only the pre-DB gates and does not depend on which `users` table
+/// variant (Main / IdpSync / none) is present in the runtime fixture.
+#[tokio::test]
+async fn list_users_cross_tenant_scope_gates_and_aliases() {
+    let Some((state, _tmp)) = test_app_state().await else {
+        eprintln!("Skipping server runtime test: Docker not available");
+        return;
+    };
+    let app = router::build_router(state);
+
+    // Case 1: ?tenant=* as a non-admin → 403 forbidden_scope.
+    // This MUST fire before any users-table probe, independent of schema.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/user?tenant=*")
+                .header("x-user-id", "developer-user")
+                .header("x-user-role", "developer")
+                .header("x-tenant-id", "default")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["error"], "forbidden_scope");
+
+    // Case 2: ?tenant=<slug> as PlatformAdmin → 501 NotImplemented.
+    // This is the "deferred to PR #65" path; we want it to return a
+    // stable, discoverable error so clients know to use ?tenant=* today.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/user?tenant=acme")
+                .header("x-user-id", "platform-admin")
+                .header("x-user-role", "platform_admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["error"], "scope_not_implemented");
+
+    // Case 3: ?tenant=all (deprecated alias) → treated as `*` by
+    // PlatformAdmin: reaches the cross-tenant branch. With no users
+    // table in the fixture, this yields 503 user_schema_unsupported
+    // (same code path as the tenant-scoped baseline). The important
+    // assertion is "not 403/501" — the alias was accepted.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/user?tenant=all")
+                .header("x-user-id", "platform-admin")
+                .header("x-user-role", "platform_admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+    assert_ne!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    // Accepts either the cross-tenant success envelope OR the 503 that
+    // the existing `detect_user_table_variant` helper emits when the
+    // users table isn't provisioned — both prove the alias was
+    // accepted and PlatformAdmin was permitted.
+    let status = resp.status();
+    assert!(
+        status == StatusCode::OK || status == StatusCode::SERVICE_UNAVAILABLE,
+        "unexpected status for ?tenant=all PlatformAdmin: {status}"
+    );
+    if status == StatusCode::OK {
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["scope"], "all");
+        assert_eq!(body["success"], true);
+        assert!(body["items"].is_array());
+    }
+}

--- a/openspec/changes/add-cross-tenant-admin-listing/tasks.md
+++ b/openspec/changes/add-cross-tenant-admin-listing/tasks.md
@@ -18,8 +18,8 @@
 
 ## 2. Handler migration (one commit per handler)
 
-- [ ] 2.1 `GET /admin/tenants` — replace local `require_platform_admin` with `RequestContext` + `list_scope`; default to `All` for backward compat (this endpoint was always cross-tenant).
-- [ ] 2.2 `GET /user` — accept `?tenant=<slug|uuid|*>`; return `scope`+`tenant`+`items[]` envelope **only when `scope=all`**, otherwise keep existing body (backward compat); decorate each item with `tenantId`+`tenantSlug` in `scope=all` mode.
+- [x] 2.1 `GET /admin/tenants` — replace local `require_platform_admin` with `RequestContext` + `list_scope`; default to `All` for backward compat (this endpoint was always cross-tenant).
+- [~] 2.2 `GET /user` — accept `?tenant=<slug|uuid|*>`; return `scope`+`tenant`+`items[]` envelope **only when `scope=all`**, otherwise keep existing body (backward compat); decorate each item with `tenantId`+`tenantSlug` in `scope=all` mode. **Partial:** `?tenant=*` and `?tenant=all` (deprecated) implemented; `?tenant=<slug>` returns `501 scope_not_implemented` pending PR #65. Per-tenant role aggregation in All mode returns `[]` with TODO → PR #66.
 - [ ] 2.3 `GET /project` — same treatment.
 - [ ] 2.4 `GET /org` — same treatment.
 - [ ] 2.5 `GET /govern/audit` — same treatment, plus ensure audit filters (`?actor`, `?since`) compose with `?tenant=*`.


### PR DESCRIPTION
Implements the cross-tenant slice of RFC task **2.2** (GET /user).

## Behavior matrix

| `?tenant=`      | Role          | Result                                     |
|-----------------|---------------|--------------------------------------------|
| _(omitted)_     | Admin / Platform | **Unchanged** — existing bare-array body  |
| `*`             | PlatformAdmin | New cross-tenant query + `{success, scope:"all", items[]}` envelope |
| `all`           | PlatformAdmin | Same as `*`, logs deprecation warning     |
| `*`             | non-admin     | `403 forbidden_scope`                     |
| `<slug>`        | any           | `501 scope_not_implemented` (deferred to PR #65) |

The no-`?tenant` path is **100% unchanged** — zero risk for existing clients.

## Envelope shape

```json
{
  "success": true,
  "scope":   "all",
  "items": [
    { "id": "…", "email": "…", "name": "…", "status": "active",
      "avatarUrl": null, "settings": {}, "createdAt": "…", "updatedAt": "…",
      "tenantId": "…", "tenantSlug": "acme", "tenantName": "Acme Corp",
      "roles": [] }
  ]
}
```

One item per `(user, tenant)` pair — a user with roles in N tenants appears N times. Matches the intended "who has access where" semantics for platform admin views.

## SQL correctness

- `DISTINCT` dedupes `(user, tenant)` when a user has multiple roles in the same tenant
- `INNER JOIN user_roles`/`tenants` correctly excludes role-less users
- Existing `?org=&team=&role=` filters preserved and scoped per-tenant via `EXISTS` subqueries binding `ur2.tenant_id = ur.tenant_id`
- Both `UserTableVariant::Main` and `UserTableVariant::IdpSync` paths implemented
- Deterministic ordering: `ORDER BY ur.tenant_id, u.created_at DESC`

## Deliberate deferrals

- **Role aggregation in All mode** — currently returns `roles: []` with inline TODO. A proper per-tenant aggregation lands in **PR #66** alongside the remaining 4 endpoints so the shape is unified across `/project`, `/org`, `/govern/audit`.
- **`?tenant=<slug>`** (PlatformAdmin viewing a single foreign tenant) — deferred to **PR #65**. The `501` response is stable and documented.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo check -p aeterna --tests` ✅
- **New test** `list_users_cross_tenant_scope_gates_and_aliases` — exercises all 3 pre-DB branches; schema-independent so it runs regardless of which `users` table variant the fixture has:
  - `?tenant=*` + non-admin → `403 forbidden_scope`
  - `?tenant=<slug>` + admin → `501 scope_not_implemented`
  - `?tenant=all` + admin → reaches DB layer (200 or 503, not 403/501)
- Adjacent tests green: `tenant_admin_route_group_is_mounted_for_org_team_user_and_govern`, `user_roles_grant_revoke_and_unsupported_schema`

## Refs

- Tracking: #44
- RFC: #56 (merged)
- Section 1: #62 (merged) — `ListTenantScope` resolver used here
- Section 2.1: #63 (merged) — `/admin/tenants` migration + RFC path amendment
- Tasks doc: `openspec/changes/add-cross-tenant-admin-listing/tasks.md` §2.2