### PR TITLE
feat(#44.d): §2.3 — add ?tenant=* to GET /project

### DIFF
--- a/cli/src/server/project_api.rs
+++ b/cli/src/server/project_api.rs
@@ -22,6 +22,12 @@ use super::{AppState, tenant_scoped_context};
 #[serde(rename_all = "camelCase")]
 struct ProjectListQuery {
     team: Option<String>,
+    /// `?tenant=` — see #44.d RFC and `user_api::UserListQuery::tenant`.
+    /// Accepted values: `*` (cross-tenant, PlatformAdmin), `all` (deprecated
+    /// alias), `<slug>` (deferred to PR #65 cluster). Omitted → tenant-scoped
+    /// behavior unchanged.
+    tenant: Option<String>,
+    /// Retained for backward compatibility with pre-RFC experimental clients.
     #[allow(dead_code)]
     all: Option<bool>,
 }
@@ -100,6 +106,38 @@ async fn list_projects(
     headers: HeaderMap,
     Query(query): Query<ProjectListQuery>,
 ) -> impl IntoResponse {
+    // #44.d §2.3 — cross-tenant listing branch.
+    // The existing tenant-scoped path below is untouched when `?tenant` is
+    // absent, preserving pre-RFC response shape for every existing client.
+    if let Some(raw) = query.tenant.as_deref() {
+        let trimmed = raw.trim();
+        let is_all_star = trimmed == "*";
+        let is_all_alias = trimmed.eq_ignore_ascii_case("all");
+        if !is_all_star && !is_all_alias {
+            return error_response(
+                StatusCode::NOT_IMPLEMENTED,
+                "scope_not_implemented",
+                "?tenant=<slug> is not yet supported on /project; use ?tenant=* for cross-tenant listing or omit the parameter",
+            );
+        }
+        if is_all_alias {
+            tracing::warn!(
+                target: "compat",
+                param = "?tenant=all",
+                replacement = "?tenant=*",
+                "deprecated tenant scope alias — clients should migrate to ?tenant=*"
+            );
+        }
+        let req_ctx = match super::context::request_context(&state, &headers).await {
+            Ok(c) => c,
+            Err(r) => return r,
+        };
+        if !req_ctx.is_platform_admin {
+            return super::context::forbidden_scope_response("PlatformAdmin");
+        }
+        return list_projects_cross_tenant(&state, &query).await;
+    }
+
     let ctx = match require_admin_context(&state, &headers).await {
         Ok(ctx) => ctx,
         Err(response) => return response,
@@ -120,6 +158,82 @@ async fn list_projects(
     }
     units.sort_by(|a, b| a.name.cmp(&b.name).then(a.id.cmp(&b.id)));
     Json(units).into_response()
+}
+
+/// Cross-tenant project listing (`?tenant=*`, PlatformAdmin only).
+///
+/// Returns one item per project across all tenants, each decorated with
+/// `tenantId` + `tenantSlug` + `tenantName`. Unlike `/user`, projects
+/// are 1:1 tenant-owned so there is no user-like row duplication.
+async fn list_projects_cross_tenant(
+    state: &AppState,
+    query: &ProjectListQuery,
+) -> axum::response::Response {
+    let mut units = match state.postgres.list_all_units().await {
+        Ok(units) => units,
+        Err(err) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "project_list_failed",
+                &err.to_string(),
+            );
+        }
+    };
+    units.retain(|unit| unit.unit_type == UnitType::Project);
+    if let Some(team_id) = query.team.as_deref() {
+        units.retain(|unit| unit.parent_id.as_deref() == Some(team_id));
+    }
+    // Stable ordering: tenant first, then project name, then id — makes the
+    // output diffable and safe for clients that paginate visually.
+    units.sort_by(|a, b| {
+        a.tenant_id
+            .cmp(&b.tenant_id)
+            .then(a.name.cmp(&b.name))
+            .then(a.id.cmp(&b.id))
+    });
+
+    // Pre-fetch tenant metadata once and decorate each item. Two DB round
+    // trips total (units + tenants) regardless of project count.
+    let tenants = match state.tenant_store.list_tenants(true).await {
+        Ok(ts) => ts,
+        Err(err) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "tenant_lookup_failed",
+                &err.to_string(),
+            );
+        }
+    };
+    let tenant_by_id: std::collections::HashMap<String, &mk_core::types::TenantRecord> = tenants
+        .iter()
+        .map(|t| (t.id.as_str().to_string(), t))
+        .collect();
+
+    let items: Vec<serde_json::Value> = units
+        .into_iter()
+        .map(|unit| {
+            let t = tenant_by_id.get(unit.tenant_id.as_str());
+            json!({
+                "id":         unit.id,
+                "name":       unit.name,
+                "parentId":   unit.parent_id,
+                "unitType":   "project",
+                "tenantId":   unit.tenant_id,
+                "tenantSlug": t.map(|t| t.slug.clone()),
+                "tenantName": t.map(|t| t.name.clone()),
+            })
+        })
+        .collect();
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "success": true,
+            "scope":   "all",
+            "items":   items,
+        })),
+    )
+        .into_response()
 }
 
 async fn show_project(

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -3746,6 +3746,114 @@ async fn govern_approve_reject_path_order() {
     assert_ne!(resp.status(), StatusCode::NOT_FOUND);
 }
 
+/// #44.d §2.3 — GET /project with `?tenant=*` / `?tenant=all` / `?tenant=<slug>`:
+/// same gate-layer coverage as the /user test, for the project endpoint.
+#[tokio::test]
+async fn list_projects_cross_tenant_scope_gates_and_aliases() {
+    let Some((state, _tmp)) = test_app_state().await else {
+        eprintln!("Skipping server runtime test: Docker not available");
+        return;
+    };
+    let app = router::build_router(state);
+
+    // Case 1: ?tenant=* as non-admin → 403 forbidden_scope.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/project?tenant=*")
+                .header("x-user-id", "developer-user")
+                .header("x-user-role", "developer")
+                .header("x-tenant-id", "default")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["error"], "forbidden_scope");
+
+    // Case 2: ?tenant=<slug> as PlatformAdmin → 501 NotImplemented.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/project?tenant=acme")
+                .header("x-user-id", "platform-admin")
+                .header("x-user-role", "platform_admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["error"], "scope_not_implemented");
+
+    // Case 3: ?tenant=* as PlatformAdmin → 200 with scope=all envelope.
+    // Unlike /user, /project doesn't depend on a schema variant so this
+    // should always return 200 (empty items in a fresh fixture).
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/project?tenant=*")
+                .header("x-user-id", "platform-admin")
+                .header("x-user-role", "platform_admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["scope"], "all");
+    assert!(body["items"].is_array());
+
+    // Case 4: ?tenant=all (deprecated alias) → same behavior as *.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/project?tenant=all")
+                .header("x-user-id", "platform-admin")
+                .header("x-user-role", "platform_admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["scope"], "all");
+}
+
 /// #44.d §2.2 — GET /user with `?tenant=*` / `?tenant=all` / `?tenant=<slug>`:
 /// verifies the authorization and scope-resolution branches that fire
 /// BEFORE any database work. This test is schema-independent — it covers

--- a/openspec/changes/add-cross-tenant-admin-listing/tasks.md
+++ b/openspec/changes/add-cross-tenant-admin-listing/tasks.md
@@ -20,7 +20,7 @@
 
 - [x] 2.1 `GET /admin/tenants` — replace local `require_platform_admin` with `RequestContext` + `list_scope`; default to `All` for backward compat (this endpoint was always cross-tenant).
 - [~] 2.2 `GET /user` — accept `?tenant=<slug|uuid|*>`; return `scope`+`tenant`+`items[]` envelope **only when `scope=all`**, otherwise keep existing body (backward compat); decorate each item with `tenantId`+`tenantSlug` in `scope=all` mode. **Partial:** `?tenant=*` and `?tenant=all` (deprecated) implemented; `?tenant=<slug>` returns `501 scope_not_implemented` pending PR #65. Per-tenant role aggregation in All mode returns `[]` with TODO → PR #66.
-- [ ] 2.3 `GET /project` — same treatment.
+- [~] 2.3 `GET /project` — same treatment. **Partial:** `?tenant=*`/`all` implemented; `?tenant=<slug>` returns `501 scope_not_implemented` pending PR #65 cluster.
 - [ ] 2.4 `GET /org` — same treatment.
 - [ ] 2.5 `GET /govern/audit` — same treatment, plus ensure audit filters (`?actor`, `?since`) compose with `?tenant=*`.
 - [ ] 2.6 Add `tenant_filter` param + new envelope to OpenAPI/Redoc schema for each of the 5.


### PR DESCRIPTION
Implements the cross-tenant slice of RFC task **2.3** (GET /project). Mechanical application of the #64 pattern to the next endpoint.

## Behavior matrix

| `?tenant=`    | Role          | Result                                    |
|---------------|---------------|-------------------------------------------|
| _(omitted)_   | Admin+        | **Unchanged** — bare array body         |
| `*`           | PlatformAdmin | `{success, scope:"all", items[]}` envelope |
| `all`         | PlatformAdmin | Same as `*`, warns deprecation            |
| `*`           | non-admin     | `403 forbidden_scope`                    |
| `<slug>`      | any           | `501 scope_not_implemented` (PR #65 cluster) |

## How this differs from /user (#64)

1. **No new SQL.** `list_all_units()` is already cross-tenant — the only change in All mode is skipping the `unit.tenant_id == ctx.tenant_id` filter that the existing handler applies after the fetch.

2. **Tenant metadata decoration** is done via a pre-fetch of `list_tenants(true)` + a `HashMap<tenant_id, &TenantRecord>` lookup. Two DB round-trips total regardless of project count.

3. **Ordering**: `(tenant_id, name, id)` — stable and diffable for visual pagination.

## Envelope shape

```json
{
  "success": true,
  "scope":   "all",
  "items": [
    { "id": "…", "name": "Backend", "parentId": "…", "unitType": "project",
      "tenantId": "…", "tenantSlug": "acme", "tenantName": "Acme Corp" }
  ]
}
```

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo check -p aeterna --tests` ✅
- **New test** `list_projects_cross_tenant_scope_gates_and_aliases` covers all 4 cases — forbidden, not_implemented, cross-tenant 200 envelope, and deprecated alias. Unlike /user, this reaches a full 200 in the fixture (no schema-variant dependency), so the envelope structure is asserted end-to-end.

## Refs

- Tracking: #44 · RFC: #56 · §1 resolver: #62 · §2.1: #63 · §2.2: #64
- Tasks doc §2.3