### PR TITLE
docs+test(#44.d): Bundle A — RLS boundary guard + canonical API doc + dev guide (§4.2 + §2.6 + §7)

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -358,6 +358,38 @@ curl http://localhost:6333/collections
 
 ---
 
+## Cross-Tenant Operations (#44.d)
+
+PlatformAdmins can list resources across every tenant on the instance by passing `?tenant=*` to any of the migrated list endpoints:
+
+| Endpoint                | Effect of `?tenant=*`                                      |
+|-------------------------|------------------------------------------------------------|
+| `GET /admin/tenants`    | Lists all tenants (was always cross-tenant).               |
+| `GET /user`             | Users from every tenant, decorated with `tenantId`/`tenantSlug`. |
+| `GET /project`          | Project organizational units, same decoration.             |
+| `GET /org`              | Organization units, same decoration.                       |
+| `GET /govern/audit`     | Audit log across tenants (no per-row tenant decoration — see canonical doc). |
+
+**Who can call it?** PlatformAdmin only. Non-admins get `403 forbidden_scope`. Callers without the `?tenant=` param see the legacy tenant-scoped behavior unchanged.
+
+**Response envelope:** `{ "success": true, "scope": "all", "items": [...] }`. Every item (except on `/govern/audit`) has a non-empty `tenantId` and `tenantSlug` — this is locked by the §4.1 contract test in `cli/tests/server_runtime_test.rs`.
+
+**Safety net:** `storage/tests/rls_boundary_test.rs` fails if any cross-tenant-readable table is ever accidentally RLS-enabled (which would silently return empty results instead of data). If you touch migrations for `tenants` / `users` / `organizational_units` / `governance_audit_log` / `referential_audit_log`, run this test locally.
+
+**Planned work:**
+- `?tenant=<slug>` (single-foreign-tenant listing): currently `501 scope_not_implemented`, scheduled in the cross-tenant listing change.
+- CLI flags: `--all-tenants` and `--tenant <slug>` on `aeterna admin {users,projects,orgs,audit} list` — see [tasks §6](../openspec/changes/add-cross-tenant-admin-listing/tasks.md#6-cli-updates-separate-pr-tracked-here-for-cross-reference).
+- Per-row tenant decoration for `/govern/audit` once `acting_as_tenant_id` is surfaced in `AuditRow`.
+
+**Canonical reference:** [`docs/api/admin.md`](api/admin.md) documents the full grammar, error codes, envelope guarantees, and ordering invariants. Any OpenAPI schema we generate in the future should use that document as its source of truth.
+
+**Common debugging tip:** if `?tenant=*` returns an empty `items[]` array but you expect data, check:
+1. The caller actually has the `platform_admin` role (not just an `admin` role scoped to a single tenant).
+2. No migration has RLS-enabled one of the tables (the RLS boundary test catches this).
+3. The target tenants are `status = 'active'` in `tenants` (soft-deleted tenants are excluded from `?tenant=*`).
+
+---
+
 ## Key Specs
 
 Before working on a specific area, read the relevant OpenSpec specification:

--- a/docs/api/admin.md
+++ b/docs/api/admin.md
@@ -1,0 +1,102 @@
+# Admin API — Cross-Tenant Listing
+
+> Status: **stable** for `?tenant=*` / `?tenant=all` on the endpoints listed below. The `?tenant=<slug>` path is **planned** and currently returns `501 scope_not_implemented`.
+>
+> Shipped in [RFC #56](https://github.com/kikokikok/aeterna/pull/56) · Tracked in [#44.d](https://github.com/kikokikok/aeterna/issues/44).
+
+This document is the canonical reference for the `?tenant=` query parameter across admin list endpoints. It is the source of truth that a future OpenAPI schema will be generated from.
+
+## Endpoints covered
+
+| Endpoint         | Since PR | §     | `?tenant=*` envelope | Per-row `tenantId`/`tenantSlug` |
+|------------------|----------|-------|----------------------|---------------------------------|
+| `GET /admin/tenants` | #63  | §2.1 | ✅                    | N/A (items _are_ tenants)       |
+| `GET /user`      | #64      | §2.2 | ✅                    | ✅                               |
+| `GET /project`   | #65      | §2.3 | ✅                    | ✅                               |
+| `GET /org`       | #66      | §2.4 | ✅                    | ✅                               |
+| `GET /govern/audit` | #68   | §2.5 | ✅                    | ❌ (see [Audit exception](#audit-exception)) |
+
+## The `?tenant=` grammar
+
+| Value                      | Meaning                                                                  | Gate                    | Response shape                 |
+|----------------------------|--------------------------------------------------------------------------|-------------------------|--------------------------------|
+| _absent_ or `?tenant=`     | Tenant-scoped to the caller's tenant (from `X-Tenant-ID` / default).    | Existing auth gate      | Legacy bare array (unchanged)  |
+| `?tenant=*`                | Cross-tenant listing — items from every active tenant.                  | **PlatformAdmin**       | Envelope (see below)           |
+| `?tenant=all`              | Deprecated alias for `*`. Emits a `compat` warning log. Will be removed in a future minor. | **PlatformAdmin** | Envelope                       |
+| `?tenant=<slug-or-uuid>`   | **Not yet implemented.** Reserved for single-foreign-tenant listing.   | PlatformAdmin (planned) | `501 scope_not_implemented`    |
+
+## The cross-tenant response envelope
+
+When `?tenant=*` (or its alias) resolves successfully, the response body uses a stable envelope that replaces the legacy bare array:
+
+```json
+{
+  "success": true,
+  "scope":   "all",
+  "items": [
+    {
+      "id":          "…",
+      "name":        "…",
+      "tenantId":    "tenant-uuid",
+      "tenantSlug":  "acme",
+      "tenantName":  "Acme Corp",
+      "…":           "… (endpoint-specific fields)"
+    }
+  ]
+}
+```
+
+### Contract guarantees
+
+For every endpoint except `/govern/audit`, the following are locked by the [§4.1 contract test](../../cli/tests/server_runtime_test.rs) (search `assert_cross_tenant_envelope_contract`):
+
+1. HTTP status is `200`.
+2. `body.success == true`.
+3. `body.scope == "all"`.
+4. `body.items` is an array.
+5. Every item has a **non-empty string** `tenantId`.
+6. Every item has a **non-empty string** `tenantSlug`.
+7. When data spans multiple tenants, `items` reflects that (the contract test asserts `≥ min_tenants` distinct tenant ids — catches accidental single-tenant collapse).
+
+Ordering is stable across pages: `(tenant_id ASC, name ASC, id ASC)`.
+
+### Audit exception
+
+`GET /govern/audit?tenant=*` emits the envelope but items intentionally **omit** `tenantId` / `tenantSlug`. The `governance_audit_log` table has no row-level tenant column (only a nullable `acting_as_tenant_id` from migration 023 that isn't in the current `SELECT`). Surfacing a misleading tenant would be worse than omitting one. A follow-up will graduate the audit endpoint to the full contract once the storage layer exposes `acting_as_tenant_id` — see the deferred tenant-decoration PR referenced in [#44.d tasks §2.5](../../openspec/changes/add-cross-tenant-admin-listing/tasks.md).
+
+## Error responses
+
+| HTTP | `error` code             | When                                                                |
+|------|--------------------------|---------------------------------------------------------------------|
+| `403` | `forbidden_scope`       | `?tenant=*` or `?tenant=all` called by a non-PlatformAdmin.         |
+| `501` | `scope_not_implemented` | `?tenant=<slug>` on any endpoint (message identifies which one).    |
+| `400` | `scope_not_allowed_for_write` | Future guard for write operations under `?tenant=*` (§5.8).   |
+
+All error bodies follow the standard error envelope:
+
+```json
+{
+  "success": false,
+  "error":   "forbidden_scope",
+  "message": "Human-readable description",
+  "required_role": "PlatformAdmin"
+}
+```
+
+## Filter composition
+
+Endpoint-specific query parameters (e.g. `?actor=`, `?since=`, `?action=` on `/govern/audit`; `?company=` on `/org`) **compose with `?tenant=*`**. The envelope is a response-shape-only transform applied after the storage query. There is no special casing: the same filter rules apply in tenant-scoped and cross-tenant modes.
+
+## Backward compatibility
+
+- Omitting `?tenant=` is always equivalent to the pre-RFC behavior. No existing client is impacted by the introduction of the parameter.
+- `?tenant=` with an empty string value is treated as absent (defensive for clients sending unfilled form fields).
+- The `?tenant=all` alias is intentionally accepted so clients that tried the feature before it was formally stabilized don't break; they now see a `compat` warning log directing them to `?tenant=*`.
+
+## Related
+
+- RFC: [PR #56](https://github.com/kikokikok/aeterna/pull/56)
+- Resolver implementation: [`cli/src/server/context.rs`](../../cli/src/server/context.rs) (search `resolve_list_scope`)
+- Contract test: [`cli/tests/server_runtime_test.rs`](../../cli/tests/server_runtime_test.rs) (search `assert_cross_tenant_envelope_contract`)
+- RLS boundary guard: [`storage/tests/rls_boundary_test.rs`](../../storage/tests/rls_boundary_test.rs)
+- CLI integration (planned): [#44.d §6](../../openspec/changes/add-cross-tenant-admin-listing/tasks.md#6-cli-updates-separate-pr-tracked-here-for-cross-reference)

--- a/openspec/changes/add-cross-tenant-admin-listing/tasks.md
+++ b/openspec/changes/add-cross-tenant-admin-listing/tasks.md
@@ -23,7 +23,7 @@
 - [~] 2.3 `GET /project` — same treatment. **Partial:** `?tenant=*`/`all` implemented; `?tenant=<slug>` returns `501 scope_not_implemented` pending PR #65 cluster.
 - [~] 2.4 `GET /org` — same treatment. **Partial:** `?tenant=*`/`all` implemented; `?tenant=<slug>` returns `501 scope_not_implemented` pending PR #65 cluster.
 - [~] 2.5 `GET /govern/audit` — **Partial:** gates + envelope wrapper + `?actor`/`?since` filter composition implemented. Per-item `tenantId`/`tenantSlug` decoration is **explicitly deferred**: `governance_audit_log` has no row-level `tenant_id` (only the nullable `acting_as_tenant_id` from migration 023, which isn't exposed in `AuditRow`). Full tenant decoration requires a follow-up PR that (a) surfaces `acting_as_tenant_id` in `AuditRow` + the SQL, and (b) arguably adds a proper `tenant_id` column via migration + backfill. `?tenant=<slug>` returns `501 scope_not_implemented`. Excluded from the §4.1 `tenantId+tenantSlug` contract test for this reason.
-- [ ] 2.6 Add `tenant_filter` param + new envelope to OpenAPI/Redoc schema for each of the 5.
+- [~] 2.6 Scope-adjusted: the repo has no OpenAPI/Redoc generation in place (no `utoipa` or similar). Landed the **source-of-truth doc** (`docs/api/admin.md`) that a future OpenAPI generator should read from. All 5 endpoints, the `?tenant=` grammar, the envelope contract, error codes, and the audit exception are documented there. Generator work deferred.
 
 ## 3. Cross-tenant repository layer
 
@@ -34,7 +34,7 @@
 ## 4. Contract tests
 
 - [~] 4.1 Contract tests landed in `cli/tests/server_runtime_test.rs` (not a dedicated file — sharing the fixture would have duplicated ~300 lines; can be migrated once a `tests/common/mod.rs` exists). `assert_cross_tenant_envelope_contract` helper covers contract for `/project` and `/org` across 2 seeded tenants; `/user` is best-effort (asserts contract when 200, skips on 503 fixture variant). `/govern/audit` will extend this when §2.5 lands.
-- [ ] 4.2 Add RLS regression guard `storage/tests/rls_boundary_test.rs`: asserts each of `users`, `projects`, `orgs`, `tenants`, `referential_audit_log`, `governance_audit_log` has `relrowsecurity = false` in `pg_class`. If a future migration RLS-enables one of these, this test fails and forces a redesign of the cross-tenant reader.
+- [x] 4.2 `storage/tests/rls_boundary_test.rs` landed. Checks both `relrowsecurity` AND `relforcerowsecurity` in `pg_class` for every table in the cross-tenant readable set (`tenants`, `users`, `organizational_units`, `governance_audit_log`, `referential_audit_log`). Note: this project uses `organizational_units` rather than separate `projects`/`orgs` tables — the original task listed logical entities; the guard tracks the physical tables the readers actually touch. Error message documents 3 resolution paths so a future dev hitting this failure has immediate direction.
 
 ## 5. Integration tests
 
@@ -56,9 +56,9 @@
 
 ## 7. Documentation
 
-- [ ] 7.1 Update `docs/api/admin.md` (or create if absent) with the `?tenant=` convention table from the proposal.
-- [ ] 7.2 Add a "Cross-tenant operations" section to `USER_GUIDE.md` / `DEVELOPER_GUIDE.md` describing when to use `--all-tenants`.
-- [ ] 7.3 Update the 7-stage framework proposal README for `refactor-platform-admin-impersonation` to mark section 5 delegated to this change.
+- [x] 7.1 `docs/api/admin.md` created — canonical reference for the `?tenant=` grammar, envelope contract, error codes, audit exception, ordering invariants, and backward compatibility story.
+- [~] 7.2 `docs/DEVELOPER_GUIDE.md` gained a "Cross-Tenant Operations (#44.d)" section. Links to the canonical doc, summarizes who-can-call-what, calls out the RLS safety net, and includes a common-debugging checklist. `USER_GUIDE.md` does not exist in this repo (only `DEVELOPER_GUIDE.md`); the user-facing content will move there when/if it's created, or be folded into the CLI flags PR (§6) which is where end-user-visible tenancy switching lands.
+- [x] 7.3 `refactor-platform-admin-impersonation/tasks.md` §5 now marked as delegated to this change, with each sub-task linked to the landing PR. Ensures readers of the parent change see #44.d as the single source of truth instead of stale/duplicate tracking.
 
 ## 8. Cleanup (feeds #44.e)
 

--- a/openspec/changes/refactor-platform-admin-impersonation/tasks.md
+++ b/openspec/changes/refactor-platform-admin-impersonation/tasks.md
@@ -34,12 +34,21 @@
 
 ## 5. PlatformAdmin cross-tenant listing
 
-- [ ] 5.1 `GET /api/v1/admin/users?tenant=*` returns users across all tenants (PlatformAdmin only); response items include `tenantId` + `tenantSlug` columns.
-- [ ] 5.2 `GET /api/v1/admin/projects?tenant=*` same shape for projects.
-- [ ] 5.3 `GET /api/v1/admin/orgs?tenant=*` same shape for organizational units.
-- [ ] 5.4 `?tenant=*` requests by non-PlatformAdmin return `403 forbidden`.
-- [ ] 5.5 Without `?tenant=*`, existing single-tenant listing semantics are preserved (requires `X-Tenant-ID` via `require_target_tenant`).
-- [ ] 5.6 Add `tenant_filter` query param documentation to the OpenAPI/Redoc schema.
+> **Delegated to change [`add-cross-tenant-admin-listing`](../add-cross-tenant-admin-listing/tasks.md) (#44.d).**
+> That change is the single source of truth for every task in this section. Progress tracked there; this list is kept for cross-reference only.
+
+- [x] 5.1 `GET /user?tenant=*` — delivered in [#64](https://github.com/kikokikok/aeterna/pull/64). Items carry `tenantId` + `tenantSlug` per the §4.1 contract.
+- [x] 5.2 `GET /project?tenant=*` — delivered in [#65](https://github.com/kikokikok/aeterna/pull/65). Full contract coverage in [#67](https://github.com/kikokikok/aeterna/pull/67).
+- [x] 5.3 `GET /org?tenant=*` — delivered in [#66](https://github.com/kikokikok/aeterna/pull/66) (plus the shared gate helper).
+- [x] 5.4 `?tenant=*` by non-PlatformAdmin → `403 forbidden_scope`. Gate helper centralized in [#66](https://github.com/kikokikok/aeterna/pull/66); test coverage across all endpoints.
+- [x] 5.5 Without `?tenant=`, legacy single-tenant behavior is preserved on all migrated endpoints (backward-compat explicitly verified in [#64](https://github.com/kikokikok/aeterna/pull/64)/[#65](https://github.com/kikokikok/aeterna/pull/65)/[#66](https://github.com/kikokikok/aeterna/pull/66)).
+- [~] 5.6 No OpenAPI/Redoc generation exists in this repo. Canonical API documentation landed at [`docs/api/admin.md`](../../../docs/api/admin.md) and serves as the source of truth for any future OpenAPI generator. See [#44.d tasks §2.6](../add-cross-tenant-admin-listing/tasks.md#2-handler-migration-one-commit-per-handler).
+
+Bonus work delivered in #44.d beyond the original scope of this section:
+- `GET /admin/tenants?tenant=*` (§2.1, [#63](https://github.com/kikokikok/aeterna/pull/63))
+- `GET /govern/audit?tenant=*` (§2.5, [#68](https://github.com/kikokikok/aeterna/pull/68)) — domain-adapted envelope; per-row tenant decoration deferred pending `acting_as_tenant_id` surfacing.
+- §4.1 envelope contract test ([#67](https://github.com/kikokikok/aeterna/pull/67)) — locks shape across endpoints.
+- §4.2 RLS regression guard — prevents silent breakage if a future migration RLS-enables any cross-tenant-readable table.
 
 ## 6. Audit log impersonation tracking
 

--- a/storage/tests/rls_boundary_test.rs
+++ b/storage/tests/rls_boundary_test.rs
@@ -1,0 +1,121 @@
+//! #44.d §4.2 — RLS boundary regression guard.
+//!
+//! The cross-tenant listing feature (#44.d) depends on PlatformAdmin code
+//! paths being able to read ACROSS tenant boundaries via a direct
+//! `SELECT ... FROM table` with no implicit tenant filter. This works today
+//! because none of the affected tables have PostgreSQL Row-Level Security
+//! (RLS) enabled.
+//!
+//! If a future migration silently RLS-enables one of these tables, the
+//! cross-tenant listing endpoints would return empty results for
+//! PlatformAdmins — and tests would still pass because they'd just see
+//! empty `items[]` arrays (vacuously satisfying the §4.1 contract).
+//!
+//! This test fails loudly if that ever happens, forcing a redesign of the
+//! cross-tenant reader (options then would be: policy that whitelists
+//! PlatformAdmin session vars, or switching to a service-role connection).
+//!
+//! Tables covered (the exact set the #44.d cross-tenant readers touch):
+//!
+//!   - `tenants`                 → /admin/tenants (§2.1)
+//!   - `users`                   → /user         (§2.2)
+//!   - `organizational_units`    → /project · /org (§2.3 · §2.4)
+//!   - `governance_audit_log`    → /govern/audit (§2.5)
+//!   - `referential_audit_log`   → companion audit stream, queried by the
+//!                                 same reader path in future PRs
+//!
+//! This list MUST stay in sync with the actual cross-tenant readers. If a
+//! new endpoint adds another table to the cross-tenant-readable set, add it
+//! here. If a table is removed from the cross-tenant set, also remove it
+//! here (stale entries would false-positive if the table is later legitimately
+//! RLS-gated for tenant-scoped reads).
+
+use sqlx::Row;
+use testing::postgres;
+
+/// Every table the #44.d cross-tenant reader path touches.
+///
+/// If any of these has `relrowsecurity = true` in `pg_class`, the
+/// cross-tenant listing endpoints are silently broken for PlatformAdmins
+/// and this test fails.
+const CROSS_TENANT_READABLE_TABLES: &[&str] = &[
+    "tenants",
+    "users",
+    "organizational_units",
+    "governance_audit_log",
+    "referential_audit_log",
+];
+
+#[tokio::test]
+async fn cross_tenant_readable_tables_have_rls_disabled() {
+    let Some(pg_fixture) = postgres().await else {
+        eprintln!("Skipping RLS boundary test: Docker not available");
+        return;
+    };
+
+    // Initialize schema so all tables exist (migrations run on connect).
+    use storage::postgres::PostgresBackend;
+    let backend = PostgresBackend::new(pg_fixture.url())
+        .await
+        .expect("connect to test postgres");
+    backend
+        .initialize_schema()
+        .await
+        .expect("run schema migrations");
+
+    let pool = sqlx::PgPool::connect(pg_fixture.url())
+        .await
+        .expect("pool for RLS query");
+
+    let mut violations = Vec::<(String, bool, bool)>::new();
+    for table in CROSS_TENANT_READABLE_TABLES {
+        // Query pg_class for the exact RLS flags of this table in the
+        // public schema. `relrowsecurity` = RLS enabled at all.
+        // `relforcerowsecurity` = RLS bypass disabled even for table
+        // owner (neither can be true for the cross-tenant reader to work).
+        let row = sqlx::query(
+            r#"
+            SELECT c.relrowsecurity, c.relforcerowsecurity
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'public' AND c.relname = $1
+            "#,
+        )
+        .bind(table)
+        .fetch_optional(&pool)
+        .await
+        .unwrap_or_else(|e| panic!("pg_class lookup failed for {table}: {e}"));
+
+        let row = row.unwrap_or_else(|| {
+            panic!(
+                "Table `{table}` is declared cross-tenant-readable in \
+                 CROSS_TENANT_READABLE_TABLES but does not exist in the schema. \
+                 Either a migration is missing or the constant is out of date."
+            )
+        });
+        let rls_enabled: bool = row.get(0);
+        let rls_forced: bool = row.get(1);
+        if rls_enabled || rls_forced {
+            violations.push((table.to_string(), rls_enabled, rls_forced));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "#44.d RLS boundary violation: the following cross-tenant-readable \
+         tables have Row-Level Security enabled, which silently breaks \
+         PlatformAdmin cross-tenant listing endpoints (/admin/tenants, /user, \
+         /project, /org, /govern/audit):\n{:#?}\n\n\
+         Resolution options:\n\
+           1. If the RLS was added by accident, disable it: \
+              `ALTER TABLE <t> DISABLE ROW LEVEL SECURITY;`\n\
+           2. If RLS is intentional, add a policy that whitelists the \
+              cross-tenant reader (e.g. `USING (true)` when a \
+              `app.is_platform_admin` session var is set), or switch \
+              the cross-tenant readers to a service role connection.\n\
+           3. If the table should no longer be cross-tenant-readable, \
+              remove it from `CROSS_TENANT_READABLE_TABLES` AND from \
+              the cross-tenant endpoints' SELECTs.",
+        violations
+    );
+}


### PR DESCRIPTION
**Bundle A** of the remaining #44.d work — batched into a single PR to reduce CI churn (following up on the "too many PRs" concern after #68). Three tasks, two commits for bisectability.

## §4.2 — RLS regression guard (`storage/tests/rls_boundary_test.rs`)

The cross-tenant listing feature assumes `SELECT ... FROM table` reads across tenants. This works today because none of the affected tables have PostgreSQL Row-Level Security enabled. If a future migration silently RLS-enables one, the failure mode is **invisible**: endpoints return empty `items[]` arrays (vacuously satisfying the §4.1 contract) while actual data is hidden.

The new test checks `relrowsecurity` **and** `relforcerowsecurity` in `pg_class` for the exact set of tables the cross-tenant readers touch:

- `tenants`
- `users`
- `organizational_units`
- `governance_audit_log`
- `referential_audit_log`

The failure message documents 3 resolution paths (disable RLS / whitelist policy / switch to service role / drop from the set) so the next dev hitting this failure has direction.

> Deviation from the original task text: the task listed `projects`/`orgs` as separate tables; this project uses a single `organizational_units` table with a discriminator. The guard tracks the physical tables the readers actually touch — noted in the tasks.md update.

## §2.6 + §7.1 — `docs/api/admin.md` (new)

The repo has no OpenAPI/Redoc generation (`utoipa`/similar absent). Rather than bolt one on as a side effect, this PR lands the **source-of-truth doc** that an OpenAPI generator would read from. It covers:

- The `?tenant=` grammar (4 value shapes × gate × response shape)
- The envelope (`{success, scope, items}`) with all 7 contract guarantees
- The audit exception (why `/govern/audit` omits per-item `tenantId`/`tenantSlug`)
- Error codes (`forbidden_scope`, `scope_not_implemented`, planned `scope_not_allowed_for_write`)
- Filter composition with `?actor`/`?since`/`?action`/`?company`/...
- Backward-compat story (absent-param path unchanged; `?tenant=all` alias + deprecation)
- Ordering invariants (`(tenant_id ASC, name ASC, id ASC)`)

## §7.2 — `docs/DEVELOPER_GUIDE.md` new section

"Cross-Tenant Operations (#44.d)" with:
- Endpoint × effect matrix
- Who-can-call-what
- RLS safety-net callout (run the new boundary test locally when touching migrations on any of the 5 tables)
- Planned-work pointer (`?tenant=<slug>` cluster, CLI flags, audit decoration)
- Common debugging checklist for empty-`items[]`-under-`?tenant=*`

USER_GUIDE.md does not exist in this repo; the end-user-visible content will land with the CLI flags bundle (§6).

## §7.3 — cross-reference

`openspec/changes/refactor-platform-admin-impersonation/tasks.md` §5 is now explicitly marked **delegated to #44.d**, with each sub-task linked to its landing PR (#63–#68). Bonus work beyond the original scope is enumerated (/admin/tenants, /govern/audit, §4.1 contract, §4.2 RLS guard) so readers of the parent change see what actually shipped.

## Tasks doc updates

| Task | Before | After | Note |
|------|--------|-------|------|
| §4.2 | [ ] | **[x]** | RLS guard landed |
| §2.6 | [ ] | **[~]** | Source-of-truth doc landed; generator deferred |
| §7.1 | [ ] | **[x]** | `docs/api/admin.md` created |
| §7.2 | [ ] | **[~]** | DEVELOPER_GUIDE done; USER_GUIDE absent, deferred |
| §7.3 | [ ] | **[x]** | cross-reference updated |

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo check -p aeterna -p storage --tests` ✅
- Zero code changes in production paths — only tests, docs, tracking
- Bisectable: commit 1 is the RLS guard, commit 2 is all docs

## Refs

- Tracking: #44 · RFC: #56 · §1: #62 · §2.1: #63 · §2.2: #64 · §2.3: #65 · §2.4+helper: #66 · §4.1: #67 · §2.5: #68
- Tasks doc §4.2, §2.6, §7.1, §7.2, §7.3