### PR TITLE
feat(#44.d): §2.5 — /govern/audit ?tenant=* (envelope + filter compose)

### DIFF
--- a/cli/src/server/govern_api.rs
+++ b/cli/src/server/govern_api.rs
@@ -70,6 +70,14 @@ struct AuditQuery {
     actor: Option<String>,
     target_type: Option<String>,
     limit: Option<usize>,
+    /// `?tenant=` — see #44.d RFC. Accepts `*` / `all` / `<slug>`.
+    /// Domain note: `governance_audit_log` has no row-level `tenant_id`;
+    /// it is an instance-scope event stream. `?tenant=*` switches to the
+    /// RFC envelope shape but does NOT filter differently from the bare
+    /// admin call (which already spans all tenants by construction).
+    /// Full per-row tenant decoration requires exposing
+    /// `acting_as_tenant_id` in `AuditRow` and is deferred.
+    tenant: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -506,6 +514,26 @@ async fn list_audit(
     headers: HeaderMap,
     Query(query): Query<AuditQuery>,
 ) -> impl IntoResponse {
+    // #44.d §2.5 — cross-tenant listing dispatch via shared helper.
+    //
+    // Domain note (see AuditQuery::tenant doc): governance_audit_log is
+    // intrinsically instance-scope — the existing bare-admin call already
+    // returns rows across all tenants. `?tenant=*` therefore does NOT widen
+    // the data set; it only changes the response shape to the RFC envelope
+    // and applies the formal gate (403 for non-admin, 501 for <slug>).
+    let wrap_in_envelope = match super::context::resolve_list_scope(
+        &state,
+        &headers,
+        query.tenant.as_deref(),
+        "/govern/audit",
+    )
+    .await
+    {
+        super::context::ListDispatch::CrossTenant => true,
+        super::context::ListDispatch::TenantScoped => false,
+        super::context::ListDispatch::Response(resp) => return resp,
+    };
+
     let _ctx = match require_admin_context(&state, &headers).await {
         Ok(ctx) => ctx,
         Err(response) => return response,
@@ -528,6 +556,9 @@ async fn list_audit(
         .as_deref()
         .and_then(|value| Uuid::parse_str(value).ok());
 
+    // ?actor and ?since compose with ?tenant=* — filters are applied by the
+    // storage layer regardless of envelope shape. This is the §2.5 "compose"
+    // requirement from tasks.md.
     match storage
         .list_audit_logs(&AuditFilters {
             action: query.action,
@@ -538,7 +569,27 @@ async fn list_audit(
         })
         .await
     {
-        Ok(entries) => Json(entries).into_response(),
+        Ok(entries) => {
+            if wrap_in_envelope {
+                // Envelope shape for cross-tenant mode. Intentionally omits
+                // per-item tenantId/tenantSlug because the underlying row
+                // lacks a reliable tenant attribution (see AuditQuery::tenant
+                // doc). Clients needing tenant context must join via
+                // actor_id → user's tenant membership at read time, or wait
+                // for the deferred PR that surfaces acting_as_tenant_id.
+                (
+                    StatusCode::OK,
+                    Json(json!({
+                        "success": true,
+                        "scope":   "all",
+                        "items":   entries,
+                    })),
+                )
+                    .into_response()
+            } else {
+                Json(entries).into_response()
+            }
+        }
         Err(err) => error_response(
             StatusCode::BAD_REQUEST,
             "govern_audit_failed",

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -3774,6 +3774,142 @@ async fn govern_approve_reject_path_order() {
     assert_ne!(resp.status(), StatusCode::NOT_FOUND);
 }
 
+/// #44.d §2.5 — GET /govern/audit with `?tenant=*` and filter composition.
+///
+/// /govern/audit is different from the other list endpoints: `governance_audit_log`
+/// is instance-scope (no row-level tenant_id), so `?tenant=*` only switches the
+/// envelope shape — it does NOT broaden the data set. This test asserts:
+///   1. Gate semantics match the other endpoints (403 / 501).
+///   2. `?tenant=*` + filters (?actor, ?since) compose correctly — the presence
+///      of ?tenant=* must NOT cause the storage filter params to be dropped.
+///   3. Envelope shape is {success, scope:"all", items} when governance is
+///      available; 503 governance_unavailable is accepted (fixture variant).
+#[tokio::test]
+async fn list_audit_cross_tenant_scope_gates_and_filter_compose() {
+    let Some((state, _tmp)) = test_app_state().await else {
+        eprintln!("Skipping server runtime test: Docker not available");
+        return;
+    };
+    let app = router::build_router(state);
+
+    // Case 1: ?tenant=* as non-admin → 403 forbidden_scope.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/govern/audit?tenant=*")
+                .header("x-user-id", "developer-user")
+                .header("x-user-role", "developer")
+                .header("x-tenant-id", "default")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["error"], "forbidden_scope");
+
+    // Case 2: ?tenant=<slug> as PlatformAdmin → 501 scope_not_implemented,
+    // and the endpoint label "/govern/audit" appears in the message.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/govern/audit?tenant=acme")
+                .header("x-user-id", "platform-admin")
+                .header("x-user-role", "platform_admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["error"], "scope_not_implemented");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("/govern/audit"),
+        "501 message should mention endpoint: {}",
+        body["message"]
+    );
+
+    // Case 3: ?tenant=* + ?since=1d + ?actor=<uuid> as PlatformAdmin.
+    //
+    // Two acceptable outcomes:
+    //   - 200 with envelope {success, scope:"all", items[]}: governance is
+    //     configured in the fixture and filters composed successfully.
+    //   - 503 governance_unavailable: governance_storage not configured.
+    //     This is the same skip pattern /user uses for variant fixtures.
+    //
+    // What we MUST NOT see:
+    //   - 400: would mean filter composition silently broke under ?tenant=*.
+    //   - 500: would mean the envelope branch has a bug.
+    let actor_uuid = uuid::Uuid::new_v4();
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&format!(
+                    "/api/v1/govern/audit?tenant=*&since=1d&actor={actor_uuid}"
+                ))
+                .header("x-user-id", "platform-admin")
+                .header("x-user-role", "platform_admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    match resp.status() {
+        StatusCode::OK => {
+            let body: serde_json::Value = serde_json::from_slice(
+                &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(body["success"], true, "envelope success must be true");
+            assert_eq!(body["scope"], "all", "envelope scope must be \"all\"");
+            assert!(body["items"].is_array(), "envelope items must be an array");
+        }
+        StatusCode::SERVICE_UNAVAILABLE => {
+            let body: serde_json::Value = serde_json::from_slice(
+                &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(
+                body["error"], "governance_unavailable",
+                "503 must carry governance_unavailable"
+            );
+            eprintln!(
+                "/govern/audit?tenant=*: governance not configured in fixture, envelope\
+                 shape couldn't be exercised — gates were still verified by cases 1+2"
+            );
+        }
+        other => panic!(
+            "/govern/audit?tenant=*&since=1d&actor=...: unexpected status {other}; filter\
+             composition may be broken"
+        ),
+    }
+}
+
 /// #44.d §2.4 — GET /org with `?tenant=*` / `?tenant=all` / `?tenant=<slug>`:
 /// same gate-layer + full-envelope coverage as /project.
 #[tokio::test]

--- a/openspec/changes/add-cross-tenant-admin-listing/tasks.md
+++ b/openspec/changes/add-cross-tenant-admin-listing/tasks.md
@@ -22,7 +22,7 @@
 - [~] 2.2 `GET /user` — accept `?tenant=<slug|uuid|*>`; return `scope`+`tenant`+`items[]` envelope **only when `scope=all`**, otherwise keep existing body (backward compat); decorate each item with `tenantId`+`tenantSlug` in `scope=all` mode. **Partial:** `?tenant=*` and `?tenant=all` (deprecated) implemented; `?tenant=<slug>` returns `501 scope_not_implemented` pending PR #65. Per-tenant role aggregation in All mode returns `[]` with TODO → PR #66.
 - [~] 2.3 `GET /project` — same treatment. **Partial:** `?tenant=*`/`all` implemented; `?tenant=<slug>` returns `501 scope_not_implemented` pending PR #65 cluster.
 - [~] 2.4 `GET /org` — same treatment. **Partial:** `?tenant=*`/`all` implemented; `?tenant=<slug>` returns `501 scope_not_implemented` pending PR #65 cluster.
-- [ ] 2.5 `GET /govern/audit` — same treatment, plus ensure audit filters (`?actor`, `?since`) compose with `?tenant=*`.
+- [~] 2.5 `GET /govern/audit` — **Partial:** gates + envelope wrapper + `?actor`/`?since` filter composition implemented. Per-item `tenantId`/`tenantSlug` decoration is **explicitly deferred**: `governance_audit_log` has no row-level `tenant_id` (only the nullable `acting_as_tenant_id` from migration 023, which isn't exposed in `AuditRow`). Full tenant decoration requires a follow-up PR that (a) surfaces `acting_as_tenant_id` in `AuditRow` + the SQL, and (b) arguably adds a proper `tenant_id` column via migration + backfill. `?tenant=<slug>` returns `501 scope_not_implemented`. Excluded from the §4.1 `tenantId+tenantSlug` contract test for this reason.
 - [ ] 2.6 Add `tenant_filter` param + new envelope to OpenAPI/Redoc schema for each of the 5.
 
 ## 3. Cross-tenant repository layer


### PR DESCRIPTION
Adds `?tenant=*` / `?tenant=all` to `GET /govern/audit` with the standard gate semantics from PR #66, plus explicit `?actor` / `?since` filter composition verification.

## Why this endpoint is different

Unlike /user, /project, /org, the `governance_audit_log` table has **no row-level `tenant_id`**. It is intrinsically an instance-scope event stream — the existing bare-admin call already returns rows across all tenants because the SQL query has no tenant filter (there is nothing to filter on).

Consequences for the envelope shape:

1. `?tenant=*` does **not** widen the data set (it was already all-tenant for any admin). Its sole effects are to switch the response to `{success, scope:"all", items}` and apply the formal PlatformAdmin gate.
2. Items intentionally **omit** `tenantId` / `tenantSlug`. Lying about per-row tenant attribution would be worse than omitting it. Migration `023_platform_admin_impersonation` added a nullable `acting_as_tenant_id` column but it is (a) NULL for the majority of rows, (b) not exposed in `AuditRow` / the `SELECT` yet.
3. /govern/audit is explicitly **excluded** from the §4.1 `tenantId+tenantSlug` contract test (PR #67). A domain-appropriate test covers its actual envelope.

Full tenant decoration is deferred to a follow-up PR that:
- Surfaces `acting_as_tenant_id` in `AuditRow` + the `SELECT`, **and/or**
- Adds a proper `tenant_id` column via migration + backfill (or joins `actor_id` → user tenant membership at read time — has cost implications).

This keeps this PR focused and avoids committing to a tenant-attribution model that deserves its own design discussion.

## Behavior matrix

| `?tenant=` value | Caller role   | Outcome                                    |
|------------------|---------------|--------------------------------------------|
| absent / empty   | any admin     | Bare array, unchanged (legacy)             |
| `*` / `all`      | PlatformAdmin | `200 {success, scope:"all", items}`        |
| `*` / `all`      | other         | `403 forbidden_scope`                      |
| `<slug>`         | PlatformAdmin | `501 scope_not_implemented` (label `/govern/audit`) |
| any              | no admin      | Existing admin gate still applies          |

## Filter composition

`?actor` and `?since` flow through to `AuditFilters` **regardless of envelope shape**. The envelope wrapping is a response-shape-only transform applied after the storage query returns. This is the §2.5 "compose" requirement from tasks.md.

## Tests

`list_audit_cross_tenant_scope_gates_and_filter_compose` asserts:

1. 403 `forbidden_scope` for non-admin + `?tenant=*`
2. 501 `scope_not_implemented` + endpoint-labeled message for `?tenant=<slug>`
3. `?tenant=*&since=1d&actor=<uuid>` as PlatformAdmin — accepts **200** (envelope shape verified) or **503** `governance_unavailable` (fixture variant, documented skip). **Rejects 400** (would mean filters broke under `?tenant=*`) and **500** (would mean envelope branch has a bug).

All 6 cross-tenant tests remain green in a single `cargo test` run:

```
test cross_tenant_envelope_contract_user_best_effort … ok
test list_audit_cross_tenant_scope_gates_and_filter_compose … ok
test list_users_cross_tenant_scope_gates_and_aliases … ok
test list_orgs_cross_tenant_scope_gates_and_aliases … ok
test cross_tenant_envelope_contract_project_and_org … ok
test list_projects_cross_tenant_scope_gates_and_aliases … ok
```

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo check -p aeterna` ✅
- Gate helper from #66 used verbatim — one more call site, zero drift surface

## Refs

- Tracking: #44 · RFC: #56 · §1: #62 · §2.1: #63 · §2.2: #64 · §2.3: #65 · §2.4+helper: #66 · §4.1: #67
- Tasks doc §2.5