### PR TITLE
feat+test(#44.d): Bundle B — ?tenant=<slug> cluster + §5 integration test matrix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "utils",
  "uuid",
  "wiremock",
@@ -8945,6 +8946,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -81,3 +81,5 @@ predicates = "3.1"
 testing.workspace = true
 wiremock.workspace = true
 serde_json.workspace = true
+# #44.d §5.6 — deprecation log capture for ?tenant=all compat-warning test.
+tracing-test = "0.2"

--- a/cli/src/server/context.rs
+++ b/cli/src/server/context.rs
@@ -275,8 +275,23 @@ pub fn forbidden_scope_response(required_role: &str) -> Response {
 /// prevents drift (trim, case-fold, deprecation warning, error message
 /// formatting) across endpoints.
 pub enum ListDispatch {
+    /// No `?tenant=` param. Caller runs its legacy tenant-scoped logic
+    /// unchanged against `X-Tenant-ID` / default. Backward compatible bit
+    /// for bit.
     TenantScoped,
+    /// `?tenant=*` or `?tenant=all` by a PlatformAdmin. Caller emits the
+    /// all-tenants envelope (`scope: "all"`).
     CrossTenant,
+    /// `?tenant=<slug-or-uuid>` by a PlatformAdmin, resolved successfully.
+    /// Caller emits the single-foreign-tenant envelope with the resolved
+    /// tenant metadata (`scope: "tenant"`, `tenant: { id, slug, name }`).
+    ///
+    /// Only returned when `resolve_list_scope` was called with
+    /// `supports_single = true`. Endpoints that don't support per-row
+    /// tenant decoration (e.g. /govern/audit — see #44.d §2.5) pass
+    /// `false` and the slug path returns `501 scope_not_implemented`
+    /// instead.
+    CrossTenantSingle(ResolvedTenant),
     Response(Response),
 }
 
@@ -294,13 +309,21 @@ pub enum ListDispatch {
 ///                          cluster; the 501 is a stable, documented
 ///                          response that clients can detect)
 ///
-/// `endpoint_label` is surfaced in the 501 body to help clients discover
+/// `endpoint_label` is surfaced in error bodies to help clients discover
 /// which endpoint they hit (e.g. `"/user"`, `"/project"`, `"/org"`).
+///
+/// `supports_single` controls whether `?tenant=<slug-or-uuid>` is routed to
+/// [`ListDispatch::CrossTenantSingle`] or returns `501 scope_not_implemented`.
+/// Endpoints that cannot (yet) produce a per-row-tenant-decorated envelope
+/// for a single foreign tenant (e.g. `/govern/audit`, see #44.d §2.5) pass
+/// `false`. This keeps the 501 stable for those endpoints while unlocking
+/// the feature on `/user`, `/project`, `/org`.
 pub async fn resolve_list_scope(
     state: &AppState,
     headers: &HeaderMap,
     raw_tenant_param: Option<&str>,
     endpoint_label: &str,
+    supports_single: bool,
 ) -> ListDispatch {
     let Some(raw) = raw_tenant_param else {
         return ListDispatch::TenantScoped;
@@ -313,16 +336,56 @@ pub async fn resolve_list_scope(
     }
     let is_all_star = trimmed == "*";
     let is_all_alias = trimmed.eq_ignore_ascii_case("all");
+
+    // Single-foreign-tenant path. Gate on supports_single, then enforce
+    // PlatformAdmin, then resolve the slug/uuid via the tenant store.
     if !is_all_star && !is_all_alias {
-        return ListDispatch::Response(error_response(
-            StatusCode::NOT_IMPLEMENTED,
-            "scope_not_implemented",
-            &format!(
-                "?tenant=<slug> is not yet supported on {endpoint_label}; use ?tenant=* for cross-tenant listing or omit the parameter"
-            ),
-            None,
-        ));
+        if !supports_single {
+            return ListDispatch::Response(error_response(
+                StatusCode::NOT_IMPLEMENTED,
+                "scope_not_implemented",
+                &format!(
+                    "?tenant=<slug> is not supported on {endpoint_label}; use ?tenant=* for cross-tenant listing or omit the parameter"
+                ),
+                None,
+            ));
+        }
+        // Identity must be resolved before we can return a `tenant_not_found`
+        // (which is information about whether the tenant exists on this
+        // instance) — we do NOT want unauthenticated probes to learn that.
+        let req_ctx = match request_context(state, headers).await {
+            Ok(c) => c,
+            Err(r) => return ListDispatch::Response(r),
+        };
+        if !req_ctx.is_platform_admin {
+            return ListDispatch::Response(forbidden_scope_response("PlatformAdmin"));
+        }
+        let record = match state.tenant_store.get_tenant(trimmed).await {
+            Ok(Some(t)) => t,
+            Ok(None) => {
+                return ListDispatch::Response(error_response(
+                    StatusCode::NOT_FOUND,
+                    "tenant_not_found",
+                    &format!("No tenant matches '{trimmed}'"),
+                    None,
+                ));
+            }
+            Err(e) => {
+                return ListDispatch::Response(error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "tenant_lookup_failed",
+                    &e.to_string(),
+                    None,
+                ));
+            }
+        };
+        return ListDispatch::CrossTenantSingle(ResolvedTenant {
+            id: record.id,
+            slug: record.slug,
+            name: record.name,
+        });
     }
+
     if is_all_alias {
         tracing::warn!(
             target: "compat",
@@ -340,6 +403,46 @@ pub async fn resolve_list_scope(
         return ListDispatch::Response(forbidden_scope_response("PlatformAdmin"));
     }
     ListDispatch::CrossTenant
+}
+
+/// Reject write operations issued with `?tenant=*` / `?tenant=all`.
+///
+/// Cross-tenant **writes** are explicitly out of scope for #44.d — the
+/// `?tenant=` parameter is a READ-side broadening. If a client sends
+/// `POST /user?tenant=*` we return `400 scope_not_allowed_for_write`
+/// instead of silently writing to the caller's tenant or fanning out.
+///
+/// Returns `Some(response)` when the guard fires, `None` otherwise.
+/// Handlers should early-return the Some path verbatim.
+///
+/// Takes a `Query<HashMap>` rather than parsing `raw_query` so we stay
+/// consistent with axum's percent-decoding and multi-value semantics.
+pub fn reject_cross_tenant_write(
+    raw_query: Option<&str>,
+    endpoint_label: &str,
+) -> Option<Response> {
+    let query = raw_query?;
+    // Hand-parse because we only care about one key and want to avoid
+    // pulling serde_urlencoded for a 3-line check. Matches the resolver's
+    // grammar: trimmed "*" or case-insensitive "all".
+    for pair in query.split('&') {
+        let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+        if k != "tenant" {
+            continue;
+        }
+        let v = v.trim();
+        if v == "*" || v.eq_ignore_ascii_case("all") {
+            return Some(error_response(
+                StatusCode::BAD_REQUEST,
+                "scope_not_allowed_for_write",
+                &format!(
+                    "?tenant=* is a read-only scope; writes to {endpoint_label} must target a single tenant via X-Tenant-ID"
+                ),
+                None,
+            ));
+        }
+    }
+    None
 }
 
 /// Returns `Ok(())` when the caller is a PlatformAdmin, `403 forbidden` otherwise.

--- a/cli/src/server/context.rs
+++ b/cli/src/server/context.rs
@@ -299,15 +299,15 @@ pub enum ListDispatch {
 ///
 /// Grammar (see RFC):
 ///
-/// - absent               → [`ListDispatch::TenantScoped`]
-/// - `*`                  → [`ListDispatch::CrossTenant`] (PlatformAdmin
-///                          required; otherwise `403 forbidden_scope`)
-/// - `all` (case-insensitive) → deprecated alias for `*`; logs a compat
-///                          warning and resolves identically
-/// - anything else        → `501 scope_not_implemented` (wiring for
-///                          `?tenant=<slug>` is deferred to a later PR
-///                          cluster; the 501 is a stable, documented
-///                          response that clients can detect)
+/// - absent: [`ListDispatch::TenantScoped`]
+/// - `*`: [`ListDispatch::CrossTenant`] — PlatformAdmin required, else
+///   `403 forbidden_scope`.
+/// - `all` (case-insensitive): deprecated alias for `*`, logs a compat
+///   warning and resolves identically.
+/// - anything else (slug or uuid): when `supports_single = true`,
+///   resolves via the tenant store to [`ListDispatch::CrossTenantSingle`]
+///   (PlatformAdmin required, `404 tenant_not_found` on miss). When
+///   `supports_single = false`, returns `501 scope_not_implemented`.
 ///
 /// `endpoint_label` is surfaced in error bodies to help clients discover
 /// which endpoint they hit (e.g. `"/user"`, `"/project"`, `"/org"`).

--- a/cli/src/server/govern_api.rs
+++ b/cli/src/server/govern_api.rs
@@ -526,11 +526,18 @@ async fn list_audit(
         &headers,
         query.tenant.as_deref(),
         "/govern/audit",
+        // /govern/audit can't attribute rows to a tenant (see §2.5 notes) —
+        // ?tenant=<slug> therefore stays 501 here until acting_as_tenant_id
+        // is surfaced in AuditRow + SELECT.
+        false,
     )
     .await
     {
         super::context::ListDispatch::CrossTenant => true,
         super::context::ListDispatch::TenantScoped => false,
+        super::context::ListDispatch::CrossTenantSingle(_) => unreachable!(
+            "supports_single=false → resolve_list_scope cannot return CrossTenantSingle"
+        ),
         super::context::ListDispatch::Response(resp) => return resp,
     };
 

--- a/cli/src/server/org_api.rs
+++ b/cli/src/server/org_api.rs
@@ -77,12 +77,21 @@ async fn list_orgs(
     // behavior — PlatformAdmins received all-tenant rows in the bare-array
     // body when ?tenant was absent. That behavior is preserved for
     // backward compat; the new `?tenant=*` path adds the RFC envelope.
-    match super::context::resolve_list_scope(&state, &headers, query.tenant.as_deref(), "/org")
-        .await
+    match super::context::resolve_list_scope(
+        &state,
+        &headers,
+        query.tenant.as_deref(),
+        "/org",
+        true, // supports ?tenant=<slug>
+    )
+    .await
     {
         super::context::ListDispatch::TenantScoped => { /* fall through */ }
         super::context::ListDispatch::CrossTenant => {
-            return list_orgs_cross_tenant(&state, &query).await;
+            return list_orgs_cross_tenant(&state, &query, None).await;
+        }
+        super::context::ListDispatch::CrossTenantSingle(t) => {
+            return list_orgs_cross_tenant(&state, &query, Some(&t)).await;
         }
         super::context::ListDispatch::Response(r) => return r,
     }
@@ -109,13 +118,14 @@ async fn list_orgs(
     Json(units).into_response()
 }
 
-/// Cross-tenant organization listing (`?tenant=*`, PlatformAdmin only).
-///
-/// Same shape as `/project` in scope=all mode — one item per org across
-/// all tenants, each decorated with `tenantId` + `tenantSlug` + `tenantName`.
+/// Cross-tenant organization listing — serves both `?tenant=*`
+/// (`single_tenant=None`) and `?tenant=<slug>` (`single_tenant=Some(...)`).
+/// Symmetric with `list_projects_cross_tenant`; see that function for the
+/// rationale on shape reuse + in-memory narrowing.
 async fn list_orgs_cross_tenant(
     state: &AppState,
     query: &OrgListQuery,
+    single_tenant: Option<&super::context::ResolvedTenant>,
 ) -> axum::response::Response {
     let mut units = match state.postgres.list_all_units().await {
         Ok(units) => units,
@@ -124,6 +134,9 @@ async fn list_orgs_cross_tenant(
         }
     };
     units.retain(|unit| unit.unit_type == UnitType::Organization);
+    if let Some(t) = single_tenant {
+        units.retain(|unit| unit.tenant_id.as_str() == t.id.as_str());
+    }
     if let Some(company_id) = query.company.as_deref() {
         units.retain(|unit| unit.parent_id.as_deref() == Some(company_id));
     }
@@ -166,15 +179,20 @@ async fn list_orgs_cross_tenant(
         })
         .collect();
 
-    (
-        StatusCode::OK,
-        Json(json!({
+    let body = match single_tenant {
+        None => json!({
             "success": true,
             "scope":   "all",
             "items":   items,
-        })),
-    )
-        .into_response()
+        }),
+        Some(t) => json!({
+            "success": true,
+            "scope":   "tenant",
+            "tenant":  { "id": t.id, "slug": t.slug, "name": t.name },
+            "items":   items,
+        }),
+    };
+    (StatusCode::OK, Json(body)).into_response()
 }
 
 async fn show_org(
@@ -196,8 +214,13 @@ async fn show_org(
 async fn create_org(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    axum::extract::RawQuery(raw_query): axum::extract::RawQuery,
     Json(req): Json<CreateOrgRequest>,
 ) -> impl IntoResponse {
+    // #44.d §5.8 — block write-with-?tenant=* (see user_api for rationale).
+    if let Some(resp) = super::context::reject_cross_tenant_write(raw_query.as_deref(), "/org") {
+        return resp;
+    }
     let ctx = match require_admin_context(&state, &headers).await {
         Ok(ctx) => ctx,
         Err(response) => return response,

--- a/cli/src/server/project_api.rs
+++ b/cli/src/server/project_api.rs
@@ -107,12 +107,21 @@ async fn list_projects(
     Query(query): Query<ProjectListQuery>,
 ) -> impl IntoResponse {
     // #44.d §2.3 — cross-tenant listing dispatch via shared helper.
-    match super::context::resolve_list_scope(&state, &headers, query.tenant.as_deref(), "/project")
-        .await
+    match super::context::resolve_list_scope(
+        &state,
+        &headers,
+        query.tenant.as_deref(),
+        "/project",
+        true, // supports ?tenant=<slug>
+    )
+    .await
     {
         super::context::ListDispatch::TenantScoped => { /* fall through */ }
         super::context::ListDispatch::CrossTenant => {
-            return list_projects_cross_tenant(&state, &query).await;
+            return list_projects_cross_tenant(&state, &query, None).await;
+        }
+        super::context::ListDispatch::CrossTenantSingle(t) => {
+            return list_projects_cross_tenant(&state, &query, Some(&t)).await;
         }
         super::context::ListDispatch::Response(r) => return r,
     }
@@ -139,14 +148,19 @@ async fn list_projects(
     Json(units).into_response()
 }
 
-/// Cross-tenant project listing (`?tenant=*`, PlatformAdmin only).
+/// Cross-tenant project listing — serves both `?tenant=*` (PlatformAdmin,
+/// `single_tenant=None`) and `?tenant=<slug>` (PlatformAdmin,
+/// `single_tenant=Some(...)`).
 ///
-/// Returns one item per project across all tenants, each decorated with
-/// `tenantId` + `tenantSlug` + `tenantName`. Unlike `/user`, projects
-/// are 1:1 tenant-owned so there is no user-like row duplication.
+/// The only difference between the two modes is (a) an additional row-level
+/// filter when `single_tenant` is Some, and (b) the envelope's `scope` field
+/// + an echoed `tenant` object so clients can tell which tenant they are
+/// looking at. Per-item decoration (`tenantId`/`tenantSlug`/`tenantName`) is
+/// identical in both modes — this keeps the items-array contract uniform.
 async fn list_projects_cross_tenant(
     state: &AppState,
     query: &ProjectListQuery,
+    single_tenant: Option<&super::context::ResolvedTenant>,
 ) -> axum::response::Response {
     let mut units = match state.postgres.list_all_units().await {
         Ok(units) => units,
@@ -159,6 +173,14 @@ async fn list_projects_cross_tenant(
         }
     };
     units.retain(|unit| unit.unit_type == UnitType::Project);
+    // Single-foreign-tenant narrowing. Applied after list_all_units so the
+    // cross-tenant SELECT is reused verbatim; the alternative would be a
+    // new single-tenant store method which would drift from the all-tenant
+    // one (ordering, filters, decoration — all would need to stay in lock
+    // step across two call sites).
+    if let Some(t) = single_tenant {
+        units.retain(|unit| unit.tenant_id.as_str() == t.id.as_str());
+    }
     if let Some(team_id) = query.team.as_deref() {
         units.retain(|unit| unit.parent_id.as_deref() == Some(team_id));
     }
@@ -204,15 +226,28 @@ async fn list_projects_cross_tenant(
         })
         .collect();
 
-    (
-        StatusCode::OK,
-        Json(json!({
+    // Envelope shape is intentionally consistent across ?tenant=* and
+    // ?tenant=<slug>: same top-level keys, same items[] contract. The only
+    // differentiators are the `scope` discriminant ("all" vs "tenant") and
+    // an echoed `tenant` object in single-tenant mode so clients can render
+    // the current view without a second lookup. We OMIT the key entirely in
+    // "all" mode rather than serializing it as `null` — it would be
+    // meaningless noise and would need to be documented away in the §4.1
+    // contract.
+    let body = match single_tenant {
+        None => json!({
             "success": true,
             "scope":   "all",
             "items":   items,
-        })),
-    )
-        .into_response()
+        }),
+        Some(t) => json!({
+            "success": true,
+            "scope":   "tenant",
+            "tenant":  { "id": t.id, "slug": t.slug, "name": t.name },
+            "items":   items,
+        }),
+    };
+    (StatusCode::OK, Json(body)).into_response()
 }
 
 async fn show_project(
@@ -233,8 +268,14 @@ async fn show_project(
 async fn create_project(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    axum::extract::RawQuery(raw_query): axum::extract::RawQuery,
     Json(req): Json<CreateProjectRequest>,
 ) -> impl IntoResponse {
+    // #44.d §5.8 — block write-with-?tenant=* (see user_api for rationale).
+    if let Some(resp) = super::context::reject_cross_tenant_write(raw_query.as_deref(), "/project")
+    {
+        return resp;
+    }
     let ctx = match require_admin_context(&state, &headers).await {
         Ok(ctx) => ctx,
         Err(response) => return response,

--- a/cli/src/server/project_api.rs
+++ b/cli/src/server/project_api.rs
@@ -152,11 +152,11 @@ async fn list_projects(
 /// `single_tenant=None`) and `?tenant=<slug>` (PlatformAdmin,
 /// `single_tenant=Some(...)`).
 ///
-/// The only difference between the two modes is (a) an additional row-level
-/// filter when `single_tenant` is Some, and (b) the envelope's `scope` field
-/// + an echoed `tenant` object so clients can tell which tenant they are
-/// looking at. Per-item decoration (`tenantId`/`tenantSlug`/`tenantName`) is
-/// identical in both modes — this keeps the items-array contract uniform.
+/// The only difference between the two modes is an additional row-level
+/// filter when `single_tenant` is Some, plus the envelope's `scope` field
+/// and an echoed `tenant` object so clients can tell which tenant they are
+/// looking at. Per-item decoration (`tenantId`/`tenantSlug`/`tenantName`)
+/// is identical in both modes — this keeps the items-array contract uniform.
 async fn list_projects_cross_tenant(
     state: &AppState,
     query: &ProjectListQuery,

--- a/cli/src/server/user_api.rs
+++ b/cli/src/server/user_api.rs
@@ -297,10 +297,21 @@ async fn list_users(
 ) -> impl IntoResponse {
     // #44.d — cross-tenant listing dispatch via shared helper.
     // See `context::resolve_list_scope` for the gate semantics.
-    match context::resolve_list_scope(&state, &headers, query.tenant.as_deref(), "/user").await {
+    match context::resolve_list_scope(
+        &state,
+        &headers,
+        query.tenant.as_deref(),
+        "/user",
+        true, // supports ?tenant=<slug>
+    )
+    .await
+    {
         context::ListDispatch::TenantScoped => { /* fall through */ }
         context::ListDispatch::CrossTenant => {
-            return list_users_cross_tenant(&state, &query).await;
+            return list_users_cross_tenant(&state, &query, None).await;
+        }
+        context::ListDispatch::CrossTenantSingle(t) => {
+            return list_users_cross_tenant(&state, &query, Some(&t)).await;
         }
         context::ListDispatch::Response(r) => return r,
     }
@@ -454,6 +465,7 @@ async fn list_users(
 async fn list_users_cross_tenant(
     state: &AppState,
     query: &UserListQuery,
+    single_tenant: Option<&context::ResolvedTenant>,
 ) -> axum::response::Response {
     let variant = match detect_user_table_variant(state).await {
         Ok(variant) => variant,
@@ -565,10 +577,23 @@ async fn list_users_cross_tenant(
         }
     };
 
+    // Build items and, in single-foreign-tenant mode, narrow to rows whose
+    // tenant_id matches the resolved target. The narrowing is done post-
+    // query rather than via SQL because the existing cross-tenant SELECT
+    // already streams each (user, tenant) pairing; applying a `.filter()`
+    // here keeps the SQL single-sourced and avoids drift between an
+    // "all tenants" and a "one tenant" variant of the query.
+    let filter_tenant_id: Option<&str> = single_tenant.map(|t| t.id.as_str());
     let items: Vec<serde_json::Value> = rows
         .into_iter()
-        .map(|row| {
-            json!({
+        .filter_map(|row| {
+            let tid: String = row.get("tenant_id");
+            if let Some(target) = filter_tenant_id
+                && tid != target
+            {
+                return None;
+            }
+            Some(json!({
                 "id":          row.get::<String, _>("user_id"),
                 "email":       row.get::<String, _>("email"),
                 "name":        row.get::<String, _>("display_name"),
@@ -577,24 +602,29 @@ async fn list_users_cross_tenant(
                 "settings":    row.get::<serde_json::Value, _>("settings"),
                 "createdAt":   row.get::<chrono::DateTime<chrono::Utc>, _>("created_at"),
                 "updatedAt":   row.get::<chrono::DateTime<chrono::Utc>, _>("updated_at"),
-                "tenantId":    row.get::<String, _>("tenant_id"),
+                "tenantId":    tid,
                 "tenantSlug":  row.get::<String, _>("tenant_slug"),
                 "tenantName":  row.get::<String, _>("tenant_name"),
                 // See docstring: per-tenant role aggregation deferred to PR #66.
                 "roles":       Vec::<serde_json::Value>::new(),
-            })
+            }))
         })
         .collect();
 
-    (
-        StatusCode::OK,
-        Json(json!({
+    let body = match single_tenant {
+        None => json!({
             "success": true,
             "scope":   "all",
             "items":   items,
-        })),
-    )
-        .into_response()
+        }),
+        Some(t) => json!({
+            "success": true,
+            "scope":   "tenant",
+            "tenant":  { "id": t.id, "slug": t.slug, "name": t.name },
+            "items":   items,
+        }),
+    };
+    (StatusCode::OK, Json(body)).into_response()
 }
 
 async fn show_user(
@@ -655,8 +685,17 @@ async fn show_user(
 async fn register_user(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    axum::extract::RawQuery(raw_query): axum::extract::RawQuery,
     Json(req): Json<RegisterUserRequest>,
 ) -> impl IntoResponse {
+    // #44.d §5.8 — block write-with-?tenant=*. The `?tenant=` param is
+    // strictly a read-side broadening; attempting to write under it is
+    // almost always a client bug (e.g. "I'm listing, let me create one
+    // with the same URL"). 400 is preferable to implicit single-tenant
+    // fallback because the latter could land data in the wrong tenant.
+    if let Some(resp) = context::reject_cross_tenant_write(raw_query.as_deref(), "/user") {
+        return resp;
+    }
     let ctx = match tenant_scoped_context(&state, &headers).await {
         Ok(ctx) => ctx,
         Err(response) => return response,

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -4454,3 +4454,455 @@ async fn cross_tenant_envelope_contract_user_best_effort() {
         other => panic!("/user?tenant=*: unexpected status {other}"),
     }
 }
+
+// ---------------------------------------------------------------------------
+// #44.d §5 — Integration test matrix for ?tenant= across /user /project /org.
+//
+// Each test below maps to a specific task in the cross-tenant listing change
+// (openspec/changes/add-cross-tenant-admin-listing/tasks.md). Keeping them
+// grouped here (rather than spread across per-endpoint modules) ensures the
+// matrix is easy to audit as a single coherent contract.
+//
+// Convention: tests gracefully skip when Docker is unavailable, following
+// the same pattern as the surrounding suite. Postgres-only behaviors (e.g.
+// seeded tenants, 404 tenant_not_found) therefore fall through in
+// headless-CI variants instead of panicking.
+// ---------------------------------------------------------------------------
+
+/// #44.d §5.3 — Without ?tenant=, list endpoints preserve legacy behavior.
+///
+/// This locks the most important backward-compat guarantee of the feature:
+/// clients that never adopt ?tenant= see BYTE-IDENTICAL responses to the
+/// pre-RFC world. We verify by asserting the response is a bare JSON array
+/// (not the new envelope), which is how all three endpoints shaped their
+/// legacy body. If a future PR accidentally wraps the legacy path in the
+/// new envelope, this test fails.
+#[tokio::test]
+async fn cross_tenant_s5_3_no_tenant_param_preserves_legacy_shape() {
+    let Some((state, _tmp)) = test_app_state().await else {
+        eprintln!("Skipping §5.3: Docker not available");
+        return;
+    };
+    let app = router::build_router(state);
+
+    for endpoint in ["/api/v1/user", "/api/v1/project", "/api/v1/org"] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(endpoint)
+                    .header("x-user-id", "platform-admin")
+                    .header("x-user-role", "platform_admin")
+                    .header("x-tenant-id", "default")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // 200 when fixture supplies the endpoint's backing data; 503 is
+        // acceptable when the variant's cross-query path is unimplemented
+        // (mirrors the best-effort pattern used elsewhere in this suite).
+        if resp.status() == StatusCode::SERVICE_UNAVAILABLE {
+            eprintln!("§5.3: {endpoint} returned 503 (fixture variant skip)");
+            continue;
+        }
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "{endpoint}: legacy path (no ?tenant) must return 200"
+        );
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            body.is_array(),
+            "{endpoint}: legacy path must return a bare array, not the envelope. \
+             The envelope would BREAK every pre-RFC client. Got: {body}"
+        );
+    }
+}
+
+/// #44.d §5.4 — PlatformAdmin + ?tenant=<slug> returns ONLY that tenant.
+///
+/// Seeds two tenants with distinguishable units, issues `?tenant=<slug-a>`,
+/// and asserts (a) the new `scope: "tenant"` envelope, (b) the echoed
+/// `tenant` object, and (c) every returned item belongs to tenant A only.
+#[tokio::test]
+async fn cross_tenant_s5_4_slug_returns_only_that_tenant() {
+    let Some((state, _tmp)) = test_app_state().await else {
+        eprintln!("Skipping §5.4: Docker not available");
+        return;
+    };
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let slug_a = format!("s5-4-a-{}", &suffix[..8]);
+    let slug_b = format!("s5-4-b-{}", &suffix[..8]);
+    let tenant_a = state
+        .tenant_store
+        .create_tenant(&slug_a, "S5.4 Tenant A")
+        .await
+        .expect("create tenant A");
+    let tenant_b = state
+        .tenant_store
+        .create_tenant(&slug_b, "S5.4 Tenant B")
+        .await
+        .expect("create tenant B");
+    for t in [&tenant_a, &tenant_b] {
+        let tid = TenantId::new(t.id.as_str().to_string()).unwrap();
+        seed_unit_of_type(
+            &state,
+            &tid,
+            mk_core::types::UnitType::Project,
+            &format!("proj-{}", t.slug),
+        )
+        .await;
+        seed_unit_of_type(
+            &state,
+            &tid,
+            mk_core::types::UnitType::Organization,
+            &format!("org-{}", t.slug),
+        )
+        .await;
+    }
+    let app = router::build_router(state);
+
+    for (endpoint_base, expected_unit_name) in [
+        ("/api/v1/project", format!("proj-{slug_a}")),
+        ("/api/v1/org", format!("org-{slug_a}")),
+    ] {
+        let uri = format!("{endpoint_base}?tenant={slug_a}");
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&uri)
+                    .header("x-user-id", "platform-admin")
+                    .header("x-user-role", "platform_admin")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "{uri}: expected 200");
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["success"], true, "{uri}: success must be true");
+        assert_eq!(
+            body["scope"], "tenant",
+            "{uri}: scope must be 'tenant' for slug path, got {}",
+            body["scope"]
+        );
+        assert_eq!(
+            body["tenant"]["slug"], slug_a,
+            "{uri}: echoed tenant.slug must match requested slug"
+        );
+        assert_eq!(
+            body["tenant"]["id"],
+            tenant_a.id.as_str(),
+            "{uri}: echoed tenant.id must match resolved tenant"
+        );
+        let items = body["items"].as_array().expect("items array");
+        // Every item must belong to tenant A. This is the CORE guarantee
+        // of the slug path — if any item leaks from tenant B we have a
+        // cross-tenant isolation bug (silent data leak to PlatformAdmin).
+        assert!(
+            !items.is_empty(),
+            "{uri}: expected at least the seeded {expected_unit_name} unit, got empty. body={body}"
+        );
+        for (i, item) in items.iter().enumerate() {
+            assert_eq!(
+                item["tenantId"],
+                tenant_a.id.as_str(),
+                "{uri}: items[{i}].tenantId must be tenant A only, item={item}"
+            );
+            assert_eq!(
+                item["tenantSlug"], slug_a,
+                "{uri}: items[{i}].tenantSlug must be slug A only, item={item}"
+            );
+        }
+    }
+}
+
+/// #44.d §5.5 — PlatformAdmin + ?tenant=<nonexistent> returns 404 tenant_not_found.
+///
+/// Must happen AFTER authorization (PlatformAdmin required) so unauthenticated
+/// callers can't probe for tenant existence — they see forbidden_scope first.
+/// Here we assert the admin case hits the 404 cleanly.
+#[tokio::test]
+async fn cross_tenant_s5_5_nonexistent_slug_returns_404() {
+    let Some((state, _tmp)) = test_app_state().await else {
+        eprintln!("Skipping §5.5: Docker not available");
+        return;
+    };
+    let app = router::build_router(state);
+    // Slug guaranteed not to exist — UUID-suffixed + explicit "nope" prefix.
+    let ghost = format!("nope-{}", uuid::Uuid::new_v4().simple());
+
+    for endpoint in ["/api/v1/user", "/api/v1/project", "/api/v1/org"] {
+        let uri = format!("{endpoint}?tenant={ghost}");
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&uri)
+                    .header("x-user-id", "platform-admin")
+                    .header("x-user-role", "platform_admin")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "{uri}: expected 404 for nonexistent tenant slug"
+        );
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            body["error"], "tenant_not_found",
+            "{uri}: error code must be tenant_not_found, body={body}"
+        );
+        assert!(
+            body["message"].as_str().unwrap_or("").contains(&ghost),
+            "{uri}: 404 message should echo the requested slug for debuggability, got {}",
+            body["message"]
+        );
+    }
+}
+
+/// #44.d §5.6 — ?tenant=all emits a deprecation warning + resolves like *.
+///
+/// Uses tracing-test to capture logs emitted during the request. The test
+/// fails if EITHER the log line is missing (client-facing behavior drift)
+/// OR the request is rejected (semantic drift from the ?tenant=* alias).
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn cross_tenant_s5_6_all_alias_emits_deprecation_log() {
+    let Some((state, _tmp)) = test_app_state().await else {
+        eprintln!("Skipping §5.6: Docker not available");
+        return;
+    };
+    let app = router::build_router(state);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/project?tenant=all")
+                .header("x-user-id", "platform-admin")
+                .header("x-user-role", "platform_admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "?tenant=all must resolve identically to ?tenant=* (same 200)"
+    );
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        body["scope"], "all",
+        "?tenant=all must emit scope=all envelope, body={body}"
+    );
+    // The compat log target carries structured fields; tracing-test lets
+    // us assert the message fragment is present. We look for the endpoint
+    // label + the parameter + the replacement hint — three independent
+    // signals so the test doesn't brittle-bind to exact wording.
+    assert!(
+        logs_contain("deprecated tenant scope alias"),
+        "expected compat warning for ?tenant=all; check tracing::warn target='compat'"
+    );
+    assert!(
+        logs_contain("?tenant=*"),
+        "compat warning must hint the canonical replacement"
+    );
+    assert!(
+        logs_contain("/project"),
+        "compat warning must tag the endpoint label for log filtering"
+    );
+}
+
+/// #44.d §5.7 — Pagination ordering is stable across ?tenant=* responses.
+///
+/// Not true pagination (the endpoints don't implement offset/limit today),
+/// but the STABLE-ORDERING contract the docs promise:
+///   (tenant_id ASC, name ASC, id ASC)
+/// Any repeated call must return items in the exact same order, and any
+/// two consecutive items must respect the total ordering. If a future PR
+/// adds real pagination, this test is the first line of defense against
+/// ordering drift between pages.
+#[tokio::test]
+async fn cross_tenant_s5_7_stable_ordering_across_calls() {
+    let Some((state, _tmp)) = test_app_state().await else {
+        eprintln!("Skipping §5.7: Docker not available");
+        return;
+    };
+    // Seed 3 tenants × 2 projects each so we have enough data for the
+    // ordering predicate to be non-trivial. 6 items, 3 tenant buckets.
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    for i in 0..3 {
+        let slug = format!("s5-7-{i}-{}", &suffix[..8]);
+        let tenant = state
+            .tenant_store
+            .create_tenant(&slug, &format!("S5.7 Tenant {i}"))
+            .await
+            .expect("create tenant");
+        let tid = TenantId::new(tenant.id.as_str().to_string()).unwrap();
+        for name in ["alpha", "beta"] {
+            seed_unit_of_type(
+                &state,
+                &tid,
+                mk_core::types::UnitType::Project,
+                &format!("{name}-{slug}"),
+            )
+            .await;
+        }
+    }
+    let app = router::build_router(state);
+
+    let fetch_items = || async {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/project?tenant=*")
+                    .header("x-user-id", "platform-admin")
+                    .header("x-user-role", "platform_admin")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        body["items"].as_array().cloned().unwrap_or_default()
+    };
+
+    let first = fetch_items().await;
+    let second = fetch_items().await;
+    assert_eq!(
+        first, second,
+        "/project?tenant=* must return items in the same order across calls"
+    );
+
+    // Verify the ordering predicate holds: (tenant_id, name, id) ASC.
+    for pair in first.windows(2) {
+        let a = &pair[0];
+        let b = &pair[1];
+        let key = |v: &serde_json::Value| {
+            (
+                v["tenantId"].as_str().unwrap_or("").to_string(),
+                v["name"].as_str().unwrap_or("").to_string(),
+                v["id"].as_str().unwrap_or("").to_string(),
+            )
+        };
+        let ka = key(a);
+        let kb = key(b);
+        assert!(
+            ka <= kb,
+            "ordering violated: {ka:?} > {kb:?}. The (tenant_id, name, id) \
+             ordering is part of the documented envelope contract \
+             (docs/api/admin.md)."
+        );
+    }
+}
+
+/// #44.d §5.8 — POST ?tenant=* returns 400 scope_not_allowed_for_write.
+///
+/// ?tenant=* is a READ-side broadening. Allowing writes under it would
+/// either (a) silently collapse to the caller's tenant — bad, it looks
+/// like you got what you asked for when you didn't — or (b) fan out to
+/// every tenant, which is a bulk-write superpower that deserves its own
+/// explicit API. Both are wrong; 400 at the entry point is correct.
+#[tokio::test]
+async fn cross_tenant_s5_8_post_with_tenant_star_rejected() {
+    let Some((state, _tmp)) = test_app_state().await else {
+        eprintln!("Skipping §5.8: Docker not available");
+        return;
+    };
+    let app = router::build_router(state);
+
+    // Body shape is irrelevant — the guard fires BEFORE request-body
+    // parsing. Using a plausible-looking payload avoids accidental early
+    // returns that would mask the guard regression.
+    let cases: &[(&str, serde_json::Value)] = &[
+        (
+            "/api/v1/user?tenant=*",
+            json!({ "email": "x@example.com", "name": "x" }),
+        ),
+        (
+            "/api/v1/project?tenant=*",
+            json!({ "name": "x", "parent_id": null }),
+        ),
+        (
+            "/api/v1/org?tenant=*",
+            json!({ "name": "x", "parent_id": null }),
+        ),
+        // ?tenant=all (alias) must be rejected symmetrically; otherwise
+        // clients using the deprecated alias would find a write hole.
+        (
+            "/api/v1/project?tenant=all",
+            json!({ "name": "x", "parent_id": null }),
+        ),
+    ];
+    for (uri, body_json) in cases {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(*uri)
+                    .header("x-user-id", "platform-admin")
+                    .header("x-user-role", "platform_admin")
+                    .header("x-tenant-id", "default")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(body_json).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "{uri}: POST with cross-tenant scope must be rejected with 400"
+        );
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            body["error"], "scope_not_allowed_for_write",
+            "{uri}: error code must be scope_not_allowed_for_write, body={body}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary (#44.d Bundle B)

Closes the remaining `?tenant=<slug>` 501s for `/user`, `/project`, `/org` and lands the full §5 integration test matrix. After Bundle A (PR #69, merged) and this, the only surviving 501 is on `/govern/audit` — intentional, per the §2.5 deferral (no row-level `tenant_id` in `governance_audit_log`).

Two commits, one feature + one test.

## Commit 1 — feat: `?tenant=<slug>` + write-scope guard (§2.2–2.4 + §5.8)

### Resolver

`resolve_list_scope` grows a `supports_single: bool` parameter:

- When `true` and param is neither `*` nor `all`, gate to PlatformAdmin (403 otherwise), look up via `tenant_store.get_tenant(slug_or_uuid)`, return `ListDispatch::CrossTenantSingle(ResolvedTenant)` on hit, `404 tenant_not_found` on miss.
- When `false`, slug path still returns `501 scope_not_implemented` — used by `/govern/audit` + `/admin/tenants`.

The auth-before-lookup order matters: non-admins see `forbidden_scope` first, so they cannot probe for tenant existence.

### Handlers

`list_users_cross_tenant`, `list_projects_cross_tenant`, `list_orgs_cross_tenant` all gain `single_tenant: Option<&ResolvedTenant>`. Filtering is a post-query `retain` (or `filter_map` for users, where the existing query already yields `tenant_id`-keyed rows) — NOT a new SQL variant. That keeps the cross-tenant SELECT single-sourced so ordering, filter composition, and per-item decoration cannot drift between all-tenants and single-foreign modes.

### Envelope

All-tenants mode: `{success, scope: "all", items[]}` — unchanged.
Single-foreign mode: `{success, scope: "tenant", tenant: {id, slug, name}, items[]}`.

The `tenant` key is OMITTED (not `null`) in the all-tenants case to keep the §4.1 contract lean.

### §5.8 — write-scope guard

New `context::reject_cross_tenant_write(raw_query, endpoint)` helper. Wired into POST `/user`, `/project`, `/org` via `axum::extract::RawQuery`. Returns `400 scope_not_allowed_for_write` when query contains `tenant=*` or `tenant=all` (alias guarded symmetrically so deprecated-alias clients don’t find a write hole).

Rationale for 400 over silent fallback: reusing a list URL for a POST would otherwise silently collapse to `X-Tenant-ID`, landing data in the wrong tenant. 400 surfaces the client bug at entry.

## Commit 2 — test: §5 integration matrix (§5.3–5.8) + docstring refresh

Six new integration tests in `cli/tests/server_runtime_test.rs`. All follow the existing Docker-skip convention so they run cleanly headless.

| Task | Test | Asserts |
|---|---|---|
| §5.3 | `cross_tenant_s5_3_no_tenant_param_preserves_legacy_shape` | No `?tenant=` → BARE array response on /user, /project, /org. Locks backward-compat. |
| §5.4 | `cross_tenant_s5_4_slug_returns_only_that_tenant` | Seeds 2 tenants; `?tenant=<slug-a>` returns scope="tenant", echoed tenant object, AND every item belongs to tenant A only (isolation contract). |
| §5.5 | `cross_tenant_s5_5_nonexistent_slug_returns_404` | Ghost slug → `tenant_not_found` on all 3 endpoints; message echoes slug. |
| §5.6 | `cross_tenant_s5_6_all_alias_emits_deprecation_log` | Uses `tracing-test` to capture `compat::warn` line. Verifies 3 independent fragments: "deprecated tenant scope alias", `?tenant=*` hint, endpoint label. |
| §5.7 | `cross_tenant_s5_7_stable_ordering_across_calls` | 3×2 seeded; 2 calls → byte-identical items[]; (tenant_id, name, id) ordering holds on every adjacent pair. |
| §5.8 | `cross_tenant_s5_8_post_with_tenant_star_rejected` | POST with `?tenant=*` and `?tenant=all` on all 3 endpoints → 400 `scope_not_allowed_for_write`. |

§5.1 + §5.2 are already covered by the envelope-contract test and the per-endpoint 403-forbidden_scope tests landed in earlier §2.x commits.

Added dev-dep: `tracing-test = "0.2"` (for §5.6).

## Verification

```
cargo check -p aeterna --tests ✅
cargo test cross_tenant_s5_ ✅ (6/6 pass, Docker-skip here)
cargo clippy -p aeterna --tests ✅ (no new warnings in touched files)
```

## Tasks closed by this PR

- [x] §2.2 `/user` — `?tenant=<slug>` implemented
- [x] §2.3 `/project` — `?tenant=<slug>` implemented
- [x] §2.4 `/org` — `?tenant=<slug>` implemented
- [x] §5.3, §5.4, §5.5, §5.6, §5.7, §5.8 integration tests

## Remaining in #44.d

- §3 cross-tenant repository layer cleanup (if any wrapping is warranted after this PR)
- §6 CLI flag wiring (separate PR, per the spec)

Refs #44.