### PR TITLE
feat+test+docs(#44.d): Bundle C — CLI --all-tenants/--tenant flags + deprecate X-Target-Tenant-Id

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -823,13 +823,27 @@ impl AeternaClient {
     // Org endpoints
     // -----------------------------------------------------------------------
 
-    pub async fn org_list(&self, company: Option<&str>, all: bool) -> Result<serde_json::Value> {
+    /// List organizations.
+    ///
+    /// When `tenant_scope` is `Some(value)`, the value is forwarded as the
+    /// `?tenant=` query parameter verbatim (see `docs/api/admin.md` for
+    /// the grammar: `*`, case-insensitive `all`, or a slug/uuid). `None`
+    /// preserves the pre-#44.d behavior (tenant-scoped listing).
+    pub async fn org_list(
+        &self,
+        company: Option<&str>,
+        all: bool,
+        tenant_scope: Option<&str>,
+    ) -> Result<serde_json::Value> {
         let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(c) = company {
             params.push(("company", c.to_string()));
         }
         if all {
             params.push(("all", "true".to_string()));
+        }
+        if let Some(t) = tenant_scope {
+            params.push(("tenant", t.to_string()));
         }
         let path = build_path("/api/v1/org", &params);
         parse_json_response(self.get(&path).await?).await
@@ -959,12 +973,16 @@ impl AeternaClient {
     // User endpoints
     // -----------------------------------------------------------------------
 
+    /// List users.
+    ///
+    /// See [`Self::org_list`] for the `tenant_scope` semantics.
     pub async fn user_list(
         &self,
         org: Option<&str>,
         team: Option<&str>,
         role: Option<&str>,
         all: bool,
+        tenant_scope: Option<&str>,
     ) -> Result<serde_json::Value> {
         let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(o) = org {
@@ -978,6 +996,9 @@ impl AeternaClient {
         }
         if all {
             params.push(("all", "true".to_string()));
+        }
+        if let Some(t) = tenant_scope {
+            params.push(("tenant", t.to_string()));
         }
         let path = build_path("/api/v1/user", &params);
         parse_json_response(self.get(&path).await?).await
@@ -1106,6 +1127,13 @@ impl AeternaClient {
         .await
     }
 
+    /// Fetch governance audit entries.
+    ///
+    /// See [`Self::org_list`] for the `tenant_scope` semantics. Note that
+    /// `/govern/audit` currently only supports `?tenant=*` (via
+    /// `--all-tenants`); `?tenant=<slug>` returns `501 scope_not_implemented`
+    /// pending the per-row `acting_as_tenant_id` column work — see
+    /// #44.d §2.5.
     pub async fn govern_audit(
         &self,
         action: Option<&str>,
@@ -1113,6 +1141,7 @@ impl AeternaClient {
         actor: Option<&str>,
         target_type: Option<&str>,
         limit: usize,
+        tenant_scope: Option<&str>,
     ) -> Result<serde_json::Value> {
         let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(a) = action {
@@ -1128,6 +1157,9 @@ impl AeternaClient {
             params.push(("target_type", t.to_string()));
         }
         params.push(("limit", limit.to_string()));
+        if let Some(t) = tenant_scope {
+            params.push(("tenant", t.to_string()));
+        }
         let path = build_path("/api/v1/govern/audit", &params);
         parse_json_response(self.get(&path).await?).await
     }

--- a/cli/src/commands/govern.rs
+++ b/cli/src/commands/govern.rs
@@ -194,6 +194,16 @@ pub struct GovernAuditArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+
+    /// #44.d §6 — cross-tenant scoping (`--all-tenants` / `--tenant <slug>`).
+    ///
+    /// On `/govern/audit` specifically: `--all-tenants` is supported and
+    /// returns the cross-tenant envelope. `--tenant <slug>` returns `501
+    /// scope_not_implemented` pending the per-row `acting_as_tenant_id`
+    /// column work (#44.d §2.5 deferral). The CLI will surface the 501
+    /// response body as a normal error.
+    #[command(flatten)]
+    pub scope: super::tenant_scope::TenantScopeArgs,
 }
 
 #[derive(Clone, ValueEnum)]
@@ -1101,6 +1111,7 @@ async fn run_audit(args: GovernAuditArgs) -> anyhow::Result<()> {
         } else {
             Some(args.action.as_str())
         };
+        let scope = args.scope.to_query_param();
         let result = client
             .govern_audit(
                 action,
@@ -1108,6 +1119,7 @@ async fn run_audit(args: GovernAuditArgs) -> anyhow::Result<()> {
                 args.actor.as_deref(),
                 args.target_type.as_deref(),
                 args.limit,
+                scope.as_deref(),
             )
             .await
             .inspect_err(|e| {
@@ -1126,7 +1138,13 @@ async fn run_audit(args: GovernAuditArgs) -> anyhow::Result<()> {
                 }
             })?;
 
-        let filtered: Vec<_> = result.as_array().cloned().unwrap_or_default();
+        // /govern/audit can return either the legacy bare array (no
+        // ?tenant=) or the #44.d cross-tenant envelope (?tenant=*). Use
+        // the shared normalizer so the rest of the rendering path stays
+        // envelope-agnostic.
+        let payload = super::tenant_scope::ListPayload::from_json(&result);
+        let filtered: Vec<serde_json::Value> = payload.items.iter().map(|v| (*v).clone()).collect();
+        let cross_tenant_banner = payload.banner.clone();
 
         match args.export {
             ExportFormat::None => {
@@ -1139,6 +1157,9 @@ async fn run_audit(args: GovernAuditArgs) -> anyhow::Result<()> {
                     println!("{}", serde_json::to_string_pretty(&output)?);
                 } else {
                     output::header(&format!("Governance Audit Trail (last {})", args.since));
+                    if let Some(banner) = &cross_tenant_banner {
+                        println!("  {banner}");
+                    }
                     println!();
 
                     if filtered.is_empty() {
@@ -1728,6 +1749,7 @@ mod tests {
             export: ExportFormat::None,
             output: None,
             json: false,
+            scope: Default::default(),
         };
         assert_eq!(args.action, "all");
         assert_eq!(args.since, "7d");
@@ -1745,6 +1767,7 @@ mod tests {
             export: ExportFormat::Json,
             output: Some("audit.json".to_string()),
             json: false,
+            scope: Default::default(),
         };
         assert_eq!(args.action, "approve");
         assert!(args.actor.is_some());
@@ -1761,6 +1784,7 @@ mod tests {
             export: ExportFormat::Csv,
             output: Some("audit.csv".to_string()),
             json: false,
+            scope: Default::default(),
         };
         matches!(args.export, ExportFormat::Csv);
         assert!(args.output.is_some());

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod status;
 pub mod sync;
 pub mod team;
 pub mod tenant;
+pub mod tenant_scope;
 pub mod user;
 
 use clap::{Parser, Subcommand};

--- a/cli/src/commands/org.rs
+++ b/cli/src/commands/org.rs
@@ -60,6 +60,10 @@ pub struct OrgListArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+
+    /// #44.d §6 — cross-tenant scoping (`--all-tenants` / `--tenant <slug>`).
+    #[command(flatten)]
+    pub scope: super::tenant_scope::TenantScopeArgs,
 }
 
 #[derive(Args)]
@@ -311,8 +315,9 @@ async fn run_create(args: OrgCreateArgs) -> anyhow::Result<()> {
 
 async fn run_list(args: OrgListArgs) -> anyhow::Result<()> {
     if let Some(client) = get_live_client().await {
+        let scope = args.scope.to_query_param();
         let result = client
-            .org_list(args.company.as_deref(), args.all)
+            .org_list(args.company.as_deref(), args.all, scope.as_deref())
             .await
             .inspect_err(|e| {
                 if args.json {
@@ -331,23 +336,35 @@ async fn run_list(args: OrgListArgs) -> anyhow::Result<()> {
             })?;
 
         if args.json {
+            // JSON mode emits the server payload verbatim — envelope or
+            // array. Automation callers need the exact server shape so
+            // they can distinguish scope=all / scope=tenant themselves.
             println!("{}", serde_json::to_string_pretty(&result)?);
         } else {
+            let payload = super::tenant_scope::ListPayload::from_json(&result);
             output::header("Organizations");
+            if let Some(banner) = &payload.banner {
+                println!("  {banner}");
+            }
             println!();
-            if let Some(orgs) = result.as_array() {
-                if orgs.is_empty() {
-                    println!("  (no organizations found)");
-                } else {
-                    for org in orgs {
-                        let id = get_str(org, &["id"]).unwrap_or("?");
-                        let name = get_str(org, &["name"]).unwrap_or("?");
-                        let company = get_str(org, &["parentId", "parent_id"]).unwrap_or("-");
+            if payload.items.is_empty() {
+                println!("  (no organizations found)");
+            } else {
+                for org in &payload.items {
+                    let id = get_str(org, &["id"]).unwrap_or("?");
+                    let name = get_str(org, &["name"]).unwrap_or("?");
+                    let company = get_str(org, &["parentId", "parent_id"]).unwrap_or("-");
+                    // In cross-tenant views decorate with the tenant slug
+                    // so operators can see WHICH tenant each row belongs
+                    // to — otherwise the listing is ambiguous (two orgs
+                    // can legitimately share a name across tenants).
+                    if args.scope.is_cross_tenant() {
+                        let tenant = get_str(org, &["tenantSlug"]).unwrap_or("-");
+                        println!("  [{tenant:<16}] {id:<24} {name:<32} {company}");
+                    } else {
                         println!("  {id:<24} {name:<32} {company}");
                     }
                 }
-            } else {
-                println!("{}", serde_json::to_string_pretty(&result)?);
             }
             println!();
         }

--- a/cli/src/commands/tenant_scope.rs
+++ b/cli/src/commands/tenant_scope.rs
@@ -1,0 +1,235 @@
+//! #44.d §6 — shared CLI args for cross-tenant scoping.
+//!
+//! Wired into `aeterna user list`, `aeterna org list`, and `aeterna govern
+//! audit`. The two flags are mutually exclusive at parse time (clap
+//! `conflicts_with`); see `to_query_param` for the mapping to the
+//! `?tenant=` grammar consumed by the server.
+//!
+//! Design choice: one tiny args struct, flattened into each list command,
+//! instead of three copy-pasted pairs of flags. Keeps the UX consistent
+//! (same flag names, same help text) and gives us a single place to add
+//! future scopes (e.g. `--tenants a,b,c`) without touching every site.
+
+use clap::Args;
+
+/// Cross-tenant scoping flags for list commands.
+///
+/// Maps 1:1 to the `?tenant=` query grammar documented in
+/// `docs/api/admin.md`:
+///
+/// | Flag              | Resolves to             |
+/// |-------------------|-------------------------|
+/// | (none)            | no query param (legacy) |
+/// | `--all-tenants`   | `?tenant=*`             |
+/// | `--tenant <slug>` | `?tenant=<slug>`        |
+///
+/// The `--all-tenants` / `--tenant` pair is mutually exclusive at parse
+/// time. Combining them is ALWAYS a client bug (what would it mean?) so
+/// rejecting at the clap layer surfaces the mistake before a request is
+/// issued.
+#[derive(Args, Debug, Clone, Default)]
+pub struct TenantScopeArgs {
+    /// List across every tenant (PlatformAdmin only).
+    ///
+    /// Emits the cross-tenant envelope
+    /// (`{success, scope: "all", items: [...]}`) with every item decorated
+    /// with `tenantId` / `tenantSlug` / `tenantName`. See
+    /// `docs/api/admin.md` for the full contract.
+    #[arg(long = "all-tenants", conflicts_with = "tenant")]
+    pub all_tenants: bool,
+
+    /// List a specific foreign tenant by slug or id (PlatformAdmin only).
+    ///
+    /// Emits the single-foreign-tenant envelope
+    /// (`{success, scope: "tenant", tenant: {...}, items: [...]}`).
+    /// Returns `404 tenant_not_found` if the slug/id doesn't exist.
+    #[arg(
+        long = "tenant",
+        value_name = "SLUG_OR_ID",
+        conflicts_with = "all_tenants"
+    )]
+    pub tenant: Option<String>,
+}
+
+impl TenantScopeArgs {
+    /// Value to send as the `?tenant=` query parameter, if any.
+    ///
+    /// Returns `None` when no scoping flag was passed — callers should
+    /// fall through to the legacy tenant-scoped path. Returns `Some("*")`
+    /// for `--all-tenants` and `Some(slug)` for `--tenant <slug>`.
+    pub fn to_query_param(&self) -> Option<String> {
+        if self.all_tenants {
+            Some("*".to_string())
+        } else {
+            self.tenant.clone()
+        }
+    }
+
+    /// True when any cross-tenant scope is requested (for callers that
+    /// want to branch on display logic, e.g. show an extra "Tenant" column).
+    pub fn is_cross_tenant(&self) -> bool {
+        self.all_tenants || self.tenant.is_some()
+    }
+}
+
+/// Description of the listing payload as received from the server.
+///
+/// CLI list commands (`user list`, `org list`, `govern audit`) can receive
+/// one of THREE shapes since #44.d:
+///
+/// 1. Bare JSON array — pre-#44.d legacy shape, returned when no
+///    `?tenant=` is sent. Callers MUST continue to support this shape for
+///    backward compatibility.
+/// 2. `{success, scope: "all", items: [...]}` — `?tenant=*` / `all` path.
+/// 3. `{success, scope: "tenant", tenant: {id, slug, name}, items: [...]}`
+///    — `?tenant=<slug>` path (not applicable to `/govern/audit`).
+///
+/// `ListPayload::from_json` normalizes all three into a single iterable
+/// view + an optional banner the CLI can print above the table.
+pub struct ListPayload<'a> {
+    /// Flattened items array, regardless of envelope shape.
+    pub items: Vec<&'a serde_json::Value>,
+    /// Human-readable banner line to print above the table, or None for
+    /// the legacy path. Examples: `"Cross-tenant view: all tenants"`,
+    /// `"Tenant view: acme (01HW...)"`.
+    pub banner: Option<String>,
+}
+
+impl<'a> ListPayload<'a> {
+    /// Normalize any of the three list-response shapes. Falls back to an
+    /// empty list + no banner if the payload is malformed (we prefer
+    /// "show an empty table" over "crash the CLI"). The server-level
+    /// tests guard the contract so this defensive branch should be dead
+    /// in practice.
+    pub fn from_json(value: &'a serde_json::Value) -> Self {
+        // Legacy bare-array shape.
+        if let Some(arr) = value.as_array() {
+            return Self {
+                items: arr.iter().collect(),
+                banner: None,
+            };
+        }
+        // Envelope shape — must have an items[] array.
+        let items: Vec<&serde_json::Value> = value
+            .get("items")
+            .and_then(|i| i.as_array())
+            .map(|a| a.iter().collect())
+            .unwrap_or_default();
+        let banner = match value.get("scope").and_then(|s| s.as_str()) {
+            Some("all") => Some("Cross-tenant view: all tenants".to_string()),
+            Some("tenant") => {
+                let slug = value
+                    .pointer("/tenant/slug")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                let id = value
+                    .pointer("/tenant/id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                Some(format!("Tenant view: {slug} ({id})"))
+            }
+            _ => None,
+        };
+        Self { items, banner }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_flags_yields_no_query_param() {
+        let args = TenantScopeArgs::default();
+        assert_eq!(args.to_query_param(), None);
+        assert!(!args.is_cross_tenant());
+    }
+
+    #[test]
+    fn all_tenants_maps_to_star() {
+        let args = TenantScopeArgs {
+            all_tenants: true,
+            tenant: None,
+        };
+        assert_eq!(args.to_query_param().as_deref(), Some("*"));
+        assert!(args.is_cross_tenant());
+    }
+
+    #[test]
+    fn slug_passes_through_verbatim() {
+        let args = TenantScopeArgs {
+            all_tenants: false,
+            tenant: Some("acme".into()),
+        };
+        assert_eq!(args.to_query_param().as_deref(), Some("acme"));
+        assert!(args.is_cross_tenant());
+    }
+
+    #[test]
+    fn list_payload_handles_legacy_bare_array() {
+        let v = serde_json::json!([{"id": "a"}, {"id": "b"}]);
+        let p = ListPayload::from_json(&v);
+        assert_eq!(p.items.len(), 2);
+        assert!(p.banner.is_none(), "legacy path must NOT show a banner");
+    }
+
+    #[test]
+    fn list_payload_handles_scope_all_envelope() {
+        let v = serde_json::json!({
+            "success": true,
+            "scope": "all",
+            "items": [{"id": "a", "tenantSlug": "t1"}],
+        });
+        let p = ListPayload::from_json(&v);
+        assert_eq!(p.items.len(), 1);
+        assert_eq!(p.banner.as_deref(), Some("Cross-tenant view: all tenants"));
+    }
+
+    #[test]
+    fn list_payload_handles_scope_tenant_envelope() {
+        let v = serde_json::json!({
+            "success": true,
+            "scope": "tenant",
+            "tenant": {"id": "01HW0000", "slug": "acme", "name": "Acme"},
+            "items": [{"id": "a"}, {"id": "b"}, {"id": "c"}],
+        });
+        let p = ListPayload::from_json(&v);
+        assert_eq!(p.items.len(), 3);
+        let banner = p.banner.expect("tenant-scope banner must be set");
+        // Assert the banner contains both slug and id so operators can
+        // visually confirm WHICH tenant they're viewing — both fields
+        // matter (slug for humans, id for log/support correlation).
+        assert!(banner.contains("acme"), "banner missing slug: {banner}");
+        assert!(banner.contains("01HW0000"), "banner missing id: {banner}");
+    }
+
+    #[test]
+    fn list_payload_tolerates_malformed_envelope() {
+        // Envelope with no items key — defensive fallback path. Must not
+        // panic; should produce an empty items[] + no banner.
+        let v = serde_json::json!({"success": true, "scope": "unknown"});
+        let p = ListPayload::from_json(&v);
+        assert!(p.items.is_empty());
+        assert!(p.banner.is_none());
+    }
+
+    #[test]
+    fn clap_rejects_both_flags_together() {
+        use clap::Parser;
+        #[derive(clap::Parser)]
+        struct Harness {
+            #[command(flatten)]
+            scope: TenantScopeArgs,
+        }
+        // Both flags specified — clap must reject via conflicts_with so we
+        // never reach run-time with an ambiguous scope.
+        let err = Harness::try_parse_from(["t", "--all-tenants", "--tenant", "acme"])
+            .err()
+            .expect("clap should reject conflicting scope flags");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cannot be used with") || msg.contains("conflict"),
+            "expected a conflict error, got: {msg}"
+        );
+    }
+}

--- a/cli/src/commands/user.rs
+++ b/cli/src/commands/user.rs
@@ -80,6 +80,10 @@ pub struct UserListArgs {
 
     #[arg(long)]
     pub json: bool,
+
+    /// #44.d §6 — cross-tenant scoping (`--all-tenants` / `--tenant <slug>`).
+    #[command(flatten)]
+    pub scope: super::tenant_scope::TenantScopeArgs,
 }
 
 #[derive(Args)]
@@ -297,12 +301,14 @@ async fn run_register(args: UserRegisterArgs) -> anyhow::Result<()> {
 
 async fn run_list(args: UserListArgs) -> anyhow::Result<()> {
     if let Some(client) = get_live_client().await {
+        let scope = args.scope.to_query_param();
         let result = client
             .user_list(
                 args.org.as_deref(),
                 args.team.as_deref(),
                 args.role.as_deref(),
                 args.all,
+                scope.as_deref(),
             )
             .await
             .inspect_err(|e| {
@@ -322,15 +328,36 @@ async fn run_list(args: UserListArgs) -> anyhow::Result<()> {
             })?;
 
         if args.json {
+            // JSON mode: emit the server envelope verbatim.
             println!("{}", serde_json::to_string_pretty(&result)?);
         } else {
+            let payload = super::tenant_scope::ListPayload::from_json(&result);
             output::header("Users");
+            if let Some(banner) = &payload.banner {
+                println!("  {banner}");
+            }
             println!();
-            if let Some(users) = result.as_array() {
-                if users.is_empty() {
-                    println!("  (no users found)");
-                } else {
-                    for user in users {
+            if payload.items.is_empty() {
+                println!("  (no users found)");
+            } else {
+                for user in &payload.items {
+                    if args.scope.is_cross_tenant() {
+                        // Prefix each row with the tenant slug — cross-tenant
+                        // views can return two users with the same email
+                        // living in different tenants, and the tenant is
+                        // the disambiguator.
+                        let tenant = user
+                            .get("tenantSlug")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("-");
+                        println!(
+                            "  [{:<16}] {:<36} {:<24} {}",
+                            tenant,
+                            user["email"].as_str().unwrap_or("?"),
+                            user["name"].as_str().unwrap_or("?"),
+                            user["status"].as_str().unwrap_or("?")
+                        );
+                    } else {
                         println!(
                             "  {:<36} {:<24} {}",
                             user["email"].as_str().unwrap_or("?"),
@@ -339,8 +366,6 @@ async fn run_list(args: UserListArgs) -> anyhow::Result<()> {
                         );
                     }
                 }
-            } else {
-                println!("{}", serde_json::to_string_pretty(&result)?);
             }
             println!();
         }
@@ -967,6 +992,7 @@ mod tests {
             role: None,
             all: false,
             json: false,
+            scope: Default::default(),
         };
         assert!(args.org.is_none());
         assert!(args.team.is_none());
@@ -983,6 +1009,7 @@ mod tests {
             role: Some("developer".to_string()),
             all: true,
             json: true,
+            scope: Default::default(),
         };
         assert_eq!(args.org, Some("engineering".to_string()));
         assert_eq!(args.team, Some("backend".to_string()));
@@ -1199,6 +1226,7 @@ mod tests {
             role: None,
             all: true,
             json: false,
+            scope: Default::default(),
         };
         assert!(args.all);
     }
@@ -1287,6 +1315,7 @@ mod tests {
             role: None,
             all: false,
             json: false,
+            scope: Default::default(),
         };
         assert!(args.org.is_some());
         assert!(args.team.is_none());
@@ -1301,6 +1330,7 @@ mod tests {
             role: None,
             all: false,
             json: false,
+            scope: Default::default(),
         };
         assert!(args.team.is_some());
         assert!(args.org.is_none());
@@ -1314,6 +1344,7 @@ mod tests {
             role: Some("admin".to_string()),
             all: false,
             json: true,
+            scope: Default::default(),
         };
         assert!(args.role.is_some());
         assert!(args.json);

--- a/cli/src/server/auth_middleware.rs
+++ b/cli/src/server/auth_middleware.rs
@@ -197,11 +197,7 @@ async fn tenant_context_from_identity(
 
     let user_id = UserId::new(user_id_str)?;
 
-    let target_tenant_id = headers
-        .get("x-target-tenant-id")
-        .and_then(|v| v.to_str().ok())
-        .filter(|s| !s.is_empty())
-        .and_then(|s| TenantId::new(s.chars().take(100).collect()));
+    let target_tenant_id = extract_deprecated_target_tenant(headers);
 
     Some(TenantContext {
         tenant_id,
@@ -210,6 +206,40 @@ async fn tenant_context_from_identity(
         roles,
         target_tenant_id,
     })
+}
+
+/// Extract the legacy `X-Target-Tenant-Id` header and emit a deprecation
+/// warning if present.
+///
+/// #44.d §8 — `X-Target-Tenant-Id` is the pre-RFC header used for ad-hoc
+/// PlatformAdmin impersonation. It has been superseded by the `?tenant=`
+/// query parameter grammar (see `docs/api/admin.md`) which is:
+/// - explicit at the call site (URL, not header)
+/// - gated consistently across all list endpoints (`forbidden_scope` /
+///   `scope_not_implemented` / `tenant_not_found`)
+/// - locked by the §4.1 envelope contract test
+///
+/// We still HONOR the header to avoid breaking any in-flight client, but
+/// emit a `tracing::warn!` with `target = "compat"` so operators can find
+/// stragglers in log aggregation and migrate them off. Removal is planned
+/// for a future minor — see #44.e.
+pub(super) fn extract_deprecated_target_tenant(
+    headers: &axum::http::HeaderMap,
+) -> Option<TenantId> {
+    let raw = headers
+        .get("x-target-tenant-id")
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty())?;
+
+    tracing::warn!(
+        target: "compat",
+        header = "X-Target-Tenant-Id",
+        replacement = "?tenant=<slug-or-*>",
+        raw_value_prefix = %raw.chars().take(16).collect::<String>(),
+        "deprecated cross-tenant header — clients should migrate to the ?tenant= query parameter; removal planned in a future minor"
+    );
+
+    TenantId::new(raw.chars().take(100).collect())
 }
 
 /// Build a synthetic `TenantContext` from legacy headers for development mode.
@@ -236,11 +266,7 @@ fn dev_context_from_headers(headers: &axum::http::HeaderMap) -> TenantContext {
         .map(|s| vec![RoleIdentifier::from_str_flexible(s)])
         .unwrap_or_default();
 
-    let target_tenant_id = headers
-        .get("x-target-tenant-id")
-        .and_then(|v| v.to_str().ok())
-        .filter(|s| !s.is_empty())
-        .and_then(|s| TenantId::new(s.chars().take(100).collect()));
+    let target_tenant_id = extract_deprecated_target_tenant(headers);
 
     TenantContext {
         tenant_id: TenantId::new(tenant_str.chars().take(100).collect())

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -48,7 +48,7 @@ use mk_core::traits::{AuthorizationService, EventPublisher, KnowledgeRepository}
 use mk_core::types::INSTANCE_SCOPE_TENANT_ID;
 use mk_core::types::SYSTEM_USER_ID;
 use mk_core::types::{PROVIDER_GITHUB, PROVIDER_KUBERNETES};
-use mk_core::types::{RoleIdentifier, TenantContext, TenantId, UserId};
+use mk_core::types::{RoleIdentifier, TenantContext, UserId};
 use serde_json::json;
 use storage::events::EventError;
 use storage::git_provider_connection_store::GitProviderConnectionError;
@@ -394,11 +394,10 @@ pub async fn authenticated_tenant_context(
         ctx.roles.clone()
     };
 
-    let target_tenant_id = headers
-        .get("x-target-tenant-id")
-        .and_then(|v| v.to_str().ok())
-        .filter(|s| !s.is_empty())
-        .and_then(|s| TenantId::new(s.chars().take(100).collect()));
+    // #44.d §8 — X-Target-Tenant-Id is deprecated in favor of ?tenant=<slug>.
+    // Delegate to the shared extractor so the compat::warn log line is
+    // emitted uniformly from every entry point that still honors the header.
+    let target_tenant_id = auth_middleware::extract_deprecated_target_tenant(headers);
 
     Ok(TenantContext {
         tenant_id: tenant.id,

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -4744,6 +4744,83 @@ async fn cross_tenant_s5_6_all_alias_emits_deprecation_log() {
     );
 }
 
+/// #44.d §8 — Legacy `X-Target-Tenant-Id` header still works, but emits a
+/// deprecation warning every time.
+///
+/// Behavioral contract (what we can NOT break without a major version):
+///
+/// 1. Requests carrying `X-Target-Tenant-Id` continue to be honored.
+///    Existing clients (CI scripts, support tools, etc.) must not break
+///    the day we ship this PR — removal is planned for a separate later
+///    minor.
+/// 2. Every such request logs a `tracing::warn!(target = "compat", ...)`
+///    line naming (a) the header, (b) the replacement grammar, and (c)
+///    enough of the raw value that log aggregation can correlate with
+///    client traffic and identify stragglers.
+///
+/// This test exercises the happy path — auth succeeds with the header
+/// set, a downstream endpoint returns 200 — and asserts the warn line is
+/// present. If a future refactor stops honoring the header OR stops
+/// emitting the warning, this test fails loudly with a precise message.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn cross_tenant_s8_legacy_target_tenant_header_emits_deprecation_log() {
+    let Some((state, _tmp)) = test_app_state().await else {
+        eprintln!("Skipping §8: Docker not available");
+        return;
+    };
+    let app = router::build_router(state);
+
+    // Use a GET that only needs auth (not cross-tenant scoping) so the
+    // compat::warn signal we assert on is UNAMBIGUOUSLY from the
+    // `X-Target-Tenant-Id` path, not from a `?tenant=*` alias code path.
+    // `/api/v1/project` with plain tenant headers is sufficient.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/project")
+                .header("x-user-id", "platform-admin")
+                .header("x-user-role", "platform_admin")
+                .header("x-tenant-id", "default")
+                // The legacy header we want to verify. A realistic client
+                // would pass a tenant slug or id here. We use a visually
+                // distinctive value so we can assert the log line echoed
+                // its prefix (operators need this to grep log streams and
+                // find which clients are still sending it).
+                .header("x-target-tenant-id", "legacy-client-abc123")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "X-Target-Tenant-Id must remain honored — removal requires a minor bump"
+    );
+
+    // Three independent fragments — if ANY of them is missing, the log
+    // line has drifted and operators' compat dashboards will break.
+    assert!(
+        logs_contain("deprecated cross-tenant header"),
+        "expected compat warning naming the deprecation"
+    );
+    assert!(
+        logs_contain("X-Target-Tenant-Id"),
+        "compat warning must name the exact header for grep-ability"
+    );
+    assert!(
+        logs_contain("?tenant="),
+        "compat warning must point clients at the replacement grammar"
+    );
+    assert!(
+        logs_contain("legacy-client-abc123"),
+        "compat warning must echo the raw value prefix so operators can correlate with client traffic"
+    );
+}
+
 /// #44.d §5.7 — Pagination ordering is stable across ?tenant=* responses.
 ///
 /// Not true pagination (the endpoints don't implement offset/limit today),

--- a/docs/api/admin.md
+++ b/docs/api/admin.md
@@ -99,4 +99,34 @@ Endpoint-specific query parameters (e.g. `?actor=`, `?since=`, `?action=` on `/g
 - Resolver implementation: [`cli/src/server/context.rs`](../../cli/src/server/context.rs) (search `resolve_list_scope`)
 - Contract test: [`cli/tests/server_runtime_test.rs`](../../cli/tests/server_runtime_test.rs) (search `assert_cross_tenant_envelope_contract`)
 - RLS boundary guard: [`storage/tests/rls_boundary_test.rs`](../../storage/tests/rls_boundary_test.rs)
-- CLI integration (planned): [#44.d §6](../../openspec/changes/add-cross-tenant-admin-listing/tasks.md#6-cli-updates-separate-pr-tracked-here-for-cross-reference)
+- CLI integration: see [CLI flags](#cli-flags) below.
+
+## CLI flags
+
+The `?tenant=` grammar is surfaced to the `aeterna` CLI via two mutually-exclusive flags, flattened into every list command that supports cross-tenant scoping:
+
+| Flag              | Server query                 | Envelope emitted        |
+|-------------------|------------------------------|-------------------------|
+| (none)            | `GET /…` (no `?tenant=`)     | legacy bare array       |
+| `--all-tenants`   | `GET /…?tenant=*`            | `scope: "all"`          |
+| `--tenant <slug>` | `GET /…?tenant=<slug>`       | `scope: "tenant"`       |
+
+Commands that honor these flags today:
+
+- `aeterna user list [--all-tenants | --tenant <slug>]`
+- `aeterna org list  [--all-tenants | --tenant <slug>]`
+- `aeterna govern audit [--all-tenants]` — `--tenant <slug>` currently returns `501 scope_not_implemented` (see §2.5 note above).
+
+Combining the two flags is rejected at parse time (clap `conflicts_with`) — combining them is always a client bug.
+
+In cross-tenant views the human-readable output grows a leading `[tenant]` column so items that would otherwise look ambiguous (e.g. two orgs with the same name in different tenants) stay distinguishable. `--json` mode emits the raw server envelope unchanged so automation can rely on the exact contract documented above.
+
+## Deprecated: `X-Target-Tenant-Id` header
+
+Prior to #44.d, PlatformAdmins could target a foreign tenant by setting the `X-Target-Tenant-Id` request header. That path is now **deprecated** in favor of the `?tenant=<slug>` query parameter documented above.
+
+- The header is **still honored** — existing CI scripts and support tools won't break when this change ships.
+- Each request carrying the header emits a `tracing::warn!(target = "compat", header = "X-Target-Tenant-Id", replacement = "?tenant=<slug-or-*>", ...)` log line including a prefix of the raw value so operators can correlate with client traffic and find stragglers.
+- Removal is planned for a future minor version — tracked in the follow-up §8 work. Clients should migrate to `?tenant=<slug>` / `?tenant=*` at their earliest convenience.
+
+Why replace it: the header was opaque at the URL level (invisible in access logs, browser devtools, curl transcripts) and bypassed the per-endpoint scope-gate that `?tenant=` now enforces uniformly (`forbidden_scope` / `scope_not_implemented` / `tenant_not_found`). The query parameter is explicit, testable, and subject to the §4.1 envelope contract test.


### PR DESCRIPTION
## Summary (#44.d Bundle C)

Surfaces the `?tenant=` grammar to the `aeterna` CLI and formally deprecates the legacy `X-Target-Tenant-Id` header (without breaking it). After Bundle A (#69) and Bundle B (#70) shipped the envelope contract + server implementation, this bundle closes the loop with the operator-facing pieces: flags, friendly rendering, and a migration runway for the old header.

Two commits, cleanly separable.

## Commit 1 — §8 deprecation of `X-Target-Tenant-Id`

Pre-#44.d, PlatformAdmins impersonated foreign tenants by setting `X-Target-Tenant-Id`. The header is problematic for three reasons:

- Invisible in URL access logs, browser devtools, curl transcripts — cross-tenant activity is hard to audit post-hoc.
- Bypasses the per-endpoint scope gate (`forbidden_scope` / `scope_not_implemented` / `tenant_not_found`) that `?tenant=` now enforces uniformly.
- Not covered by the §4.1 envelope contract test.

This commit marks it deprecated **without breaking it**:

- Refactor the three extraction sites (`auth_middleware.rs` authenticated + dev paths, `server/mod.rs` legacy reader) into one `pub(super) extract_deprecated_target_tenant` helper.
- The helper emits `tracing::warn!(target = "compat", header = "X-Target-Tenant-Id", replacement = "?tenant=<slug-or-*>", raw_value_prefix = …)` on every hit. The 16-char value prefix lets operators correlate log entries with specific client traffic and identify stragglers.
- TenantId extraction logic is byte-identical — existing clients keep working.

Removal is tracked as follow-up (#44.e).

## Commit 2 — §6 CLI flags + §8 integration test + docs

### New module: `cli/src/commands/tenant_scope.rs`

`TenantScopeArgs` is a tiny flattened clap struct with two mutually-exclusive flags mapping 1:1 to the `?tenant=` grammar:

| Flag              | Server query               | Envelope         |
|-------------------|----------------------------|------------------|
| (none)            | `GET /…`                    | legacy array     |
| `--all-tenants`   | `GET /…?tenant=*`           | `scope: "all"`   |
| `--tenant <slug>` | `GET /…?tenant=<slug>`      | `scope: "tenant"`|

Combining the two is rejected at parse time (clap `conflicts_with`) — always a client bug.

Flattened into `UserListArgs`, `OrgListArgs`, `GovernAuditArgs`. Client methods `org_list`, `user_list`, `govern_audit` grow a tail `tenant_scope: Option<&str>` param; `None` preserves exact pre-#44.d behavior.

### `ListPayload` normalizer

The three possible response shapes (legacy array / `scope=all` / `scope=tenant`) are normalized into a uniform `(items, banner)` view. Banner:

- `scope=all` → `"Cross-tenant view: all tenants"`
- `scope=tenant` → `"Tenant view: <slug> (<id>)"` (both fields — slug for humans, id for log correlation)
- legacy → no banner (preserves pre-#44.d output byte-identically)

Cross-tenant views also prepend a `[tenant-slug]` column per row so ambiguous names (two orgs named "Platform" in different tenants) stay distinguishable. `--json` mode emits the raw server envelope verbatim so automation can branch on `scope`.

### §8 integration test

`cross_tenant_s8_legacy_target_tenant_header_emits_deprecation_log` sends a plain GET with `X-Target-Tenant-Id` on `/project`, asserts 200 OK + **four independent log fragments**:

1. `"deprecated cross-tenant header"` (human prefix)
2. `"X-Target-Tenant-Id"` (exact header name, for grep-ability)
3. `"?tenant="` (replacement grammar hint)
4. raw-value prefix (so log aggregation can correlate)

Endpoint choice (`/project` over a cross-tenant endpoint) is deliberate: we need a path where the ONLY compat::warn source is the header reader, not a `?tenant=all` alias branch.

### Unit tests

`tenant_scope::tests` grows from 4 to 8 — adds `ListPayload` coverage for all three shapes + a defensive fallback.

### Docs

`docs/api/admin.md` grows a CLI-flags table and a deprecation section for the header.

## Verification

```
cargo check -p aeterna --tests ✅
cargo fmt ✅
cargo test -p aeterna --lib tenant_scope:: ✅ (8/8)
cargo test -p aeterna --test server_runtime_test cross_tenant_s8 ✅ (1/1)
```

## Tasks closed

- [x] §6 CLI flags on `user list`, `org list`, `govern audit`
- [x] §8 `X-Target-Tenant-Id` deprecation warning + integration test

## #44.d status after this PR

Bundle A (#69), Bundle B (#70), Bundle C (this PR) cover §1–2, §4–8. Remaining:

- §3 cross-tenant repository-layer cleanup — deferred; no immediate wrapping need surfaced by Bundle B.
- §2.5 `/govern/audit?tenant=<slug>` — deferred, needs per-row `acting_as_tenant_id` column (already documented in admin.md).
- §8 actual removal of `X-Target-Tenant-Id` — tracked as #44.e (minor bump required).

Refs #44.