### PR TITLE
feat(#44.d): extract cross-tenant gate helper + §2.4 (/org)

### DIFF
--- a/cli/src/server/context.rs
+++ b/cli/src/server/context.rs
@@ -252,6 +252,96 @@ pub fn forbidden_scope_response(required_role: &str) -> Response {
     (StatusCode::FORBIDDEN, axum::Json(body)).into_response()
 }
 
+// ---------------------------------------------------------------------------
+// #44.d — cross-tenant listing dispatch helper
+// ---------------------------------------------------------------------------
+
+/// Three-way outcome of resolving `?tenant=` on a list endpoint.
+///
+/// Each list handler that supports `?tenant=` (see #44.d RFC) uses
+/// [`resolve_list_scope`] to classify the request into one of these:
+///
+/// - [`ListDispatch::TenantScoped`] — no `?tenant` param; caller should
+///   run its existing tenant-scoped logic unchanged (preserves backward
+///   compatibility bit-for-bit).
+/// - [`ListDispatch::CrossTenant`] — `?tenant=*` or the deprecated alias
+///   `?tenant=all` by a PlatformAdmin; caller should dispatch to its
+///   cross-tenant list function which emits the scope-envelope body.
+/// - [`ListDispatch::Response`] — authorization or input error; caller
+///   returns the response verbatim.
+///
+/// This helper was extracted after a third near-identical copy of the
+/// same gate block appeared (user_api, project_api, then org_api). It
+/// prevents drift (trim, case-fold, deprecation warning, error message
+/// formatting) across endpoints.
+pub enum ListDispatch {
+    TenantScoped,
+    CrossTenant,
+    Response(Response),
+}
+
+/// Resolve a `?tenant=` query parameter for a list endpoint.
+///
+/// Grammar (see RFC):
+///
+/// - absent               → [`ListDispatch::TenantScoped`]
+/// - `*`                  → [`ListDispatch::CrossTenant`] (PlatformAdmin
+///                          required; otherwise `403 forbidden_scope`)
+/// - `all` (case-insensitive) → deprecated alias for `*`; logs a compat
+///                          warning and resolves identically
+/// - anything else        → `501 scope_not_implemented` (wiring for
+///                          `?tenant=<slug>` is deferred to a later PR
+///                          cluster; the 501 is a stable, documented
+///                          response that clients can detect)
+///
+/// `endpoint_label` is surfaced in the 501 body to help clients discover
+/// which endpoint they hit (e.g. `"/user"`, `"/project"`, `"/org"`).
+pub async fn resolve_list_scope(
+    state: &AppState,
+    headers: &HeaderMap,
+    raw_tenant_param: Option<&str>,
+    endpoint_label: &str,
+) -> ListDispatch {
+    let Some(raw) = raw_tenant_param else {
+        return ListDispatch::TenantScoped;
+    };
+    let trimmed = raw.trim();
+    // Empty string is treated like the absent case — defensive for clients
+    // that send `?tenant=` with no value (e.g. optional-form-field clients).
+    if trimmed.is_empty() {
+        return ListDispatch::TenantScoped;
+    }
+    let is_all_star = trimmed == "*";
+    let is_all_alias = trimmed.eq_ignore_ascii_case("all");
+    if !is_all_star && !is_all_alias {
+        return ListDispatch::Response(error_response(
+            StatusCode::NOT_IMPLEMENTED,
+            "scope_not_implemented",
+            &format!(
+                "?tenant=<slug> is not yet supported on {endpoint_label}; use ?tenant=* for cross-tenant listing or omit the parameter"
+            ),
+            None,
+        ));
+    }
+    if is_all_alias {
+        tracing::warn!(
+            target: "compat",
+            param = "?tenant=all",
+            replacement = "?tenant=*",
+            endpoint = endpoint_label,
+            "deprecated tenant scope alias — clients should migrate to ?tenant=*"
+        );
+    }
+    let req_ctx = match request_context(state, headers).await {
+        Ok(c) => c,
+        Err(r) => return ListDispatch::Response(r),
+    };
+    if !req_ctx.is_platform_admin {
+        return ListDispatch::Response(forbidden_scope_response("PlatformAdmin"));
+    }
+    ListDispatch::CrossTenant
+}
+
 /// Returns `Ok(())` when the caller is a PlatformAdmin, `403 forbidden` otherwise.
 ///
 /// Unlike the legacy `tenant_scoped_context`-based check, this function has

--- a/cli/src/server/org_api.rs
+++ b/cli/src/server/org_api.rs
@@ -22,6 +22,9 @@ use super::{AppState, tenant_scoped_context};
 #[serde(rename_all = "camelCase")]
 struct OrgListQuery {
     company: Option<String>,
+    /// `?tenant=` — see #44.d RFC. Accepts `*` / `all` / `<slug>`.
+    tenant: Option<String>,
+    /// Retained for backward compatibility with pre-RFC experimental clients.
     #[allow(dead_code)]
     all: Option<bool>,
 }
@@ -69,6 +72,21 @@ async fn list_orgs(
     headers: HeaderMap,
     Query(query): Query<OrgListQuery>,
 ) -> impl IntoResponse {
+    // #44.d §2.4 — cross-tenant listing dispatch.
+    // Historical note: this handler already had half-baked cross-tenant
+    // behavior — PlatformAdmins received all-tenant rows in the bare-array
+    // body when ?tenant was absent. That behavior is preserved for
+    // backward compat; the new `?tenant=*` path adds the RFC envelope.
+    match super::context::resolve_list_scope(&state, &headers, query.tenant.as_deref(), "/org")
+        .await
+    {
+        super::context::ListDispatch::TenantScoped => { /* fall through */ }
+        super::context::ListDispatch::CrossTenant => {
+            return list_orgs_cross_tenant(&state, &query).await;
+        }
+        super::context::ListDispatch::Response(r) => return r,
+    }
+
     let ctx = match require_admin_context(&state, &headers).await {
         Ok(ctx) => ctx,
         Err(response) => return response,
@@ -89,6 +107,74 @@ async fn list_orgs(
     }
     units.sort_by(|a, b| a.name.cmp(&b.name).then(a.id.cmp(&b.id)));
     Json(units).into_response()
+}
+
+/// Cross-tenant organization listing (`?tenant=*`, PlatformAdmin only).
+///
+/// Same shape as `/project` in scope=all mode — one item per org across
+/// all tenants, each decorated with `tenantId` + `tenantSlug` + `tenantName`.
+async fn list_orgs_cross_tenant(
+    state: &AppState,
+    query: &OrgListQuery,
+) -> axum::response::Response {
+    let mut units = match state.postgres.list_all_units().await {
+        Ok(units) => units,
+        Err(err) => {
+            return error_response(StatusCode::BAD_REQUEST, "org_list_failed", &err.to_string());
+        }
+    };
+    units.retain(|unit| unit.unit_type == UnitType::Organization);
+    if let Some(company_id) = query.company.as_deref() {
+        units.retain(|unit| unit.parent_id.as_deref() == Some(company_id));
+    }
+    // Stable ordering: tenant first, then org name, then id.
+    units.sort_by(|a, b| {
+        a.tenant_id
+            .cmp(&b.tenant_id)
+            .then(a.name.cmp(&b.name))
+            .then(a.id.cmp(&b.id))
+    });
+
+    let tenants = match state.tenant_store.list_tenants(true).await {
+        Ok(ts) => ts,
+        Err(err) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "tenant_lookup_failed",
+                &err.to_string(),
+            );
+        }
+    };
+    let tenant_by_id: std::collections::HashMap<String, &mk_core::types::TenantRecord> = tenants
+        .iter()
+        .map(|t| (t.id.as_str().to_string(), t))
+        .collect();
+
+    let items: Vec<serde_json::Value> = units
+        .into_iter()
+        .map(|unit| {
+            let t = tenant_by_id.get(unit.tenant_id.as_str());
+            json!({
+                "id":         unit.id,
+                "name":       unit.name,
+                "parentId":   unit.parent_id,
+                "unitType":   "organization",
+                "tenantId":   unit.tenant_id,
+                "tenantSlug": t.map(|t| t.slug.clone()),
+                "tenantName": t.map(|t| t.name.clone()),
+            })
+        })
+        .collect();
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "success": true,
+            "scope":   "all",
+            "items":   items,
+        })),
+    )
+        .into_response()
 }
 
 async fn show_org(

--- a/cli/src/server/project_api.rs
+++ b/cli/src/server/project_api.rs
@@ -106,36 +106,15 @@ async fn list_projects(
     headers: HeaderMap,
     Query(query): Query<ProjectListQuery>,
 ) -> impl IntoResponse {
-    // #44.d §2.3 — cross-tenant listing branch.
-    // The existing tenant-scoped path below is untouched when `?tenant` is
-    // absent, preserving pre-RFC response shape for every existing client.
-    if let Some(raw) = query.tenant.as_deref() {
-        let trimmed = raw.trim();
-        let is_all_star = trimmed == "*";
-        let is_all_alias = trimmed.eq_ignore_ascii_case("all");
-        if !is_all_star && !is_all_alias {
-            return error_response(
-                StatusCode::NOT_IMPLEMENTED,
-                "scope_not_implemented",
-                "?tenant=<slug> is not yet supported on /project; use ?tenant=* for cross-tenant listing or omit the parameter",
-            );
+    // #44.d §2.3 — cross-tenant listing dispatch via shared helper.
+    match super::context::resolve_list_scope(&state, &headers, query.tenant.as_deref(), "/project")
+        .await
+    {
+        super::context::ListDispatch::TenantScoped => { /* fall through */ }
+        super::context::ListDispatch::CrossTenant => {
+            return list_projects_cross_tenant(&state, &query).await;
         }
-        if is_all_alias {
-            tracing::warn!(
-                target: "compat",
-                param = "?tenant=all",
-                replacement = "?tenant=*",
-                "deprecated tenant scope alias — clients should migrate to ?tenant=*"
-            );
-        }
-        let req_ctx = match super::context::request_context(&state, &headers).await {
-            Ok(c) => c,
-            Err(r) => return r,
-        };
-        if !req_ctx.is_platform_admin {
-            return super::context::forbidden_scope_response("PlatformAdmin");
-        }
-        return list_projects_cross_tenant(&state, &query).await;
+        super::context::ListDispatch::Response(r) => return r,
     }
 
     let ctx = match require_admin_context(&state, &headers).await {

--- a/cli/src/server/user_api.rs
+++ b/cli/src/server/user_api.rs
@@ -295,38 +295,14 @@ async fn list_users(
     headers: HeaderMap,
     Query(query): Query<UserListQuery>,
 ) -> impl IntoResponse {
-    // #44.d — cross-tenant listing branch.
-    // The existing tenant-scoped path below is untouched when `?tenant` is
-    // absent, preserving pre-RFC response shape for every existing client.
-    if let Some(raw) = query.tenant.as_deref() {
-        let trimmed = raw.trim();
-        let is_all_star = trimmed == "*";
-        let is_all_alias = trimmed.eq_ignore_ascii_case("all");
-        if !is_all_star && !is_all_alias {
-            // `?tenant=<slug>` is part of the RFC but its wiring for /user
-            // is deferred to PR #65 so this change stays reviewable.
-            return error_response(
-                StatusCode::NOT_IMPLEMENTED,
-                "scope_not_implemented",
-                "?tenant=<slug> is not yet supported on /user; use ?tenant=* for cross-tenant listing or omit the parameter",
-            );
+    // #44.d — cross-tenant listing dispatch via shared helper.
+    // See `context::resolve_list_scope` for the gate semantics.
+    match context::resolve_list_scope(&state, &headers, query.tenant.as_deref(), "/user").await {
+        context::ListDispatch::TenantScoped => { /* fall through */ }
+        context::ListDispatch::CrossTenant => {
+            return list_users_cross_tenant(&state, &query).await;
         }
-        if is_all_alias {
-            tracing::warn!(
-                target: "compat",
-                param = "?tenant=all",
-                replacement = "?tenant=*",
-                "deprecated tenant scope alias — clients should migrate to ?tenant=*"
-            );
-        }
-        let req_ctx = match context::request_context(&state, &headers).await {
-            Ok(c) => c,
-            Err(r) => return r,
-        };
-        if !req_ctx.is_platform_admin {
-            return context::forbidden_scope_response("PlatformAdmin");
-        }
-        return list_users_cross_tenant(&state, &query).await;
+        context::ListDispatch::Response(r) => return r,
     }
 
     let ctx = match require_admin_context(&state, &headers).await {

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -3746,6 +3746,126 @@ async fn govern_approve_reject_path_order() {
     assert_ne!(resp.status(), StatusCode::NOT_FOUND);
 }
 
+/// #44.d §2.4 — GET /org with `?tenant=*` / `?tenant=all` / `?tenant=<slug>`:
+/// same gate-layer + full-envelope coverage as /project.
+#[tokio::test]
+async fn list_orgs_cross_tenant_scope_gates_and_aliases() {
+    let Some((state, _tmp)) = test_app_state().await else {
+        eprintln!("Skipping server runtime test: Docker not available");
+        return;
+    };
+    let app = router::build_router(state);
+
+    // Case 1: ?tenant=* as non-admin → 403 forbidden_scope.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/org?tenant=*")
+                .header("x-user-id", "developer-user")
+                .header("x-user-role", "developer")
+                .header("x-tenant-id", "default")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["error"], "forbidden_scope");
+
+    // Case 2: ?tenant=<slug> as PlatformAdmin → 501 NotImplemented,
+    // and the error message mentions /org so clients know which endpoint.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/org?tenant=acme")
+                .header("x-user-id", "platform-admin")
+                .header("x-user-role", "platform_admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["error"], "scope_not_implemented");
+    assert!(
+        body["message"].as_str().unwrap_or("").contains("/org"),
+        "501 body should mention the endpoint path, got: {}",
+        body["message"]
+    );
+
+    // Case 3: ?tenant=* as PlatformAdmin → 200 with scope=all envelope.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/org?tenant=*")
+                .header("x-user-id", "platform-admin")
+                .header("x-user-role", "platform_admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["scope"], "all");
+    assert!(body["items"].is_array());
+
+    // Case 4: ?tenant= (empty) → treated as absent (tenant-scoped path),
+    // defensive for clients sending unfilled form fields. Should NOT 501.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/org?tenant=")
+                .header("x-user-id", "admin-user")
+                .header("x-user-role", "admin")
+                .header("x-tenant-id", "default")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    // Admin in a tenant-scoped /org call returns a bare array (legacy shape).
+    if resp.status() == StatusCode::OK {
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            body.is_array(),
+            "empty ?tenant= must yield legacy bare-array body"
+        );
+    }
+}
+
 /// #44.d §2.3 — GET /project with `?tenant=*` / `?tenant=all` / `?tenant=<slug>`:
 /// same gate-layer coverage as the /user test, for the project endpoint.
 #[tokio::test]

--- a/openspec/changes/add-cross-tenant-admin-listing/tasks.md
+++ b/openspec/changes/add-cross-tenant-admin-listing/tasks.md
@@ -21,7 +21,7 @@
 - [x] 2.1 `GET /admin/tenants` — replace local `require_platform_admin` with `RequestContext` + `list_scope`; default to `All` for backward compat (this endpoint was always cross-tenant).
 - [~] 2.2 `GET /user` — accept `?tenant=<slug|uuid|*>`; return `scope`+`tenant`+`items[]` envelope **only when `scope=all`**, otherwise keep existing body (backward compat); decorate each item with `tenantId`+`tenantSlug` in `scope=all` mode. **Partial:** `?tenant=*` and `?tenant=all` (deprecated) implemented; `?tenant=<slug>` returns `501 scope_not_implemented` pending PR #65. Per-tenant role aggregation in All mode returns `[]` with TODO → PR #66.
 - [~] 2.3 `GET /project` — same treatment. **Partial:** `?tenant=*`/`all` implemented; `?tenant=<slug>` returns `501 scope_not_implemented` pending PR #65 cluster.
-- [ ] 2.4 `GET /org` — same treatment.
+- [~] 2.4 `GET /org` — same treatment. **Partial:** `?tenant=*`/`all` implemented; `?tenant=<slug>` returns `501 scope_not_implemented` pending PR #65 cluster.
 - [ ] 2.5 `GET /govern/audit` — same treatment, plus ensure audit filters (`?actor`, `?since`) compose with `?tenant=*`.
 - [ ] 2.6 Add `tenant_filter` param + new envelope to OpenAPI/Redoc schema for each of the 5.
 


### PR DESCRIPTION
Two changes in one PR, both required together to keep the refactor reviewable against a real second caller.

## Change 1 — extract `context::resolve_list_scope` + `ListDispatch`

The pre-DB gate block (parse `?tenant`, handle `*` / `all` / `<slug>`, emit deprecation warning, check `is_platform_admin`) had been duplicated verbatim in `user_api` and `project_api`. A third copy in `org_api` would have made drift inevitable (one endpoint forgets to trim, another forgets the deprecation warning, etc.).

The helper is a pure three-way dispatcher:

```rust
pub enum ListDispatch {
    TenantScoped,         // caller runs existing logic unchanged
    CrossTenant,          // caller dispatches to its list_X_cross_tenant fn
    Response(Response),   // caller returns r verbatim (403 / 501)
}

pub async fn resolve_list_scope(
    state: &AppState, headers: &HeaderMap,
    raw_tenant_param: Option<&str>, endpoint_label: &str,
) -> ListDispatch { … }
```

**Call sites in `user_api` and `project_api` refactored** — the existing tests (`list_users_cross_tenant_scope_gates_and_aliases`, `list_projects_cross_tenant_scope_gates_and_aliases`) remain green without modification, proving the extraction is behavior-preserving.

**Bonus fix:** the helper treats empty-string `?tenant=` as the absent case, defensive against clients that send unfilled form fields. Previously these would fall through to the 501 path.

## Change 2 — apply to `GET /org` (task 2.4)

Behavior matrix matches `/user` and `/project`.

**Historical note worth calling out**: `/org` already had half-baked cross-tenant behavior — PlatformAdmins received all-tenant rows in the bare-array body when `?tenant` was absent. **That behavior is PRESERVED for backward compat** (the tenant-scoped branch is untouched); the new `?tenant=*` path adds the proper RFC envelope on top of it. Any existing client that relied on the implicit all-tenant view continues to work.

`list_orgs_cross_tenant` reuses the same shape as `list_projects_cross_tenant`: filter to `Organization`, optional `company-id` filter, stable ordering `(tenant, name, id)`, one tenant pre-fetch + `HashMap` decoration.

## Tests

```
running 3 tests
test list_orgs_cross_tenant_scope_gates_and_aliases     … ok
test list_users_cross_tenant_scope_gates_and_aliases    … ok   (unchanged, proves refactor)
test list_projects_cross_tenant_scope_gates_and_aliases … ok   (unchanged, proves refactor)
```

New `list_orgs_cross_tenant_scope_gates_and_aliases` covers:

1. `?tenant=*` + non-admin → `403 forbidden_scope`
2. `?tenant=<slug>` + admin → `501 scope_not_implemented` **and asserts the error message mentions `/org`** (new: the endpoint_label param is surfaced to clients)
3. `?tenant=*` + PlatformAdmin → `200` with `{success, scope:"all", items[]}`
4. `?tenant=` (empty) → treated as absent, returns legacy bare-array body

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo check -p aeterna --tests` ✅
- `cargo clippy -p aeterna --tests` — no new warnings on touched code

## Refs

- Tracking: #44 · RFC: #56 · §1: #62 · §2.1: #63 · §2.2: #64 · §2.3: #65
- Tasks doc §2.4

## What\s next

PR #67 will apply the same helper to `/govern/audit` (§2.5). That endpoint has additional complexity (`?actor=`, `?since=` filters that must compose with `?tenant=*`), which is why it\s held back from this PR.