### PR TITLE
RFC: Decide RLS enforcement model — Option A (dual-role / dual-pool)

### DIFF
--- a/openspec/changes/decide-rls-enforcement-model/README.md
+++ b/openspec/changes/decide-rls-enforcement-model/README.md
@@ -1,12 +1,18 @@
 # decide-rls-enforcement-model
 
-**Decision: Option A** — activate RLS on every request-scoped connection.
+**Decision: Option A** — activate RLS on every request-scoped connection, via a **two-role / two-pool / two-helper** design.
 
-- `proposal.md` — why, decision summary, 5-bundle rollout plan.
-- `design.md` — threat model, option analysis, implementation strategy, risk register.
-- `tasks.md` — itemized work per bundle (A.1 hazard fixes → A.2 role + CI → A.3 repo refactor → A.4 prod flip → A.5 cleanup).
-- `specs/runtime-security-hardening/spec.md` — normative spec delta (final-state wording).
+- `aeterna_app` (NOBYPASSRLS) + `state.pool` + `with_tenant_context(&ctx, …)` — 99% of traffic
+- `aeterna_admin` (BYPASSRLS) + `state.admin_pool` (size=4) + `with_admin_context(&ctx, …)` — PA cross-tenant, scheduled cross-tenant jobs, migrations
+- `system_ctx` sentinel for internal scheduled work
+- Every `with_admin_context` call is auto-audited inside the helper
 
-Originally opened as Option C (RLS as a test-time gate). Architect override on threat-model grounds pivoted the decision to A. See commit trail.
+Implementation lands in **3 stacked bundles** (originally 5 — A.4 and A.5 collapsed into A.3 wave 6 because the system is pre-production):
+
+- **A.1** — Hazard fixes (H1 session-scope set_config, H2 dual-GUC namespace)
+- **A.2** — Roles + migration + dual pools + both helpers + CI verification suite
+- **A.3** — Call-site refactor in 6 waves; wave 6 flips `DATABASE_URL`, deletes orphan calls (H3), graduates lint to deny
+
+See `proposal.md` / `design.md` / `tasks.md` / `specs/runtime-security-hardening/spec.md`.
 
 Tracks issue #58. Graduated via PR #72.

--- a/openspec/changes/decide-rls-enforcement-model/README.md
+++ b/openspec/changes/decide-rls-enforcement-model/README.md
@@ -1,10 +1,12 @@
 # decide-rls-enforcement-model
 
-Architectural decision change: records the chosen PostgreSQL row-level security enforcement model for Aeterna. Resolves #58.
+**Decision: Option A** — activate RLS on every request-scoped connection.
 
-- `proposal.md` — Why, What Changes, capabilities touched, decision summary.
-- `design.md` — Full analysis of Options A / B / C, hazards surfaced by the analysis, recommendation rationale.
-- `specs/runtime-security-hardening/spec.md` — 1 MODIFIED + 2 ADDED requirements on the `runtime-security-hardening` capability.
-- `tasks.md` — Implementation tasks for the chosen option (C: RLS as CI-time gate).
+- `proposal.md` — why, decision summary, 5-bundle rollout plan.
+- `design.md` — threat model, option analysis, implementation strategy, risk register.
+- `tasks.md` — itemized work per bundle (A.1 hazard fixes → A.2 role + CI → A.3 repo refactor → A.4 prod flip → A.5 cleanup).
+- `specs/runtime-security-hardening/spec.md` — normative spec delta (final-state wording).
 
-**Decision:** Option C — RLS stays enabled and policies are authored, but prod connections remain BYPASSRLS; a dedicated non-BYPASSRLS role (`aeterna_app_rls`) is used by the integration test suite to convert the policies into a CI enforcement gate against missed `WHERE tenant_id = ?` clauses.
+Originally opened as Option C (RLS as a test-time gate). Architect override on threat-model grounds pivoted the decision to A. See commit trail.
+
+Tracks issue #58. Graduated via PR #72.

--- a/openspec/changes/decide-rls-enforcement-model/README.md
+++ b/openspec/changes/decide-rls-enforcement-model/README.md
@@ -1,0 +1,10 @@
+# decide-rls-enforcement-model
+
+Architectural decision change: records the chosen PostgreSQL row-level security enforcement model for Aeterna. Resolves #58.
+
+- `proposal.md` — Why, What Changes, capabilities touched, decision summary.
+- `design.md` — Full analysis of Options A / B / C, hazards surfaced by the analysis, recommendation rationale.
+- `specs/runtime-security-hardening/spec.md` — 1 MODIFIED + 2 ADDED requirements on the `runtime-security-hardening` capability.
+- `tasks.md` — Implementation tasks for the chosen option (C: RLS as CI-time gate).
+
+**Decision:** Option C — RLS stays enabled and policies are authored, but prod connections remain BYPASSRLS; a dedicated non-BYPASSRLS role (`aeterna_app_rls`) is used by the integration test suite to convert the policies into a CI enforcement gate against missed `WHERE tenant_id = ?` clauses.

--- a/openspec/changes/decide-rls-enforcement-model/design.md
+++ b/openspec/changes/decide-rls-enforcement-model/design.md
@@ -1,0 +1,115 @@
+# Design: RLS Enforcement Model
+
+## 1. Current State
+
+### 1.1 What exists on paper
+
+| Migration | Tables | Policy shape |
+|-----------|--------|--------------|
+| `004_enable_rls.sql` | `sync_state`, `memory_entries`, `knowledge_items` | `USING (tenant_id = current_setting('app.tenant_id', true)::uuid)` |
+| `016_governance_rls.sql` | `governance_configs`, `approval_requests`, `governance_roles`, `approval_decisions`, `escalation_queue` | `FORCE ROW LEVEL SECURITY` + scope helper functions keyed on `current_setting('app.company_id', true)` |
+| `024_normalize_rls_session_variables.sql` | `governance_events`, `event_delivery_metrics`, `event_consumer_state` | `USING (tenant_id = current_setting('app.tenant_id', true))` |
+| various intermediate migrations | 14 other tables | mix of `app.tenant_id` / `app.current_tenant_id` (normalization pass deferred) |
+
+Total: **22 tables, ENABLE; 5 of those additionally FORCE**.
+
+### 1.2 What exists in code
+
+`activate_tenant_context` call sites (repo-wide grep):
+
+```
+storage/src/postgres.rs:63        set_config('app.tenant_id', $1, false)  ← helper body
+storage/src/gdpr.rs:407,490,580   set_config('app.tenant_id', $1, true)
+cli/src/server/backup_api.rs:1597 set_config('app.tenant_id', $1, false)
+cli/src/server/sync.rs:131,256    activate_tenant_context(...)            ← only 2 high-level call sites
+```
+
+Repository-layer SELECTs against the 22 RLS tables: **100+ call sites** across `cli/src/server/user_api.rs`, `project_api.rs`, `org_api.rs`, `memory_api.rs`, `knowledge_api.rs`, `governance_api.rs`, `audit_api.rs`. None of them pre-activate a tenant context. All of them carry an explicit `WHERE tenant_id = $1` clause (the real enforcement).
+
+### 1.3 Prior-art hazards surfaced by this analysis
+
+**Hazard H1 — session-scope `set_config`.** `storage/src/postgres.rs:63` and `cli/src/server/backup_api.rs:1597` both use `set_config('app.tenant_id', $1, false)`. The third argument `false` means *session-level* — the setting survives on the pooled connection after the query completes. The next request borrowing that connection inherits tenant A's `app.tenant_id` unless it explicitly resets. Under the current prod BYPASSRLS reality this has no blast radius; under Option A it becomes a cross-tenant leak. Either way the fix is the same: switch to `set_config(..., true)` (transaction-local) and wrap the query in an explicit BEGIN.
+
+**Hazard H2 — dual GUC namespace.** Older migrations use `app.company_id`; newer use `app.tenant_id`; the normalization pass (`024`) only converted three tables. A request that sets one GUC leaves the other stale on the connection. Again invisible under BYPASSRLS, weaponized under Option A.
+
+**Hazard H3 — orphan `activate_tenant_context` call sites in `sync.rs`.** The two call sites that DO activate context are themselves no-ops (they run as BYPASSRLS). They read as correct defense-in-depth code; they are actually dead code. This misleads contributors reviewing `sync.rs` as a reference for how to write RLS-aware code.
+
+## 2. Options Considered
+
+### Option A — Make RLS real
+
+Prod enforcement via RLS. Shape:
+
+1. New migration: `CREATE ROLE aeterna_app_rls LOGIN NOBYPASSRLS PASSWORD …`; grant `USAGE` on schema + per-table DML.
+2. Prod `DATABASE_URL` switches to `aeterna_app_rls`. Deploy ordering: role exists before image flip.
+3. Auth middleware acquires a pool connection, `BEGIN`, `SET LOCAL app.tenant_id = $1`, runs handler, `COMMIT` (or `ROLLBACK` on error). Connection lifetime == request lifetime.
+4. The 100+ repository call sites DO NOT change — they continue to carry their `WHERE tenant_id = ?` clauses (belt-and-suspenders).
+5. Fix H1/H2/H3 as preconditions (mandatory; otherwise prod breaks under non-BYPASSRLS).
+
+**Pros.** Genuine defense in depth. A missed `WHERE tenant_id = ?` in app code is caught at the DB layer. Compliance narrative is real, not paper.
+
+**Cons.**
+- Transaction-per-request overhead. For read-mostly endpoints this roughly doubles round trips to the DB (BEGIN + query + COMMIT).
+- Connection handle must be threaded through every handler (or hidden in an axum Extension). Either way, the 100+ repository sites need to accept a `&mut PgConnection` or a `&mut Transaction` instead of a `&PgPool`. That is the ~100-site refactor.
+- `FORCE ROW LEVEL SECURITY` on governance tables means even the table owner (migration runner) is subject to policy — migrations need to `SET ROLE postgres` explicitly or we lose the ability to run DDL against those tables as any non-bypassing role.
+- The session-variable leak (H1) MUST be fixed first or every pooled connection becomes a cross-tenant time bomb.
+
+**Effort.** 4–6 weeks of focused work, high coordination cost across storage + server + CI.
+
+### Option B — Drop RLS
+
+Remove all 22 `ENABLE ROW LEVEL SECURITY` / 5 `FORCE ROW LEVEL SECURITY`. Drop all policies. Delete `activate_tenant_context`. Document in `AGENTS.md` that tenant isolation is app-layer `WHERE tenant_id = ?`, enforced by code review and `sqlx` query macros.
+
+**Pros.** Honest. Cheap (one migration + code removal). No overhead. No session-variable leak to worry about.
+
+**Cons.** Loses the paper defense-in-depth story that Kyriba security / compliance reviews may require. Zero DB-layer safety net against a missed `WHERE` clause. Future Kyriba auditors will ask why a multi-tenant product has no RLS; answer ("application code enforces") is correct but unsatisfying.
+
+**Effort.** 1 week.
+
+### Option C — RLS as test-time gate
+
+Prod connection stays BYPASSRLS (no change to runtime). Integration tests run under a dedicated `aeterna_app_rls` role that is non-BYPASSRLS, and exercise the actual handler code under a real tenant context.
+
+Concrete shape:
+
+1. New migration: `CREATE ROLE aeterna_app_rls LOGIN NOBYPASSRLS PASSWORD 'test_only_insecure'`; grant minimal DML. Role is test-only; prod deploys do not use it.
+2. `cli/tests/rls_enforcement_test.rs` — new integration test file:
+   - Opens a second pool using `DATABASE_URL` with username replaced by `aeterna_app_rls`.
+   - For each RLS-protected table, runs two queries: (a) with `SELECT set_config('app.tenant_id', <tid>, true)` in a BEGIN → expect N rows; (b) without setting context → expect 0 rows.
+   - Additionally exercises the high-level list paths (`/user`, `/project`, `/org`, `/govern/audit`) against the RLS role to prove the handler + repository stack produces tenant-filtered results even with RLS actually enforced.
+3. Fix H1/H2/H3 opportunistically. H1 is a hard requirement for the test to pass without flakes.
+
+**Pros.**
+- Prod overhead unchanged (0 ms, 0 connection-lifecycle churn).
+- Real compile-time-ish guarantee: any future PR that introduces a query missing `WHERE tenant_id = ?` against an RLS-protected table fails CI. This is the main value RLS provides today; Option C captures that value at 5% of Option A's cost.
+- Kyriba security review answer: “RLS policies are authored, enforced in CI against a non-BYPASSRLS role, and additionally enforced at the application layer in prod for latency reasons.” That is a defensible posture.
+- Reversible. If threat model changes, we flip prod to `aeterna_app_rls` and we're in Option A with the session-variable bugs already fixed.
+
+**Cons.**
+- Not true defense in depth *in prod*. A prod-only regression (e.g. a hand-rolled query added via a migration-time admin script) could still leak across tenants.
+- Requires test discipline: the RLS test role must be kept in sync with per-table grants as migrations add tables. We guard this with a schema-introspection test that fails if a new RLS-enabled table lacks an explicit grant to `aeterna_app_rls`.
+
+**Effort.** 1–2 weeks.
+
+## 3. Recommendation — Option C
+
+Option A is technically the "right answer" for a product under a strict zero-trust threat model. Aeterna is not that product: it is an internal-tenant tool where the adversary is a buggy handler, not a malicious user of the public API. Against that threat model, Option A's runtime overhead and refactor cost buys us protection against a class of bug (missed `WHERE tenant_id = ?`) that Option C already catches in CI.
+
+Option B throws away the authored policies, which we would regret the first time a Kyriba security review asks "what stops a SQL injection from reading another tenant?". With Option C the answer is "the app's DB role has access to all tenants but every query carries `WHERE tenant_id = ?` and the CI suite runs under a role where missing that clause returns zero rows."
+
+Option C preserves the policies as a live artifact (they must compile, they must pass the test suite) and converts them from decorative to enforceable. It is reversible to Option A if the threat model changes.
+
+## 4. Spec Impact
+
+One MODIFIED and one ADDED requirement on `runtime-security-hardening`:
+
+- **MODIFIED** "Backend-Specific Persistence Isolation" — clarifies that on Postgres, tenant isolation is enforced by application-layer `WHERE tenant_id = ?` clauses; RLS policies are authored for CI enforcement, not prod.
+- **ADDED** "RLS Test-Time Enforcement" — normative requirement that a dedicated non-BYPASSRLS role exists, that the integration test suite exercises all RLS-protected tables under that role, and that schema introspection fails CI if a new RLS-enabled table lacks a grant to the test role.
+
+Spec delta lives in `specs/runtime-security-hardening/spec.md`.
+
+## 5. Rollout
+
+1. Land this change (proposal + design + spec delta + migration adding `aeterna_app_rls` role + test suite + H1 fixes).
+2. Archive it once the test suite is green and `AGENTS.md` / `DEVELOPER_GUIDE.md` are updated.
+3. If / when the threat model changes: file a new change `flip-prod-to-rls-enforced` that builds on this one. The role exists, the session-variable hygiene is fixed — that change becomes a middleware-wiring PR instead of a six-week architectural lift.

--- a/openspec/changes/decide-rls-enforcement-model/design.md
+++ b/openspec/changes/decide-rls-enforcement-model/design.md
@@ -2,74 +2,117 @@
 
 ## 1. Problem
 
-The codebase ships with a comprehensive RLS story on paper: 22 tables with `ENABLE ROW LEVEL SECURITY`, 5 with `FORCE`, and an explicit GUC `app.tenant_id` that every policy consults. The runtime behavior does not match the paper. `PostgresBackend::activate_tenant_context` is called in two places (both in `cli/src/server/sync.rs`, both currently effective no-ops); no migration creates a non-BYPASSRLS role; prod `DATABASE_URL` points at whatever role the operator provisioned, which in the shipped compose config is `postgres` (superuser, implicit BYPASSRLS).
+The codebase ships with a comprehensive RLS story on paper: 22 tables with `ENABLE ROW LEVEL SECURITY`, 5 with `FORCE`, an explicit `app.tenant_id` GUC, and 24 migrations' worth of policies. The runtime behavior does not match. `PostgresBackend::activate_tenant_context` is called in two places (both orphan no-ops in `sync.rs`), no migration creates a non-BYPASSRLS role, and the shipped `DATABASE_URL` points at the `postgres` superuser. The app-layer `WHERE tenant_id = $N` clauses are the de facto isolation. Any handler that forgets that clause leaks cross-tenant rows and the RLS policies do nothing.
 
-The app-layer `WHERE tenant_id = $N` clauses scattered across the repository layer are the de facto isolation. If any handler forgets that clause on an RLS-protected table, the query returns cross-tenant rows in prod even though RLS appears enabled.
+There is no production environment and no live user base. The system is pre-launch. Fixing the enforcement model now costs a refactor with zero blast radius; inheriting BYPASSRLS into launch costs a rewrite under customer pressure.
 
-Three viable resolutions exist. Each is a complete answer; they are not cumulative.
+## 2. Goal
 
-## 2. Threat model (the deciding input)
+Make row-level security the authoritative tenant isolation mechanism at runtime, not a paper artifact. Retain the app-layer `WHERE tenant_id = ?` clauses as required defense in depth on top. Build an end-to-end CI regression guard that catches any future code path that bypasses the model.
 
-The threat model this change locks in, after architect override on the initial C recommendation:
-
-> **T1.** A buggy handler on a live production request — a missing `WHERE tenant_id = ?` clause, a typo in a join, a repository method that was written for admin-scope and re-used for user-scope — MUST NOT be able to read rows belonging to another tenant, even if it successfully reaches `self.pool.acquire()` and issues the query.
->
-> **T2.** A compromised handler (SQL injection, deserialization RCE, dependency supply-chain) on a live production request MUST be constrained by the database's own isolation mechanism, not only by the handler's own SQL string.
-
-`T1` is within reach of Option C if we accept "regression caught in CI before merge" as sufficient. `T2` is not — a compromised handler in prod never ran against the CI role, and Option C's test-time enforcement is silent on that path. Option A is the only option that satisfies both.
+This is not a threat-model-driven change (no threat model is interesting pre-production). It is an architectural correctness change: the documented enforcement posture and the runtime enforcement posture must agree.
 
 ## 3. Option analysis
 
+Three options are viable; Option A is chosen.
+
 ### 3.1 Option A — Activate RLS on every request-scoped connection (chosen)
 
-**Shape.** App connects as a non-BYPASSRLS role (`aeterna_app`). Every request borrows a connection via `with_tenant_context(&ctx, |conn| …)`, which opens an explicit transaction, issues `SET LOCAL app.tenant_id = $1`, runs the body, and commits or rolls back. RLS policies evaluate against the live GUC on every statement; any query without the `WHERE` clause still returns only the current tenant's rows because the policy enforces the predicate.
+**Shape.** Two PostgreSQL roles, two connection pools, two helpers. The application connects via `aeterna_app` (non-BYPASSRLS) for all per-tenant work and via `aeterna_admin` (BYPASSRLS) for the narrow admin surface. Every request that touches tenant-scoped tables acquires its connection through `with_tenant_context(&ctx, |tx| …)` which opens a transaction, issues `SET LOCAL app.tenant_id = $1`, runs the body, and commits. Cross-tenant admin work goes through `with_admin_context(&ctx, |tx| …)` on a separate small pool, with audit-logging wired into the helper itself.
 
-**Satisfies threat model.** Both `T1` and `T2`. The database itself is the final gate.
+**Why chosen.** Only option that makes RLS authoritative at runtime. The dual-role design solves the PlatformAdmin cross-tenant and scheduled-jobs problems without forcing BYPASSRLS onto the default role. The CI verification suite acts as the permanent regression guard. Pre-production timing makes the refactor essentially free.
 
-**Cost.**
-- **4–6 weeks of engineering.** Helper implementation is 1–2 days; the 100-site repository refactor is 3–4 weeks spread across 4–6 waves; the canary rollout adds 2+ weeks of soak time that runs in parallel with cleanup work.
-- **Transaction-per-request overhead.** Every read path now incurs `BEGIN` … `COMMIT` round-trips. On pgbouncer with transaction-mode pooling the overhead is negligible (pgbouncer was already transaction-scoping connections); on session-mode pooling the overhead is larger. Current deployments use transaction-mode pgbouncer per `docker-compose.yml`, so this is a near-zero regression in practice.
-- **Hazard resolution required first.** H1 (session-scope `set_config(..., false)`) and H2 (dual GUC namespace) must be closed before the role flip, because revoking BYPASSRLS weaponizes both into live cross-tenant leaks. This is why Bundle A.1 is a hard prerequisite for Bundle A.4.
-
-**Rollback.** Per-bundle: A.1–A.3 are warn-level or CI-only, trivially revertable. A.4 is a single env-var change (`AETERNA_DB_ROLE=bypassrls`) plus a rolling pool restart, under 5 minutes per region. A.5 is the only non-revertable bundle and only lands after A.4 has soaked in prod for ≥ 4 weeks.
+**Cost.** 4–6 weeks of engineering split across 3 bundles. Transaction-per-request overhead on the default pool; negligible on the current transaction-mode pgbouncer setup, and not a concern pre-production regardless.
 
 ### 3.2 Option B — Drop RLS entirely (rejected)
 
-**Shape.** `ALTER TABLE … DISABLE ROW LEVEL SECURITY` on all 22 tables, drop all policies, update docs to say "app-layer only."
+**Shape.** `ALTER TABLE … DISABLE ROW LEVEL SECURITY` on all 22 tables, drop all policies, document app-layer-only.
 
-**Satisfies threat model.** Neither `T1` nor `T2`.
+**Why rejected.** Honest about the current reality but throws away the migrations that wrote the policies and eliminates the path to defense in depth. Same correctness properties as the current state; different label.
 
-**Cost.** ~1 week. Simplifies the mental model at the cost of losing every downstream defense. Also throws away migration 024 (the partial GUC normalization) as dead code.
+### 3.3 Option C — RLS as a CI-only gate (rejected)
 
-**Why rejected.** Unacceptable under the locked threat model. Also loses the ability to ever revisit defense-in-depth without reintroducing the same 22 policies from scratch.
+**Shape.** Keep the default role on BYPASSRLS; add `aeterna_app` but use it only in an integration test suite that exercises every RLS table.
 
-### 3.3 Option C — RLS as a test-time gate (rejected)
+**Why rejected.** Covers the "regression caught pre-merge" case but does nothing at runtime. Accepts that a missing `WHERE` clause in a never-tested code path still leaks. Not worse than today but not better either; the CI value survives by shipping the suite inside Bundle A.2.
 
-**Shape.** Keep prod on BYPASSRLS; add a dedicated non-BYPASSRLS role used only by an integration test suite; every RLS-enabled table is exercised under that role on every CI run.
+## 4. The dual-role, dual-pool design
 
-**Satisfies threat model.** `T1` partially (catches regressions pre-merge), not `T2`.
+The design rests on four concepts that must be introduced together or the parts don't hold up.
 
-**Cost.** 1–2 weeks. The cheapest option that preserves some defense-in-depth value.
+### 4.1 Two roles
 
-**Why rejected.** The gap between "caught in CI" and "caught in prod" is exactly the window that matters for `T1`’s live-request variant, and all of `T2`. The architect's override on the initial C recommendation was explicit: the threat model includes prod-time compromise, not only pre-merge regression. The CI suite from Option C is preserved as a permanent regression guard (shipped inside Bundle A.2), so nothing is lost by choosing A.
+`aeterna_app` has `NOBYPASSRLS` and is granted table-level DML only on tables that have `rowsecurity = true`. Any query it runs against an RLS-protected table is filtered by the policy. This is the role that runs 99% of traffic.
 
-## 4. Implementation strategy
+`aeterna_admin` has `BYPASSRLS` and is granted DML on all application tables. It exists to cover the small set of legitimate cross-tenant operations: PlatformAdmin list endpoints with `?tenant=*`, scheduled cross-tenant maintenance, and the migration runner. Nothing else.
 
-### 4.1 Why staged, not big-bang
+If the application role had `BYPASSRLS` granted directly (the shortest-path alternative), every handler would silently bypass RLS regardless of intent, and the whole point of the change evaporates.
 
-A single PR that (a) ships the new role + grants, (b) refactors 100 query sites, (c) flips prod away from BYPASSRLS is unreviewable and unrevertable. It also couples the three hardest failure modes — grant gaps, refactor bugs, and transaction-per-request overhead — into one incident if anything goes wrong. The bundle structure exists to decouple them.
+### 4.2 Two pools
 
-### 4.2 Bundle ordering and independence
+`state.pool` opens connections as `aeterna_app`, has the normal pool size, and serves request traffic. `state.admin_pool` opens connections as `aeterna_admin`, has `max_connections = 4`, and serves admin/scheduled work. The small pool is a deliberate signal: admin operations are rare, so accidentally running hot-loop work through the admin pool fails loudly.
 
-Bundle A.1 and A.2 are **independent** — either can land first; neither changes runtime behavior under the current BYPASSRLS role. A.3 depends on A.2 (it needs the CI suite to prove the refactor). A.4 depends on A.1, A.2, A.3 all being complete — the role flip only works if hazards are closed, the role exists, and every query goes through the helper. A.5 depends on A.4 having soaked.
+### 4.3 Two helpers
 
-The net property: **any subset of {A.1, A.2, A.3} landing in prod without A.4 introduces zero risk.** A.3 in particular is net-beneficial pre-flip (closes the `activate_tenant_context` gap and makes the transaction scope explicit) and net-neutral under BYPASSRLS (the `SET LOCAL` is harmless when the role bypasses the policy).
+```rust
+pub async fn with_tenant_context<F, T>(&self, ctx: &TenantContext, body: F) -> Result<T>
+where F: FnOnce(&mut Transaction<'_, Postgres>) -> BoxFuture<Result<T>>
+{
+    let mut tx = self.pool.begin().await?;
+    sqlx::query!("SELECT set_config('app.tenant_id', $1, true)", ctx.tenant_id.to_string())
+        .execute(&mut *tx).await?;
+    let out = body(&mut tx).await?;
+    tx.commit().await?;
+    Ok(out)
+}
 
-### 4.3 The `with_tenant_context` helper
-
-The helper pattern is load-bearing. Each call site transforms roughly from:
-
+pub async fn with_admin_context<F, T>(&self, ctx: &TenantContext, body: F) -> Result<T>
+where F: FnOnce(&mut Transaction<'_, Postgres>) -> BoxFuture<Result<T>>
+{
+    let mut tx = self.admin_pool.begin().await?;
+    let out = body(&mut tx).await?;
+    tx.commit().await?;
+    self.audit_admin_access(ctx).await?;
+    Ok(out)
+}
 ```
+
+The tenant helper issues `SET LOCAL`; the admin helper does not. Rustdoc on both declares that direct `state.pool` / `state.admin_pool` access is forbidden outside these helpers. A CI lint (warn-level in A.2, deny-level in A.3 wave 6) enforces it.
+
+The admin helper's `audit_admin_access` call writes a `governance_audit_log` row with `actor_id`, `actor_type`, `admin_scope = true`, and `acting_as_tenant_id = NULL`. Because the audit call lives inside the helper, every cross-tenant admin access is traced without any per-call-site bookkeeping.
+
+### 4.4 Context routing
+
+Handlers choose the helper from the resolved request context:
+
+- `ctx.scope = Tenant(id)` or `CrossTenantSingle(id)` → `with_tenant_context` (the single-tenant-foreign case of #44.d is still one tenant at a time from the DB's perspective).
+- `ctx.scope = CrossTenantAll` and `ctx.actor.is_platform_admin()` → `with_admin_context`.
+- Scheduled per-tenant jobs → scheduler enumerates tenants via `with_admin_context(&system_ctx, …)`, per-tenant work dispatches through `with_tenant_context(&TenantContext::from_scheduled_job(t, job_id), …)`.
+- Scheduled cross-tenant jobs (audit compaction, global rate-limit sweeps) → `with_admin_context(&system_ctx, …)`.
+
+`system_ctx` is a sentinel `TenantContext` with `actor_type = 'system'`, no human actor, no tenant. It exists so scheduled work has a first-class way to identify itself in audit attribution.
+
+## 5. Implementation strategy
+
+### 5.1 Why three bundles
+
+A single PR that stands up roles, wires pools, refactors 100 call sites, and flips the connection string would be unreviewable and would couple every failure mode into one incident. The bundle structure decouples them:
+
+- **A.1 (hazards)** lands in any order, no coupling to the rest.
+- **A.2 (roles + pools + helpers + CI)** lands before any A.3 wave but does not change runtime behavior of existing code — the helpers exist but nothing calls them yet.
+- **A.3 (call-site refactor)** is 6 waves. The first 5 are behavioral no-ops under BYPASSRLS (the `SET LOCAL` is ignored by a BYPASSRLS role). Wave 6 is the single commit that flips `DATABASE_URL` and turns RLS from "tested" to "enforced."
+
+### 5.2 Pre-production simplification
+
+The previous revision of this document contained a Bundle A.4 (`AETERNA_DB_ROLE` feature flag) and a Bundle A.5 (escape-hatch removal + lint graduation). Both were written under the assumption that a production deployment existed. With no prod and no users, both bundles collapse into A.3 wave 6: one commit flips `DATABASE_URL`, deletes the orphan calls, and graduates the lint. No feature flag, no canary, no soak period, no rollback runbook.
+
+This simplification is explicit in the decision: if a production environment comes later, the feature-flag + canary posture returns as a separate operational change at that time.
+
+### 5.3 Refactor mechanics
+
+Each call site transforms from:
+
+```rust
 let mut conn = self.pool.acquire().await?;
 let rows = sqlx::query_as::<_, Row>("SELECT … FROM users WHERE tenant_id = $1")
     .bind(tenant_id).fetch_all(&mut *conn).await?;
@@ -77,34 +120,38 @@ let rows = sqlx::query_as::<_, Row>("SELECT … FROM users WHERE tenant_id = $1"
 
 to:
 
-```
+```rust
 let rows = self.with_tenant_context(&ctx, |tx| async move {
-    sqlx::query_as::<_, Row>("SELECT … FROM users")   // WHERE clause now optional per RLS, kept for DiD
+    sqlx::query_as::<_, Row>("SELECT … FROM users")   // WHERE kept as DiD
         .fetch_all(&mut **tx).await
         .map_err(Into::into)
 }).await?;
 ```
 
-The explicit `WHERE tenant_id = $N` stays as defense-in-depth — Bundle A.5's `AGENTS.md` update documents that this is required, not optional. The RLS policy is the floor; the `WHERE` clause is the ceiling; any query where the two disagree is a bug and `rls_enforcement_test.rs` surfaces it.
+The explicit `WHERE tenant_id = $N` stays as required defense in depth. Bundle A.3 wave 6 updates `AGENTS.md` to document that this is mandatory, not optional — the RLS policy is the floor, the `WHERE` clause is the ceiling, and any query where they disagree is a bug surfaced by `rls_enforcement_test.rs`.
 
-### 4.4 Async workers
+Admin-scope sites (those that currently build a cross-tenant `SELECT` under PlatformAdmin) transform into `with_admin_context(&ctx, |tx| …)`. The `WHERE tenant_id` clause, if present, typically disappears on these because the whole point is cross-tenant read; if present for narrower filtering (e.g., `WHERE status = 'active'`), it stays.
 
-Waves 4 and 5 of A.3 handle `sync.rs` / `webhook.rs` / backup / GDPR paths that don't have a request-scoped tenant. The pattern: each async task acquires its context from its own job record (`sync_jobs.tenant_id`, `backup_jobs.tenant_id`, …) and passes a synthesized `TenantContext::from_async_job(job_id, tenant_id)` into `with_tenant_context`. There is no "unscoped" escape hatch — a job without a tenant either doesn't need RLS-protected tables or is a bug.
+### 5.4 Async workers
 
-## 5. Risk register
+A.3 Wave 4 establishes the pattern for sync / webhook / backup / GDPR workers. The pattern is documented in `DEVELOPER_GUIDE.md` (A.2.4.1) and enforced by the CI suite (A.2.3.5, A.2.3.6). There is no "unscoped worker" escape hatch: a worker that touches tenant-scoped tables either (a) knows its tenant and uses `with_tenant_context` or (b) is genuinely cross-tenant and uses `with_admin_context` with `system_ctx`. No third option.
 
-**H1 — session-scope `set_config(..., false)` on pooled connections.** Current behavior: `backup_api.rs:1597` and legacy call sites use session scope; the setting persists after `.release()` and leaks to whichever request next borrows that connection. Under BYPASSRLS this is silent. Under non-BYPASSRLS (post-A.4) this becomes a live cross-tenant leak. **Mitigation:** Bundle A.1 closes every instance and lands before A.4. Regression test in A.1.
+## 6. Risk register
 
-**H2 — dual GUC namespace.** Migration 024 normalized the policies to read `app.tenant_id`, but several app-side call sites still write `app.company_id` or `app.current_tenant_id`. Under BYPASSRLS this is silent. Under non-BYPASSRLS the policy reads the canonical var and finds NULL → zero rows returned → user-visible outage. **Mitigation:** Bundle A.1 grep-normalizes every app-side read/write; grep regression test in A.1.
+**H1 — session-scope `set_config(..., false)` on pooled connections.** Today: silent under BYPASSRLS. Post-A.3-wave-6: live cross-tenant leak. Mitigation: closed in Bundle A.1 with a regression test.
 
-**H3 — orphan `activate_tenant_context` calls in `sync.rs`.** Currently no-ops under BYPASSRLS; post-A.3 they double-`SET LOCAL` inside `with_tenant_context`, which is harmless but noisy. **Mitigation:** Bundle A.5 deletes them.
+**H2 — dual GUC namespace.** Today: silent. Post-A.3-wave-6: handler runs, RLS policy reads the wrong variable, gets NULL, returns zero rows → visible outage. Mitigation: closed in Bundle A.1 with a grep regression test.
 
-**H4 — transaction-per-request overhead under session-mode pooling.** Not applicable to current deployments (transaction-mode pgbouncer), but documented so a future infra change doesn't regress. **Mitigation:** A.4.8 Grafana panel for transaction duration; alert threshold established during canary.
+**H3 — orphan `activate_tenant_context` in `sync.rs`.** Today: no-op. Post-A.3-wave-6: double-`SET LOCAL` inside `with_tenant_context`, harmless but noisy. Mitigation: deletion in A.3 wave 6.
 
-**H5 — missed grant on a newly-added RLS table.** A contributor adds a migration with `ENABLE ROW LEVEL SECURITY` but forgets to grant `aeterna_app` access → the table is empty under the RLS role. **Mitigation:** A.2.6.1 pre-flight query enumerates `pg_tables WHERE rowsecurity = true` and fails the test run with a named-table error if any grant is missing.
+**H4 — missed grant on a newly-added RLS table.** A contributor adds a migration with `ENABLE ROW LEVEL SECURITY` but forgets to extend the `aeterna_app` grant list. The table is empty under the RLS role. Mitigation: pre-flight in A.2.3.1 enumerates `pg_tables WHERE rowsecurity = true` and fails the CI run with a named-table error.
 
-## 6. Open questions
+**H5 — admin pool misuse.** A handler reaches for `state.admin_pool` directly (skipping `with_admin_context`) and bypasses RLS without audit attribution. Mitigation: CI lint, warn-level in A.2 (A.2.3.7), deny-level in A.3 wave 6. Admin helper's `audit_admin_access` is inside the helper so it cannot be skipped when the helper IS used.
 
-- **pgbouncer auth plumbing.** Can pgbouncer's `auth_file` or `auth_query` resolve the `aeterna_app` password from the same secret store as the app, without duplicating credentials? Tracked for Bundle A.4; may require a small infra PR.
-- **Password rotation.** Initial plan is a secret-manager-backed password referenced as `${APP_DB_PASSWORD}`. Rotation cadence and procedure tracked as an ops ticket after A.4 lands.
-- **Read replicas.** Do read replicas inherit the RLS policies and the grants? Yes (replica replays the full catalog), but the `aeterna_app` role must exist on the replica's primary before failover. Covered by standard replica provisioning; flagged here so it's not forgotten during the A.4 rollout.
+**H6 — scheduled job without tenant attribution.** A new scheduled job touches tenant-scoped tables without picking `with_tenant_context` or `with_admin_context`. Mitigation: the direct-pool-access lint catches this; the handler model forces an explicit choice.
+
+## 7. Open questions
+
+- **Migration runner role.** Migrations currently run as whatever role `DATABASE_URL` points at. Post-A.3-wave-6 that's `aeterna_app`, which cannot run migrations (no DDL privileges). Two options: (a) migration runner uses a third role `aeterna_migrate` with DDL grants; (b) migration runner uses `aeterna_admin`. Leaning (b) for simplicity; flag for review.
+- **pgbouncer auth.** If pgbouncer is in the path, its `auth_file` or `auth_query` needs to resolve both `aeterna_app` and `aeterna_admin` passwords. Tracked as an infra follow-up within Bundle A.3 wave 6.
+- **Audit volume from `with_admin_context`.** Every admin helper call writes an audit row. For frequent admin operations (e.g., PlatformAdmin browsing `/user?tenant=*` repeatedly) this may need deduplication or batched audit. Flagged for review once A.2 CI suite surfaces the actual call volume.

--- a/openspec/changes/decide-rls-enforcement-model/design.md
+++ b/openspec/changes/decide-rls-enforcement-model/design.md
@@ -1,115 +1,110 @@
-# Design: RLS Enforcement Model
+# Design — Decide RLS Enforcement Model
 
-## 1. Current State
+## 1. Problem
 
-### 1.1 What exists on paper
+The codebase ships with a comprehensive RLS story on paper: 22 tables with `ENABLE ROW LEVEL SECURITY`, 5 with `FORCE`, and an explicit GUC `app.tenant_id` that every policy consults. The runtime behavior does not match the paper. `PostgresBackend::activate_tenant_context` is called in two places (both in `cli/src/server/sync.rs`, both currently effective no-ops); no migration creates a non-BYPASSRLS role; prod `DATABASE_URL` points at whatever role the operator provisioned, which in the shipped compose config is `postgres` (superuser, implicit BYPASSRLS).
 
-| Migration | Tables | Policy shape |
-|-----------|--------|--------------|
-| `004_enable_rls.sql` | `sync_state`, `memory_entries`, `knowledge_items` | `USING (tenant_id = current_setting('app.tenant_id', true)::uuid)` |
-| `016_governance_rls.sql` | `governance_configs`, `approval_requests`, `governance_roles`, `approval_decisions`, `escalation_queue` | `FORCE ROW LEVEL SECURITY` + scope helper functions keyed on `current_setting('app.company_id', true)` |
-| `024_normalize_rls_session_variables.sql` | `governance_events`, `event_delivery_metrics`, `event_consumer_state` | `USING (tenant_id = current_setting('app.tenant_id', true))` |
-| various intermediate migrations | 14 other tables | mix of `app.tenant_id` / `app.current_tenant_id` (normalization pass deferred) |
+The app-layer `WHERE tenant_id = $N` clauses scattered across the repository layer are the de facto isolation. If any handler forgets that clause on an RLS-protected table, the query returns cross-tenant rows in prod even though RLS appears enabled.
 
-Total: **22 tables, ENABLE; 5 of those additionally FORCE**.
+Three viable resolutions exist. Each is a complete answer; they are not cumulative.
 
-### 1.2 What exists in code
+## 2. Threat model (the deciding input)
 
-`activate_tenant_context` call sites (repo-wide grep):
+The threat model this change locks in, after architect override on the initial C recommendation:
+
+> **T1.** A buggy handler on a live production request — a missing `WHERE tenant_id = ?` clause, a typo in a join, a repository method that was written for admin-scope and re-used for user-scope — MUST NOT be able to read rows belonging to another tenant, even if it successfully reaches `self.pool.acquire()` and issues the query.
+>
+> **T2.** A compromised handler (SQL injection, deserialization RCE, dependency supply-chain) on a live production request MUST be constrained by the database's own isolation mechanism, not only by the handler's own SQL string.
+
+`T1` is within reach of Option C if we accept "regression caught in CI before merge" as sufficient. `T2` is not — a compromised handler in prod never ran against the CI role, and Option C's test-time enforcement is silent on that path. Option A is the only option that satisfies both.
+
+## 3. Option analysis
+
+### 3.1 Option A — Activate RLS on every request-scoped connection (chosen)
+
+**Shape.** App connects as a non-BYPASSRLS role (`aeterna_app`). Every request borrows a connection via `with_tenant_context(&ctx, |conn| …)`, which opens an explicit transaction, issues `SET LOCAL app.tenant_id = $1`, runs the body, and commits or rolls back. RLS policies evaluate against the live GUC on every statement; any query without the `WHERE` clause still returns only the current tenant's rows because the policy enforces the predicate.
+
+**Satisfies threat model.** Both `T1` and `T2`. The database itself is the final gate.
+
+**Cost.**
+- **4–6 weeks of engineering.** Helper implementation is 1–2 days; the 100-site repository refactor is 3–4 weeks spread across 4–6 waves; the canary rollout adds 2+ weeks of soak time that runs in parallel with cleanup work.
+- **Transaction-per-request overhead.** Every read path now incurs `BEGIN` … `COMMIT` round-trips. On pgbouncer with transaction-mode pooling the overhead is negligible (pgbouncer was already transaction-scoping connections); on session-mode pooling the overhead is larger. Current deployments use transaction-mode pgbouncer per `docker-compose.yml`, so this is a near-zero regression in practice.
+- **Hazard resolution required first.** H1 (session-scope `set_config(..., false)`) and H2 (dual GUC namespace) must be closed before the role flip, because revoking BYPASSRLS weaponizes both into live cross-tenant leaks. This is why Bundle A.1 is a hard prerequisite for Bundle A.4.
+
+**Rollback.** Per-bundle: A.1–A.3 are warn-level or CI-only, trivially revertable. A.4 is a single env-var change (`AETERNA_DB_ROLE=bypassrls`) plus a rolling pool restart, under 5 minutes per region. A.5 is the only non-revertable bundle and only lands after A.4 has soaked in prod for ≥ 4 weeks.
+
+### 3.2 Option B — Drop RLS entirely (rejected)
+
+**Shape.** `ALTER TABLE … DISABLE ROW LEVEL SECURITY` on all 22 tables, drop all policies, update docs to say "app-layer only."
+
+**Satisfies threat model.** Neither `T1` nor `T2`.
+
+**Cost.** ~1 week. Simplifies the mental model at the cost of losing every downstream defense. Also throws away migration 024 (the partial GUC normalization) as dead code.
+
+**Why rejected.** Unacceptable under the locked threat model. Also loses the ability to ever revisit defense-in-depth without reintroducing the same 22 policies from scratch.
+
+### 3.3 Option C — RLS as a test-time gate (rejected)
+
+**Shape.** Keep prod on BYPASSRLS; add a dedicated non-BYPASSRLS role used only by an integration test suite; every RLS-enabled table is exercised under that role on every CI run.
+
+**Satisfies threat model.** `T1` partially (catches regressions pre-merge), not `T2`.
+
+**Cost.** 1–2 weeks. The cheapest option that preserves some defense-in-depth value.
+
+**Why rejected.** The gap between "caught in CI" and "caught in prod" is exactly the window that matters for `T1`’s live-request variant, and all of `T2`. The architect's override on the initial C recommendation was explicit: the threat model includes prod-time compromise, not only pre-merge regression. The CI suite from Option C is preserved as a permanent regression guard (shipped inside Bundle A.2), so nothing is lost by choosing A.
+
+## 4. Implementation strategy
+
+### 4.1 Why staged, not big-bang
+
+A single PR that (a) ships the new role + grants, (b) refactors 100 query sites, (c) flips prod away from BYPASSRLS is unreviewable and unrevertable. It also couples the three hardest failure modes — grant gaps, refactor bugs, and transaction-per-request overhead — into one incident if anything goes wrong. The bundle structure exists to decouple them.
+
+### 4.2 Bundle ordering and independence
+
+Bundle A.1 and A.2 are **independent** — either can land first; neither changes runtime behavior under the current BYPASSRLS role. A.3 depends on A.2 (it needs the CI suite to prove the refactor). A.4 depends on A.1, A.2, A.3 all being complete — the role flip only works if hazards are closed, the role exists, and every query goes through the helper. A.5 depends on A.4 having soaked.
+
+The net property: **any subset of {A.1, A.2, A.3} landing in prod without A.4 introduces zero risk.** A.3 in particular is net-beneficial pre-flip (closes the `activate_tenant_context` gap and makes the transaction scope explicit) and net-neutral under BYPASSRLS (the `SET LOCAL` is harmless when the role bypasses the policy).
+
+### 4.3 The `with_tenant_context` helper
+
+The helper pattern is load-bearing. Each call site transforms roughly from:
 
 ```
-storage/src/postgres.rs:63        set_config('app.tenant_id', $1, false)  ← helper body
-storage/src/gdpr.rs:407,490,580   set_config('app.tenant_id', $1, true)
-cli/src/server/backup_api.rs:1597 set_config('app.tenant_id', $1, false)
-cli/src/server/sync.rs:131,256    activate_tenant_context(...)            ← only 2 high-level call sites
+let mut conn = self.pool.acquire().await?;
+let rows = sqlx::query_as::<_, Row>("SELECT … FROM users WHERE tenant_id = $1")
+    .bind(tenant_id).fetch_all(&mut *conn).await?;
 ```
 
-Repository-layer SELECTs against the 22 RLS tables: **100+ call sites** across `cli/src/server/user_api.rs`, `project_api.rs`, `org_api.rs`, `memory_api.rs`, `knowledge_api.rs`, `governance_api.rs`, `audit_api.rs`. None of them pre-activate a tenant context. All of them carry an explicit `WHERE tenant_id = $1` clause (the real enforcement).
+to:
 
-### 1.3 Prior-art hazards surfaced by this analysis
+```
+let rows = self.with_tenant_context(&ctx, |tx| async move {
+    sqlx::query_as::<_, Row>("SELECT … FROM users")   // WHERE clause now optional per RLS, kept for DiD
+        .fetch_all(&mut **tx).await
+        .map_err(Into::into)
+}).await?;
+```
 
-**Hazard H1 — session-scope `set_config`.** `storage/src/postgres.rs:63` and `cli/src/server/backup_api.rs:1597` both use `set_config('app.tenant_id', $1, false)`. The third argument `false` means *session-level* — the setting survives on the pooled connection after the query completes. The next request borrowing that connection inherits tenant A's `app.tenant_id` unless it explicitly resets. Under the current prod BYPASSRLS reality this has no blast radius; under Option A it becomes a cross-tenant leak. Either way the fix is the same: switch to `set_config(..., true)` (transaction-local) and wrap the query in an explicit BEGIN.
+The explicit `WHERE tenant_id = $N` stays as defense-in-depth — Bundle A.5's `AGENTS.md` update documents that this is required, not optional. The RLS policy is the floor; the `WHERE` clause is the ceiling; any query where the two disagree is a bug and `rls_enforcement_test.rs` surfaces it.
 
-**Hazard H2 — dual GUC namespace.** Older migrations use `app.company_id`; newer use `app.tenant_id`; the normalization pass (`024`) only converted three tables. A request that sets one GUC leaves the other stale on the connection. Again invisible under BYPASSRLS, weaponized under Option A.
+### 4.4 Async workers
 
-**Hazard H3 — orphan `activate_tenant_context` call sites in `sync.rs`.** The two call sites that DO activate context are themselves no-ops (they run as BYPASSRLS). They read as correct defense-in-depth code; they are actually dead code. This misleads contributors reviewing `sync.rs` as a reference for how to write RLS-aware code.
+Waves 4 and 5 of A.3 handle `sync.rs` / `webhook.rs` / backup / GDPR paths that don't have a request-scoped tenant. The pattern: each async task acquires its context from its own job record (`sync_jobs.tenant_id`, `backup_jobs.tenant_id`, …) and passes a synthesized `TenantContext::from_async_job(job_id, tenant_id)` into `with_tenant_context`. There is no "unscoped" escape hatch — a job without a tenant either doesn't need RLS-protected tables or is a bug.
 
-## 2. Options Considered
+## 5. Risk register
 
-### Option A — Make RLS real
+**H1 — session-scope `set_config(..., false)` on pooled connections.** Current behavior: `backup_api.rs:1597` and legacy call sites use session scope; the setting persists after `.release()` and leaks to whichever request next borrows that connection. Under BYPASSRLS this is silent. Under non-BYPASSRLS (post-A.4) this becomes a live cross-tenant leak. **Mitigation:** Bundle A.1 closes every instance and lands before A.4. Regression test in A.1.
 
-Prod enforcement via RLS. Shape:
+**H2 — dual GUC namespace.** Migration 024 normalized the policies to read `app.tenant_id`, but several app-side call sites still write `app.company_id` or `app.current_tenant_id`. Under BYPASSRLS this is silent. Under non-BYPASSRLS the policy reads the canonical var and finds NULL → zero rows returned → user-visible outage. **Mitigation:** Bundle A.1 grep-normalizes every app-side read/write; grep regression test in A.1.
 
-1. New migration: `CREATE ROLE aeterna_app_rls LOGIN NOBYPASSRLS PASSWORD …`; grant `USAGE` on schema + per-table DML.
-2. Prod `DATABASE_URL` switches to `aeterna_app_rls`. Deploy ordering: role exists before image flip.
-3. Auth middleware acquires a pool connection, `BEGIN`, `SET LOCAL app.tenant_id = $1`, runs handler, `COMMIT` (or `ROLLBACK` on error). Connection lifetime == request lifetime.
-4. The 100+ repository call sites DO NOT change — they continue to carry their `WHERE tenant_id = ?` clauses (belt-and-suspenders).
-5. Fix H1/H2/H3 as preconditions (mandatory; otherwise prod breaks under non-BYPASSRLS).
+**H3 — orphan `activate_tenant_context` calls in `sync.rs`.** Currently no-ops under BYPASSRLS; post-A.3 they double-`SET LOCAL` inside `with_tenant_context`, which is harmless but noisy. **Mitigation:** Bundle A.5 deletes them.
 
-**Pros.** Genuine defense in depth. A missed `WHERE tenant_id = ?` in app code is caught at the DB layer. Compliance narrative is real, not paper.
+**H4 — transaction-per-request overhead under session-mode pooling.** Not applicable to current deployments (transaction-mode pgbouncer), but documented so a future infra change doesn't regress. **Mitigation:** A.4.8 Grafana panel for transaction duration; alert threshold established during canary.
 
-**Cons.**
-- Transaction-per-request overhead. For read-mostly endpoints this roughly doubles round trips to the DB (BEGIN + query + COMMIT).
-- Connection handle must be threaded through every handler (or hidden in an axum Extension). Either way, the 100+ repository sites need to accept a `&mut PgConnection` or a `&mut Transaction` instead of a `&PgPool`. That is the ~100-site refactor.
-- `FORCE ROW LEVEL SECURITY` on governance tables means even the table owner (migration runner) is subject to policy — migrations need to `SET ROLE postgres` explicitly or we lose the ability to run DDL against those tables as any non-bypassing role.
-- The session-variable leak (H1) MUST be fixed first or every pooled connection becomes a cross-tenant time bomb.
+**H5 — missed grant on a newly-added RLS table.** A contributor adds a migration with `ENABLE ROW LEVEL SECURITY` but forgets to grant `aeterna_app` access → the table is empty under the RLS role. **Mitigation:** A.2.6.1 pre-flight query enumerates `pg_tables WHERE rowsecurity = true` and fails the test run with a named-table error if any grant is missing.
 
-**Effort.** 4–6 weeks of focused work, high coordination cost across storage + server + CI.
+## 6. Open questions
 
-### Option B — Drop RLS
-
-Remove all 22 `ENABLE ROW LEVEL SECURITY` / 5 `FORCE ROW LEVEL SECURITY`. Drop all policies. Delete `activate_tenant_context`. Document in `AGENTS.md` that tenant isolation is app-layer `WHERE tenant_id = ?`, enforced by code review and `sqlx` query macros.
-
-**Pros.** Honest. Cheap (one migration + code removal). No overhead. No session-variable leak to worry about.
-
-**Cons.** Loses the paper defense-in-depth story that Kyriba security / compliance reviews may require. Zero DB-layer safety net against a missed `WHERE` clause. Future Kyriba auditors will ask why a multi-tenant product has no RLS; answer ("application code enforces") is correct but unsatisfying.
-
-**Effort.** 1 week.
-
-### Option C — RLS as test-time gate
-
-Prod connection stays BYPASSRLS (no change to runtime). Integration tests run under a dedicated `aeterna_app_rls` role that is non-BYPASSRLS, and exercise the actual handler code under a real tenant context.
-
-Concrete shape:
-
-1. New migration: `CREATE ROLE aeterna_app_rls LOGIN NOBYPASSRLS PASSWORD 'test_only_insecure'`; grant minimal DML. Role is test-only; prod deploys do not use it.
-2. `cli/tests/rls_enforcement_test.rs` — new integration test file:
-   - Opens a second pool using `DATABASE_URL` with username replaced by `aeterna_app_rls`.
-   - For each RLS-protected table, runs two queries: (a) with `SELECT set_config('app.tenant_id', <tid>, true)` in a BEGIN → expect N rows; (b) without setting context → expect 0 rows.
-   - Additionally exercises the high-level list paths (`/user`, `/project`, `/org`, `/govern/audit`) against the RLS role to prove the handler + repository stack produces tenant-filtered results even with RLS actually enforced.
-3. Fix H1/H2/H3 opportunistically. H1 is a hard requirement for the test to pass without flakes.
-
-**Pros.**
-- Prod overhead unchanged (0 ms, 0 connection-lifecycle churn).
-- Real compile-time-ish guarantee: any future PR that introduces a query missing `WHERE tenant_id = ?` against an RLS-protected table fails CI. This is the main value RLS provides today; Option C captures that value at 5% of Option A's cost.
-- Kyriba security review answer: “RLS policies are authored, enforced in CI against a non-BYPASSRLS role, and additionally enforced at the application layer in prod for latency reasons.” That is a defensible posture.
-- Reversible. If threat model changes, we flip prod to `aeterna_app_rls` and we're in Option A with the session-variable bugs already fixed.
-
-**Cons.**
-- Not true defense in depth *in prod*. A prod-only regression (e.g. a hand-rolled query added via a migration-time admin script) could still leak across tenants.
-- Requires test discipline: the RLS test role must be kept in sync with per-table grants as migrations add tables. We guard this with a schema-introspection test that fails if a new RLS-enabled table lacks an explicit grant to `aeterna_app_rls`.
-
-**Effort.** 1–2 weeks.
-
-## 3. Recommendation — Option C
-
-Option A is technically the "right answer" for a product under a strict zero-trust threat model. Aeterna is not that product: it is an internal-tenant tool where the adversary is a buggy handler, not a malicious user of the public API. Against that threat model, Option A's runtime overhead and refactor cost buys us protection against a class of bug (missed `WHERE tenant_id = ?`) that Option C already catches in CI.
-
-Option B throws away the authored policies, which we would regret the first time a Kyriba security review asks "what stops a SQL injection from reading another tenant?". With Option C the answer is "the app's DB role has access to all tenants but every query carries `WHERE tenant_id = ?` and the CI suite runs under a role where missing that clause returns zero rows."
-
-Option C preserves the policies as a live artifact (they must compile, they must pass the test suite) and converts them from decorative to enforceable. It is reversible to Option A if the threat model changes.
-
-## 4. Spec Impact
-
-One MODIFIED and one ADDED requirement on `runtime-security-hardening`:
-
-- **MODIFIED** "Backend-Specific Persistence Isolation" — clarifies that on Postgres, tenant isolation is enforced by application-layer `WHERE tenant_id = ?` clauses; RLS policies are authored for CI enforcement, not prod.
-- **ADDED** "RLS Test-Time Enforcement" — normative requirement that a dedicated non-BYPASSRLS role exists, that the integration test suite exercises all RLS-protected tables under that role, and that schema introspection fails CI if a new RLS-enabled table lacks a grant to the test role.
-
-Spec delta lives in `specs/runtime-security-hardening/spec.md`.
-
-## 5. Rollout
-
-1. Land this change (proposal + design + spec delta + migration adding `aeterna_app_rls` role + test suite + H1 fixes).
-2. Archive it once the test suite is green and `AGENTS.md` / `DEVELOPER_GUIDE.md` are updated.
-3. If / when the threat model changes: file a new change `flip-prod-to-rls-enforced` that builds on this one. The role exists, the session-variable hygiene is fixed — that change becomes a middleware-wiring PR instead of a six-week architectural lift.
+- **pgbouncer auth plumbing.** Can pgbouncer's `auth_file` or `auth_query` resolve the `aeterna_app` password from the same secret store as the app, without duplicating credentials? Tracked for Bundle A.4; may require a small infra PR.
+- **Password rotation.** Initial plan is a secret-manager-backed password referenced as `${APP_DB_PASSWORD}`. Rotation cadence and procedure tracked as an ops ticket after A.4 lands.
+- **Read replicas.** Do read replicas inherit the RLS policies and the grants? Yes (replica replays the full catalog), but the `aeterna_app` role must exist on the replica's primary before failover. Covered by standard replica provisioning; flagged here so it's not forgotten during the A.4 rollout.

--- a/openspec/changes/decide-rls-enforcement-model/proposal.md
+++ b/openspec/changes/decide-rls-enforcement-model/proposal.md
@@ -2,38 +2,61 @@
 
 ## Why
 
-The database layer has 22 tables with `ENABLE ROW LEVEL SECURITY` and 5 with `FORCE ROW LEVEL SECURITY` — across `storage/migrations/004_enable_rls.sql`, `016_governance_rls.sql`, and `024_normalize_rls_session_variables.sql`. Every policy is keyed off `current_setting('app.tenant_id', true)` (or `app.company_id`, `app.current_tenant_id` in older policies). Yet `PostgresBackend::activate_tenant_context` is called in exactly **2 code paths**, both in `cli/src/server/sync.rs`.
+The database layer has 22 tables with `ENABLE ROW LEVEL SECURITY` and 5 with `FORCE ROW LEVEL SECURITY` across `storage/migrations/004_enable_rls.sql`, `016_governance_rls.sql`, and `024_normalize_rls_session_variables.sql`. Every policy is keyed off `current_setting('app.tenant_id', true)`. `PostgresBackend::activate_tenant_context` is called in exactly 2 code paths (both in `cli/src/server/sync.rs`). The remaining 100+ query sites never set the session variable.
 
-The remaining 100+ query sites across `cli/src/server/*_api.rs` never set the session variable before running a query. There are only two ways that can be true while tests still pass:
+Tests pass anyway because the shipped `DATABASE_URL` points at the `postgres` superuser (implicit BYPASSRLS), so every RLS policy silently no-ops. The actual tenant isolation is the `WHERE tenant_id = $N` clauses in repository code. Any handler that forgets that clause leaks cross-tenant rows and the RLS policies we wrote do nothing to stop it.
 
-1. **`current_setting('app.tenant_id', true)` returns NULL** on those queries → RLS policies evaluate `tenant_id = NULL` → every row excluded → queries return empty. This contradicts observed behavior — tests pass and features work.
-2. **The app's DB role has `BYPASSRLS`** (or is the table owner and tables do not have `FORCE ROW LEVEL SECURITY`). RLS is decorative; the *actual* tenant isolation is the app-level `WHERE tenant_id = $1` clauses sprinkled throughout the repository layer.
-
-Option 2 matches reality. No migration creates an explicit app role; the connection uses whatever Postgres user the operator's `DATABASE_URL` points at, which for a default compose setup is `postgres` (superuser, implicit BYPASSRLS). The governance tables that use `FORCE ROW LEVEL SECURITY` only work because `backup_api.rs` and `gdpr.rs` paths call `SELECT set_config('app.tenant_id', $1, false)` before their queries — and the `false` third argument makes it session-level, which leaks to the next request borrowing that pooled connection.
-
-The result is a defense-in-depth story that reads well in security reviews but does not actually exist at runtime. Any missed `WHERE tenant_id = ?` in application code becomes a cross-tenant data leak. The one path that *does* call `activate_tenant_context` is itself a no-op because it runs under BYPASSRLS too.
-
-This is an **architectural decision**, not a patch. Issue #58 explicitly asks for a recorded decision under `openspec/changes/` before any implementation work begins.
+There is no production environment or live user base yet. The window to fix the enforcement model without operational ceremony is now. Issue #58 requires a recorded decision under `openspec/changes/` before implementation.
 
 ## What Changes
 
-This change is **decision-first, implementation-staged**. It records the chosen enforcement model in the `runtime-security-hardening` capability so downstream changes inherit a settled premise. The implementation path is a 5-bundle staged rollout; each bundle ships a standalone PR and is independently revertable. Bundle boundaries are structured so that any one bundle landing in prod without the rest cannot introduce a regression.
+This change ratifies **Option A — activate RLS on every request-scoped connection** and records it in the `runtime-security-hardening` capability. Three options are analyzed in `design.md`; the decision summary is normative:
 
-Three options are analyzed in full in `design.md`; the summary here is normative once this change is accepted:
+- **Option A (chosen).** Non-BYPASSRLS application role + transaction-scoped `SET LOCAL app.tenant_id` + repository refactor so every query acquires its connection through a `with_tenant_context` helper. Real database-enforced isolation.
+- **Option B (rejected).** Drop all RLS policies, app-layer-only. Honest but loses all defense in depth.
+- **Option C (rejected).** RLS as a CI-only gate, prod stays BYPASSRLS. Captures regression value but leaves the runtime defenseless. The CI suite from C survives as a permanent regression guard inside Bundle A.2.
 
-- **Option A — Activate RLS on every request-scoped connection.** App role loses `BYPASSRLS` in prod, every request runs inside an explicit `BEGIN` with `SET LOCAL app.tenant_id`, and the ~100 repository query sites are refactored to acquire their connection through a `with_tenant_context(ctx, |conn| …)` helper. Real, database-enforced defense in depth. 4–6 weeks, transaction-per-request overhead.
-- **Option B — Drop RLS entirely.** Remove all policies, `ALTER TABLE … DISABLE ROW LEVEL SECURITY`, document app-layer-only isolation. Honest about the current reality; loses the defense-in-depth story entirely.
-- **Option C — RLS as a test-time gate, not a prod control.** Prod connections stay BYPASSRLS; integration tests run under a dedicated non-BYPASSRLS role and catch missing `WHERE tenant_id = ?` clauses in CI. Captures ~95% of Option A's value at ~5% of the cost. No prod overhead.
+Option A is the right call even pre-production: it locks in the enforcement model now while the blast radius of a refactor is zero, rather than inheriting the BYPASSRLS posture into launch.
 
-**Decision: Option A.** An initial recommendation of Option C was overridden by the reviewing architect (see the #72 commit trail for the pivot). The threat model this change accepts as authoritative is "a compromised or buggy handler on a live production request MUST NOT be able to read another tenant's rows", not merely "a missing `WHERE` clause MUST be caught in CI." Under that threat model Option C is insufficient — it makes the missing clause a `cargo test` failure but leaves the prod database defenseless once the clause is missing at request time — and only Option A provides the property. The cost is justified.
+### Dual-role, dual-pool design
 
-The implementation lands in five stacked bundles (see `tasks.md` for the itemized work and `design.md` §4 for rationale):
+Option A is implemented with **two PostgreSQL roles and two connection pools**, not one. This is integral to the design, not an operational afterthought:
 
-- **Bundle A.1 — Hazard fixes (P0 prerequisite).** Close Hazards H1 (session-scope `set_config(..., false)` on a pooled connection) and H2 (dual GUC namespace `app.company_id` vs `app.tenant_id` only partially normalized by migration 024). Safe to ship immediately; MUST ship before A.4 because the role flip weaponizes both hazards into live cross-tenant leaks.
-- **Bundle A.2 — Dedicated `aeterna_app` non-BYPASSRLS role + migration + grants.** Infrastructure only. Prod `DATABASE_URL` continues to point at the legacy BYPASSRLS role until A.4. An integration test suite runs every RLS-enabled table under the new role end-to-end on every CI run — this is the "Option C safety net" preserved as a permanent regression guard even though A is the chosen enforcement path.
-- **Bundle A.3 — Repository call-site refactor.** Introduce `with_tenant_context(&ctx, |conn| async { … })` helper in `storage/src/postgres.rs`. Refactor the ~100 query sites in 4–6 domain-themed waves (user → org → project → team → governance → audit → sync → backup/gdpr), each wave a standalone PR. Post-refactor, `grep` for direct `self.pool.acquire()` on RLS-protected paths fails CI via a new `deny_lint`.
-- **Bundle A.4 — Prod flip.** Ship a feature flag (`AETERNA_DB_ROLE=bypassrls|rls`) that controls which connection string the pool opens on. Default remains `bypassrls` at flag-land time. Canary environments flip to `rls` first; prod flips after a minimum 2-week soak. Rollback is a single env-var change plus pool restart.
-- **Bundle A.5 — Remove BYPASSRLS escape hatch + ratchets.** Delete the `bypassrls` code path, remove the `activate_tenant_context` dead calls in `sync.rs` (Hazard H3), graduate the `deny_lint` for direct pool access from warn to deny, update `AGENTS.md`/`DEVELOPER_GUIDE.md` to reflect the final model.
+| Role | Pool | `BYPASSRLS` | Used by |
+|---|---|---|---|
+| `aeterna_app` | `state.pool` (default, large) | No | Every per-tenant request; async workers running per-tenant jobs |
+| `aeterna_admin` | `state.admin_pool` (size=4) | Yes | PlatformAdmin with `?tenant=*`; scheduled cross-tenant maintenance; migration runner |
+
+Request routing is driven by two explicit helpers:
+
+```
+with_tenant_context(&ctx, |tx| …)   // default pool, BEGIN + SET LOCAL app.tenant_id + body + COMMIT
+with_admin_context(&ctx, |tx| …)    // admin pool, BEGIN + body + COMMIT (no SET LOCAL; RLS bypassed by role)
+```
+
+The router picks based on `ctx.scope`:
+- `Tenant(_)` or `CrossTenantSingle(_)` → `with_tenant_context` (99% of traffic)
+- `CrossTenantAll` and actor is `PlatformAdmin` → `with_admin_context`
+- Scheduled jobs → see pattern below
+
+Every `with_admin_context` call is auto-audited (actor + `acting_as_tenant_id = NULL` + `admin_scope = true`) so cross-tenant reads are traceable. A CI lint forbids any code path from reaching `state.admin_pool` without going through `with_admin_context`.
+
+### Scheduled jobs pattern
+
+Scheduled work splits into two shapes; the helpers compose to cover both:
+
+- **Per-tenant jobs** (sync, per-tenant backup, per-tenant GDPR export) — the scheduler uses `with_admin_context` for a one-shot `SELECT id FROM tenants WHERE active`, then dispatches each tenant's work through `with_tenant_context(&TenantContext::from_scheduled_job(t, job_id), …)`. RLS enforces scope on the per-tenant body.
+- **Truly cross-tenant jobs** (audit log compaction, cross-tenant analytics rollups, global rate-limit sweeps) — run entirely under `with_admin_context(&system_ctx, …)`. `system_ctx` is a sentinel `TenantContext` that represents "no human actor, internal system"; audit rows written during these jobs have `actor_type = 'system'`.
+
+### Staged implementation (3 bundles)
+
+The implementation lands in three stacked PRs; see `tasks.md`:
+
+- **Bundle A.1 — Hazard fixes (prerequisite).** Close H1 (session-scope `set_config(..., false)` on pooled connections) and H2 (dual GUC namespace `app.company_id` / `app.current_tenant_id` not fully normalized on the app side). Safe to merge immediately; no behavior change under BYPASSRLS, essential invariant once BYPASSRLS is gone.
+- **Bundle A.2 — Roles + migration + dual pools + CI verification.** Migration 025 creates both roles with correct grants. `AppState` grows a second pool. `with_tenant_context` + `with_admin_context` helpers land with a compile-time exclusion (direct `state.pool`/`state.admin_pool` access is lint-warned). CI suite runs every RLS table end-to-end under `aeterna_app`, and every admin-scoped handler under `aeterna_admin`.
+- **Bundle A.3 — Call-site refactor + cutover.** Refactor the ~100 repository query sites in 4–6 domain-themed waves (user → org → project → team → governance → audit → sync → backup/gdpr), each wave a standalone PR against the base branch. Final wave flips `DATABASE_URL` to `aeterna_app`, wires the admin pool URL, deletes the orphan `activate_tenant_context` calls in `sync.rs` (Hazard H3), and graduates the direct-pool-access lint from warn to deny.
+
+Bundles A.1 and A.2 are independent; either can land first. A.3's waves depend on A.2. The final commit of A.3's last wave is the only one that changes runtime behavior from "tests run under RLS" to "everything runs under RLS" — but since there is no prod and no users, that commit is a one-line env change, not an operational event.
 
 ## Capabilities
 
@@ -43,11 +66,11 @@ None.
 
 ### Modified Capabilities
 
-- `runtime-security-hardening`: rewrites the PostgreSQL isolation requirement to make row-level security the authoritative runtime control (previously: application layer was authoritative, RLS was a paper artifact); adds supporting requirements for per-request transaction-scoped tenant context, non-BYPASSRLS application role in production, session-variable hygiene, and CI verification under the non-BYPASSRLS role. These requirements become enforceable progressively as each bundle lands; the final-state wording in the spec delta represents the post-A.5 world and is the target the bundles drive toward.
+- `runtime-security-hardening`: rewrites the PostgreSQL isolation requirement to make row-level security the authoritative runtime control; adds requirements for the two-role/two-pool model, per-request transaction-scoped tenant context, administrative cross-tenant access via the admin pool + helper, session variable hygiene, and end-to-end RLS verification.
 
 ## Not In Scope
 
-- Replacing the `app.tenant_id` / `app.company_id` GUC namespace with a single unified variable. Migration 024 partially normalized this and Hazard H2 (Bundle A.1 of `tasks.md`) completes the job for the paths the app actually traverses; a full GUC consolidation migration is deferred as a separate change.
-- Changing the tenant resolution middleware. This change is about enforcement at the DB layer; the request-scoped tenant context is assumed to already be correct when it reaches the connection pool.
-- Removing app-layer `WHERE tenant_id = ?` clauses. They remain as defense in depth on top of the new primary enforcement; `AGENTS.md` is updated to describe both layers as required.
-- Option C's standalone landing. The integration test suite described in Option C ships inside Bundle A.2 as a permanent regression guard, but the decision on the enforcement model is Option A.
+- Replacing the `app.tenant_id` / `app.company_id` GUC namespace with a single unified variable across all migrations. Migration 024 normalized the policies; Bundle A.1 closes the app-side writes. A full retroactive GUC consolidation is deferred as a separate change.
+- Changing the tenant resolution middleware. This change enforces at the DB layer; the request-scoped tenant context is assumed to already be correct when it reaches the pool.
+- Removing app-layer `WHERE tenant_id = ?` clauses. They remain as required defense in depth on top of RLS; `AGENTS.md` is updated in Bundle A.3's last wave to describe both layers as mandatory, neither optional.
+- Operational rollout mechanics (canary, feature flags, rollback runbooks). Not applicable pre-production; would be a separate concern if and when a production deployment is stood up.

--- a/openspec/changes/decide-rls-enforcement-model/proposal.md
+++ b/openspec/changes/decide-rls-enforcement-model/proposal.md
@@ -1,0 +1,54 @@
+# Decide RLS Enforcement Model
+
+## Why
+
+The database layer has 22 tables with `ENABLE ROW LEVEL SECURITY` and 5 with `FORCE ROW LEVEL SECURITY` — across `storage/migrations/004_enable_rls.sql`, `016_governance_rls.sql`, and `024_normalize_rls_session_variables.sql`. Every policy is keyed off `current_setting('app.tenant_id', true)` (or `app.company_id`, `app.current_tenant_id` in older policies). Yet `PostgresBackend::activate_tenant_context` is called in exactly **2 code paths**, both in `cli/src/server/sync.rs`.
+
+The remaining 100+ query sites across `cli/src/server/*_api.rs` never set the session variable before running a query. There are only two ways that can be true while tests still pass:
+
+1. **`current_setting('app.tenant_id', true)` returns NULL** on those queries → RLS policies evaluate `tenant_id = NULL` → every row excluded → queries return empty. This contradicts observed behavior — tests pass and features work.
+2. **The app's DB role has `BYPASSRLS`** (or is the table owner and tables do not have `FORCE ROW LEVEL SECURITY`). RLS is decorative; the *actual* tenant isolation is the app-level `WHERE tenant_id = $1` clauses sprinkled throughout the repository layer.
+
+Option 2 matches reality. No migration creates an explicit app role; the connection uses whatever Postgres user the operator's `DATABASE_URL` points at, which for a default compose setup is `postgres` (superuser, implicit BYPASSRLS). The governance tables that use `FORCE ROW LEVEL SECURITY` only work because `backup_api.rs` and `gdpr.rs` paths call `SELECT set_config('app.tenant_id', $1, false)` before their queries — and the `false` third argument makes it session-level, which leaks to the next request borrowing that pooled connection.
+
+The result is a defense-in-depth story that reads well in security reviews but does not actually exist at runtime. Any missed `WHERE tenant_id = ?` in application code becomes a cross-tenant data leak. The one path that *does* call `activate_tenant_context` is itself a no-op because it runs under BYPASSRLS too.
+
+This is an **architectural decision**, not a patch. Issue #58 explicitly asks for a recorded decision under `openspec/changes/` before any implementation work begins.
+
+## What Changes
+
+This change is **decision-first, implementation-conditional**. It records the chosen enforcement model in the `runtime-security-hardening` capability so downstream changes inherit a settled premise. The implementation path attached to this change is only the work needed to make the decision true; options not selected stay out of scope.
+
+Three options are analyzed in full in `design.md`; the summary here is normative once this change is accepted:
+
+- **Option A — Activate RLS on every request-scoped connection.** Middleware-owned connection handle, `SET LOCAL app.tenant_id = $1` inside a BEGIN per request, app role loses BYPASSRLS in prod. Genuine defense in depth; ~100-site repository refactor plus transaction-per-request overhead. Inherits the session-variable leak hazard already present in `backup_api.rs`.
+- **Option B — Drop RLS entirely.** Remove all policies, `ALTER TABLE … DISABLE ROW LEVEL SECURITY`, document app-layer-only isolation. Honest and cheap; loses the paper defense-in-depth story that Kyriba security review may require.
+- **Option C — RLS as a test-time gate, not a prod control.** Prod connections stay BYPASSRLS; integration tests explicitly `SET ROLE aeterna_app_rls` (non-BYPASSRLS) and `activate_tenant_context` before exercising handlers. Missing `WHERE tenant_id = ?` in app code fails tests, never prod. Low prod overhead, real compile-time-ish guarantee via CI.
+
+**Decision:** Option C, with two guardrails (see `design.md` §3 for full rationale):
+
+1. Create an explicit `aeterna_app_rls` role via migration, non-BYPASSRLS, granted `USAGE` + per-table `SELECT/INSERT/UPDATE/DELETE`.
+2. A new integration test suite runs under that role end-to-end for the `user`, `project`, `org`, `memory`, `knowledge`, `governance` list/get paths, exercising both the positive path (tenant context set → rows returned) and the negative path (tenant context unset → 0 rows).
+
+The prod `DATABASE_URL` user stays as-is (typically superuser / BYPASSRLS). We do NOT flip prod to non-BYPASSRLS: the per-request transaction overhead and repository-site refactor are not justified by the threat model improvement, and the session-variable leak bug surfaced above would need fixing first anyway.
+
+Follow-on work to fix the prior-art hazards surfaced by this analysis is in `tasks.md`:
+
+- Fix the `set_config(..., false)` → `set_config(..., true)` typo pattern in `backup_api.rs:1597`, `gdpr.rs:407/490/580`, and `storage/src/postgres.rs:63` so session state never leaks across pooled requests (whether or not we adopt Option A later).
+- Audit the remaining repository sites for missing `WHERE tenant_id = ?` clauses on RLS-protected tables. This is the real enforcement surface.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `runtime-security-hardening`: adds a normative requirement (RLS is a test-time gate, not a prod enforcement control) and a supporting requirement (test-role setup, session-variable hygiene). No behavioral change to any existing runtime surface — only a statement of intent that makes the current implementation honest and protects future contributors from assuming RLS blocks cross-tenant reads in prod.
+
+## Not In Scope
+
+- Flipping prod connections to non-BYPASSRLS (Option A). Tracked separately for reconsideration if the threat model changes.
+- Removing RLS policies / dropping the RLS GUC infrastructure (Option B). Retained for test-time enforcement.
+- Refactoring the ~100 repository call sites to explicitly filter by `tenant_id` — they already do; this change documents that the app layer is the authoritative enforcement point, it does not move the line.

--- a/openspec/changes/decide-rls-enforcement-model/proposal.md
+++ b/openspec/changes/decide-rls-enforcement-model/proposal.md
@@ -17,25 +17,23 @@ This is an **architectural decision**, not a patch. Issue #58 explicitly asks fo
 
 ## What Changes
 
-This change is **decision-first, implementation-conditional**. It records the chosen enforcement model in the `runtime-security-hardening` capability so downstream changes inherit a settled premise. The implementation path attached to this change is only the work needed to make the decision true; options not selected stay out of scope.
+This change is **decision-first, implementation-staged**. It records the chosen enforcement model in the `runtime-security-hardening` capability so downstream changes inherit a settled premise. The implementation path is a 5-bundle staged rollout; each bundle ships a standalone PR and is independently revertable. Bundle boundaries are structured so that any one bundle landing in prod without the rest cannot introduce a regression.
 
 Three options are analyzed in full in `design.md`; the summary here is normative once this change is accepted:
 
-- **Option A — Activate RLS on every request-scoped connection.** Middleware-owned connection handle, `SET LOCAL app.tenant_id = $1` inside a BEGIN per request, app role loses BYPASSRLS in prod. Genuine defense in depth; ~100-site repository refactor plus transaction-per-request overhead. Inherits the session-variable leak hazard already present in `backup_api.rs`.
-- **Option B — Drop RLS entirely.** Remove all policies, `ALTER TABLE … DISABLE ROW LEVEL SECURITY`, document app-layer-only isolation. Honest and cheap; loses the paper defense-in-depth story that Kyriba security review may require.
-- **Option C — RLS as a test-time gate, not a prod control.** Prod connections stay BYPASSRLS; integration tests explicitly `SET ROLE aeterna_app_rls` (non-BYPASSRLS) and `activate_tenant_context` before exercising handlers. Missing `WHERE tenant_id = ?` in app code fails tests, never prod. Low prod overhead, real compile-time-ish guarantee via CI.
+- **Option A — Activate RLS on every request-scoped connection.** App role loses `BYPASSRLS` in prod, every request runs inside an explicit `BEGIN` with `SET LOCAL app.tenant_id`, and the ~100 repository query sites are refactored to acquire their connection through a `with_tenant_context(ctx, |conn| …)` helper. Real, database-enforced defense in depth. 4–6 weeks, transaction-per-request overhead.
+- **Option B — Drop RLS entirely.** Remove all policies, `ALTER TABLE … DISABLE ROW LEVEL SECURITY`, document app-layer-only isolation. Honest about the current reality; loses the defense-in-depth story entirely.
+- **Option C — RLS as a test-time gate, not a prod control.** Prod connections stay BYPASSRLS; integration tests run under a dedicated non-BYPASSRLS role and catch missing `WHERE tenant_id = ?` clauses in CI. Captures ~95% of Option A's value at ~5% of the cost. No prod overhead.
 
-**Decision:** Option C, with two guardrails (see `design.md` §3 for full rationale):
+**Decision: Option A.** An initial recommendation of Option C was overridden by the reviewing architect (see the #72 commit trail for the pivot). The threat model this change accepts as authoritative is "a compromised or buggy handler on a live production request MUST NOT be able to read another tenant's rows", not merely "a missing `WHERE` clause MUST be caught in CI." Under that threat model Option C is insufficient — it makes the missing clause a `cargo test` failure but leaves the prod database defenseless once the clause is missing at request time — and only Option A provides the property. The cost is justified.
 
-1. Create an explicit `aeterna_app_rls` role via migration, non-BYPASSRLS, granted `USAGE` + per-table `SELECT/INSERT/UPDATE/DELETE`.
-2. A new integration test suite runs under that role end-to-end for the `user`, `project`, `org`, `memory`, `knowledge`, `governance` list/get paths, exercising both the positive path (tenant context set → rows returned) and the negative path (tenant context unset → 0 rows).
+The implementation lands in five stacked bundles (see `tasks.md` for the itemized work and `design.md` §4 for rationale):
 
-The prod `DATABASE_URL` user stays as-is (typically superuser / BYPASSRLS). We do NOT flip prod to non-BYPASSRLS: the per-request transaction overhead and repository-site refactor are not justified by the threat model improvement, and the session-variable leak bug surfaced above would need fixing first anyway.
-
-Follow-on work to fix the prior-art hazards surfaced by this analysis is in `tasks.md`:
-
-- Fix the `set_config(..., false)` → `set_config(..., true)` typo pattern in `backup_api.rs:1597`, `gdpr.rs:407/490/580`, and `storage/src/postgres.rs:63` so session state never leaks across pooled requests (whether or not we adopt Option A later).
-- Audit the remaining repository sites for missing `WHERE tenant_id = ?` clauses on RLS-protected tables. This is the real enforcement surface.
+- **Bundle A.1 — Hazard fixes (P0 prerequisite).** Close Hazards H1 (session-scope `set_config(..., false)` on a pooled connection) and H2 (dual GUC namespace `app.company_id` vs `app.tenant_id` only partially normalized by migration 024). Safe to ship immediately; MUST ship before A.4 because the role flip weaponizes both hazards into live cross-tenant leaks.
+- **Bundle A.2 — Dedicated `aeterna_app` non-BYPASSRLS role + migration + grants.** Infrastructure only. Prod `DATABASE_URL` continues to point at the legacy BYPASSRLS role until A.4. An integration test suite runs every RLS-enabled table under the new role end-to-end on every CI run — this is the "Option C safety net" preserved as a permanent regression guard even though A is the chosen enforcement path.
+- **Bundle A.3 — Repository call-site refactor.** Introduce `with_tenant_context(&ctx, |conn| async { … })` helper in `storage/src/postgres.rs`. Refactor the ~100 query sites in 4–6 domain-themed waves (user → org → project → team → governance → audit → sync → backup/gdpr), each wave a standalone PR. Post-refactor, `grep` for direct `self.pool.acquire()` on RLS-protected paths fails CI via a new `deny_lint`.
+- **Bundle A.4 — Prod flip.** Ship a feature flag (`AETERNA_DB_ROLE=bypassrls|rls`) that controls which connection string the pool opens on. Default remains `bypassrls` at flag-land time. Canary environments flip to `rls` first; prod flips after a minimum 2-week soak. Rollback is a single env-var change plus pool restart.
+- **Bundle A.5 — Remove BYPASSRLS escape hatch + ratchets.** Delete the `bypassrls` code path, remove the `activate_tenant_context` dead calls in `sync.rs` (Hazard H3), graduate the `deny_lint` for direct pool access from warn to deny, update `AGENTS.md`/`DEVELOPER_GUIDE.md` to reflect the final model.
 
 ## Capabilities
 
@@ -45,10 +43,11 @@ None.
 
 ### Modified Capabilities
 
-- `runtime-security-hardening`: adds a normative requirement (RLS is a test-time gate, not a prod enforcement control) and a supporting requirement (test-role setup, session-variable hygiene). No behavioral change to any existing runtime surface — only a statement of intent that makes the current implementation honest and protects future contributors from assuming RLS blocks cross-tenant reads in prod.
+- `runtime-security-hardening`: rewrites the PostgreSQL isolation requirement to make row-level security the authoritative runtime control (previously: application layer was authoritative, RLS was a paper artifact); adds supporting requirements for per-request transaction-scoped tenant context, non-BYPASSRLS application role in production, session-variable hygiene, and CI verification under the non-BYPASSRLS role. These requirements become enforceable progressively as each bundle lands; the final-state wording in the spec delta represents the post-A.5 world and is the target the bundles drive toward.
 
 ## Not In Scope
 
-- Flipping prod connections to non-BYPASSRLS (Option A). Tracked separately for reconsideration if the threat model changes.
-- Removing RLS policies / dropping the RLS GUC infrastructure (Option B). Retained for test-time enforcement.
-- Refactoring the ~100 repository call sites to explicitly filter by `tenant_id` — they already do; this change documents that the app layer is the authoritative enforcement point, it does not move the line.
+- Replacing the `app.tenant_id` / `app.company_id` GUC namespace with a single unified variable. Migration 024 partially normalized this and Hazard H2 (Bundle A.1 of `tasks.md`) completes the job for the paths the app actually traverses; a full GUC consolidation migration is deferred as a separate change.
+- Changing the tenant resolution middleware. This change is about enforcement at the DB layer; the request-scoped tenant context is assumed to already be correct when it reaches the connection pool.
+- Removing app-layer `WHERE tenant_id = ?` clauses. They remain as defense in depth on top of the new primary enforcement; `AGENTS.md` is updated to describe both layers as required.
+- Option C's standalone landing. The integration test suite described in Option C ships inside Bundle A.2 as a permanent regression guard, but the decision on the enforcement model is Option A.

--- a/openspec/changes/decide-rls-enforcement-model/specs/runtime-security-hardening/spec.md
+++ b/openspec/changes/decide-rls-enforcement-model/specs/runtime-security-hardening/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: Backend-Specific Persistence Isolation
+The system SHALL define and enforce tenant isolation explicitly for each persistence backend used in production-capable deployments. On PostgreSQL, the authoritative enforcement layer is the application's repository code; row-level security policies exist as an authored, CI-enforced artifact rather than a production runtime control.
+
+#### Scenario: PostgreSQL tenant isolation is enforced at the application layer
+- **WHEN** PostgreSQL stores tenant-scoped data
+- **THEN** every repository-layer query against a tenant-scoped table SHALL include an explicit `WHERE tenant_id = $N` clause (or equivalent `company_id` clause for governance tables)
+- **AND** the production database role MAY have `BYPASSRLS` or be the table owner without triggering an isolation violation
+- **AND** documentation (`AGENTS.md`, `DEVELOPER_GUIDE.md`) SHALL state that the application layer is the authoritative enforcement point on PostgreSQL
+
+#### Scenario: RLS policies are authored and kept valid
+- **WHEN** a migration adds a tenant-scoped table to PostgreSQL
+- **THEN** that migration SHALL `ENABLE ROW LEVEL SECURITY` on the table
+- **AND** SHALL define at least one policy keyed on the canonical session variable `app.tenant_id` (or `app.company_id` for governance-scoped tables)
+- **AND** the policies SHALL remain valid under the CI enforcement suite defined in "RLS Test-Time Enforcement"
+
+#### Scenario: Qdrant tenant isolation is enforced by storage routing
+- **WHEN** Qdrant stores tenant-scoped vectors or payloads
+- **THEN** the storage layer SHALL route operations through tenant-scoped collections, mandatory tenant filters, or both
+- **AND** it SHALL reject or prevent queries that could return vectors from another tenant
+
+#### Scenario: Redis tenant isolation is enforced by storage namespaces
+- **WHEN** Redis stores tenant-scoped working memory, session data, checkpoints, streams, or caches
+- **THEN** the storage layer SHALL use tenant-scoped key namespaces and access wrappers for those keys
+- **AND** callers SHALL NOT read or mutate another tenant's Redis data without an explicit authorized tenant context
+
+## ADDED Requirements
+
+### Requirement: RLS Test-Time Enforcement
+The system SHALL maintain a dedicated non-`BYPASSRLS` PostgreSQL role used exclusively by the integration test suite, and SHALL exercise every RLS-enabled table under that role on every CI run. This converts the row-level security policies from a decorative production artifact into a CI-enforced guard against repository-layer queries missing their `WHERE tenant_id = ?` clause.
+
+#### Scenario: Dedicated non-BYPASSRLS role exists
+- **WHEN** the migration suite is applied against a fresh database
+- **THEN** a role named `aeterna_app_rls` SHALL exist
+- **AND** the role SHALL have `LOGIN` but SHALL NOT have `BYPASSRLS` or `SUPERUSER`
+- **AND** the role SHALL hold `USAGE` on the application schema and DML (`SELECT`, `INSERT`, `UPDATE`, `DELETE`) on every table that has `ENABLE ROW LEVEL SECURITY`
+
+#### Scenario: RLS isolation is verified end-to-end per table
+- **WHEN** the integration test suite runs
+- **THEN** for every table with `ENABLE ROW LEVEL SECURITY`, there SHALL be a test that connects as `aeterna_app_rls`, begins a transaction, seeds rows for two distinct tenants, sets `app.tenant_id` to one tenant via `set_config(..., true)`, and asserts that a `SELECT *` returns only that tenant's rows
+- **AND** for every such table there SHALL be a test asserting that without setting `app.tenant_id`, the same `SELECT *` returns zero rows
+
+#### Scenario: Schema introspection guards role grants
+- **WHEN** the integration test suite starts
+- **THEN** a pre-flight query SHALL enumerate every table in `pg_tables` where `rowsecurity = true`
+- **AND** SHALL assert that `aeterna_app_rls` has been granted at minimum `SELECT` on each such table
+- **AND** SHALL fail the run with a message naming the missing table if any grant is absent, so that adding a new RLS-protected table without updating the test grant fails CI
+
+#### Scenario: Handler-level list paths are exercised under RLS
+- **WHEN** the integration test suite runs
+- **THEN** the `/user`, `/project`, `/org`, and `/govern/audit` list endpoints SHALL be exercised against a test server whose pool connects as `aeterna_app_rls`
+- **AND** each list SHALL return only the authenticated tenant's rows
+- **AND** attempting a request with no resolved tenant context SHALL either return `400 select_tenant` (at the middleware layer) or an empty list (at the RLS layer) — never rows from another tenant
+
+### Requirement: Tenant Session Variable Hygiene
+Every code path that writes the `app.tenant_id` (or `app.company_id`) PostgreSQL session variable SHALL use a transaction-scoped write so that the setting cannot survive on a pooled connection after the originating query completes. This guards against a pooled connection carrying a prior request's tenant context into a subsequent request.
+
+#### Scenario: set_config uses transaction scope
+- **WHEN** the application calls `set_config('app.tenant_id', $1, ?)` (or the equivalent `SET` / `SET LOCAL` statement)
+- **THEN** the call SHALL pass `true` as the third argument (transaction-local) and SHALL be inside an explicit `BEGIN`
+- **AND** the application SHALL NOT rely on session-scoped `set_config(..., false)` for tenant context, so that returning a connection to the pool cannot leak tenant state
+
+#### Scenario: Test suite catches session-scope misuse
+- **WHEN** a new query is introduced that writes `app.tenant_id` with session scope
+- **THEN** a dedicated `cargo test` target SHALL fail by detecting a pooled-connection leak: it acquires a connection, sets context to tenant A, returns the connection to the pool, acquires a fresh connection, and asserts that `current_setting('app.tenant_id', true)` returns empty rather than tenant A's identifier

--- a/openspec/changes/decide-rls-enforcement-model/specs/runtime-security-hardening/spec.md
+++ b/openspec/changes/decide-rls-enforcement-model/specs/runtime-security-hardening/spec.md
@@ -1,19 +1,22 @@
 ## MODIFIED Requirements
 
 ### Requirement: Backend-Specific Persistence Isolation
-The system SHALL define and enforce tenant isolation explicitly for each persistence backend used in production-capable deployments. On PostgreSQL, the authoritative enforcement layer is the application's repository code; row-level security policies exist as an authored, CI-enforced artifact rather than a production runtime control.
+The system SHALL define and enforce tenant isolation explicitly for each persistence backend used in production-capable deployments. On PostgreSQL, the authoritative enforcement layer is PostgreSQL row-level security policies evaluated against a transaction-scoped `app.tenant_id` GUC; the repository layer's explicit `WHERE tenant_id = $N` clauses remain as a required second layer of defense in depth.
 
-#### Scenario: PostgreSQL tenant isolation is enforced at the application layer
+#### Scenario: PostgreSQL tenant isolation is enforced by row-level security
 - **WHEN** PostgreSQL stores tenant-scoped data
-- **THEN** every repository-layer query against a tenant-scoped table SHALL include an explicit `WHERE tenant_id = $N` clause (or equivalent `company_id` clause for governance tables)
-- **AND** the production database role MAY have `BYPASSRLS` or be the table owner without triggering an isolation violation
-- **AND** documentation (`AGENTS.md`, `DEVELOPER_GUIDE.md`) SHALL state that the application layer is the authoritative enforcement point on PostgreSQL
+- **THEN** the production application database role SHALL NOT have `BYPASSRLS` and SHALL NOT be the table owner of any tenant-scoped table
+- **AND** every tenant-scoped table SHALL have `ENABLE ROW LEVEL SECURITY` with at least one policy keyed on `current_setting('app.tenant_id', true)`
+- **AND** every request-scoped query path SHALL acquire its database connection through the `with_tenant_context` helper (or equivalent) that opens an explicit transaction, issues `SET LOCAL app.tenant_id = $1`, runs the query body, and commits or rolls back
+- **AND** every repository-layer query against a tenant-scoped table SHALL additionally include an explicit `WHERE tenant_id = $N` clause (or equivalent `company_id` clause for governance tables) as defense in depth on top of the RLS policy
+- **AND** documentation (`AGENTS.md`, `DEVELOPER_GUIDE.md`) SHALL state the two-layer model: RLS is authoritative, the `WHERE` clause is required defense in depth, neither is optional
 
 #### Scenario: RLS policies are authored and kept valid
 - **WHEN** a migration adds a tenant-scoped table to PostgreSQL
 - **THEN** that migration SHALL `ENABLE ROW LEVEL SECURITY` on the table
 - **AND** SHALL define at least one policy keyed on the canonical session variable `app.tenant_id` (or `app.company_id` for governance-scoped tables)
-- **AND** the policies SHALL remain valid under the CI enforcement suite defined in "RLS Test-Time Enforcement"
+- **AND** SHALL grant `SELECT, INSERT, UPDATE, DELETE` on the table to the `aeterna_app` application role
+- **AND** the policies SHALL remain valid under the CI enforcement suite defined in "RLS End-to-End Verification"
 
 #### Scenario: Qdrant tenant isolation is enforced by storage routing
 - **WHEN** Qdrant stores tenant-scoped vectors or payloads
@@ -27,40 +30,83 @@ The system SHALL define and enforce tenant isolation explicitly for each persist
 
 ## ADDED Requirements
 
-### Requirement: RLS Test-Time Enforcement
-The system SHALL maintain a dedicated non-`BYPASSRLS` PostgreSQL role used exclusively by the integration test suite, and SHALL exercise every RLS-enabled table under that role on every CI run. This converts the row-level security policies from a decorative production artifact into a CI-enforced guard against repository-layer queries missing their `WHERE tenant_id = ?` clause.
+### Requirement: Non-BYPASSRLS Application Role in Production
+The system SHALL provision a dedicated PostgreSQL role (`aeterna_app`) that does NOT have `BYPASSRLS` and SHALL use this role for all production request-scoped database connections. The legacy BYPASSRLS role remains available only behind a feature flag for emergency rollback.
 
-#### Scenario: Dedicated non-BYPASSRLS role exists
+#### Scenario: Production pool opens connections as aeterna_app
+- **WHEN** the application starts in production
+- **THEN** `AETERNA_DB_ROLE` SHALL resolve to `rls` (the default after Bundle A.4's rollout soak)
+- **AND** the connection pool SHALL authenticate as `aeterna_app` using the password supplied via `APP_DB_PASSWORD`
+- **AND** the startup log SHALL emit `db_role=rls` at `INFO` level so the effective role is visible in post-incident review
+
+#### Scenario: aeterna_app lacks BYPASSRLS
 - **WHEN** the migration suite is applied against a fresh database
-- **THEN** a role named `aeterna_app_rls` SHALL exist
-- **AND** the role SHALL have `LOGIN` but SHALL NOT have `BYPASSRLS` or `SUPERUSER`
-- **AND** the role SHALL hold `USAGE` on the application schema and DML (`SELECT`, `INSERT`, `UPDATE`, `DELETE`) on every table that has `ENABLE ROW LEVEL SECURITY`
+- **THEN** the role `aeterna_app` SHALL exist
+- **AND** `pg_roles.rolbypassrls` SHALL be `false` for `aeterna_app`
+- **AND** `pg_roles.rolsuper` SHALL be `false` for `aeterna_app`
+- **AND** `aeterna_app` SHALL hold `USAGE` on the application schema and `SELECT, INSERT, UPDATE, DELETE` on every table that has `ENABLE ROW LEVEL SECURITY`
 
-#### Scenario: RLS isolation is verified end-to-end per table
-- **WHEN** the integration test suite runs
-- **THEN** for every table with `ENABLE ROW LEVEL SECURITY`, there SHALL be a test that connects as `aeterna_app_rls`, begins a transaction, seeds rows for two distinct tenants, sets `app.tenant_id` to one tenant via `set_config(..., true)`, and asserts that a `SELECT *` returns only that tenant's rows
-- **AND** for every such table there SHALL be a test asserting that without setting `app.tenant_id`, the same `SELECT *` returns zero rows
+#### Scenario: Rollback escape hatch is operationally documented
+- **WHEN** an operator needs to revert to the legacy BYPASSRLS role
+- **THEN** setting `AETERNA_DB_ROLE=bypassrls` and performing a rolling pool restart SHALL be sufficient to switch the effective role
+- **AND** the rollback SHALL complete in under 5 minutes per region per `docs/ops/rls_rollback.md`
+- **AND** the bypass path SHALL be removed in Bundle A.5 after a minimum 4-week prod soak under `rls`
 
-#### Scenario: Schema introspection guards role grants
-- **WHEN** the integration test suite starts
-- **THEN** a pre-flight query SHALL enumerate every table in `pg_tables` where `rowsecurity = true`
-- **AND** SHALL assert that `aeterna_app_rls` has been granted at minimum `SELECT` on each such table
-- **AND** SHALL fail the run with a message naming the missing table if any grant is absent, so that adding a new RLS-protected table without updating the test grant fails CI
+### Requirement: Per-Request Transaction-Scoped Tenant Context
+Every code path that reads from or writes to a tenant-scoped PostgreSQL table SHALL acquire its connection through a helper that opens an explicit transaction, sets `app.tenant_id` transaction-locally, and commits or rolls back before returning the connection to the pool. Direct `pool.acquire()` or `pool.begin()` on tenant-scoped paths SHALL be forbidden.
 
-#### Scenario: Handler-level list paths are exercised under RLS
-- **WHEN** the integration test suite runs
-- **THEN** the `/user`, `/project`, `/org`, and `/govern/audit` list endpoints SHALL be exercised against a test server whose pool connects as `aeterna_app_rls`
-- **AND** each list SHALL return only the authenticated tenant's rows
-- **AND** attempting a request with no resolved tenant context SHALL either return `400 select_tenant` (at the middleware layer) or an empty list (at the RLS layer) — never rows from another tenant
+#### Scenario: Request handlers use with_tenant_context
+- **WHEN** a request handler queries a tenant-scoped table
+- **THEN** the handler SHALL call `with_tenant_context(&ctx, |tx| async { … })` (or an equivalent async-worker-scoped helper)
+- **AND** the helper SHALL issue `BEGIN`, `SET LOCAL app.tenant_id = $1`, the handler body, and `COMMIT`/`ROLLBACK` in that order
+- **AND** the handler SHALL NOT call `self.pool.acquire()` or `self.pool.begin()` directly on a tenant-scoped path
+
+#### Scenario: Async workers carry their own tenant context
+- **WHEN** an async worker (sync, webhook, backup, GDPR) processes a job that touches tenant-scoped tables
+- **THEN** the worker SHALL read the tenant identifier from its job record
+- **AND** SHALL construct a `TenantContext` from that identifier
+- **AND** SHALL acquire its connection through `with_tenant_context` using that context
+- **AND** a job that touches tenant-scoped tables without an associated tenant identifier SHALL fail fast rather than running unscoped
+
+#### Scenario: Direct pool access is lint-enforced
+- **WHEN** a contributor introduces a call to `self.pool.acquire()` or `self.pool.begin()` outside of `with_tenant_context`
+- **THEN** the CI `deny_lint` SHALL fail the build unless the call site carries an `#[allow(direct_pool_access)]` attribute with a justification comment documenting why the path is tenant-context-free (e.g., health check, schema migration)
 
 ### Requirement: Tenant Session Variable Hygiene
-Every code path that writes the `app.tenant_id` (or `app.company_id`) PostgreSQL session variable SHALL use a transaction-scoped write so that the setting cannot survive on a pooled connection after the originating query completes. This guards against a pooled connection carrying a prior request's tenant context into a subsequent request.
+Every code path that writes the `app.tenant_id` PostgreSQL session variable SHALL use transaction-scoped writes so that the setting cannot survive on a pooled connection after the originating request completes. The legacy `app.company_id` and `app.current_tenant_id` GUC names SHALL NOT be written by application code; migration 024 normalized the policies to `app.tenant_id` and Bundle A.1 normalizes the app-side.
 
 #### Scenario: set_config uses transaction scope
-- **WHEN** the application calls `set_config('app.tenant_id', $1, ?)` (or the equivalent `SET` / `SET LOCAL` statement)
+- **WHEN** the application calls `set_config('app.tenant_id', $1, ?)` (or the equivalent `SET LOCAL` statement)
 - **THEN** the call SHALL pass `true` as the third argument (transaction-local) and SHALL be inside an explicit `BEGIN`
-- **AND** the application SHALL NOT rely on session-scoped `set_config(..., false)` for tenant context, so that returning a connection to the pool cannot leak tenant state
+- **AND** the application SHALL NOT pass `false` (session-scoped) anywhere outside of an explicitly-allowlisted diagnostic path
+
+#### Scenario: Canonical GUC namespace is enforced
+- **WHEN** application code reads or writes a tenant session variable
+- **THEN** it SHALL use the name `app.tenant_id` exclusively
+- **AND** SHALL NOT reference `app.company_id`, `app.current_tenant_id`, or `app.current_company_id` outside of migration files
+- **AND** a compile-time grep test SHALL fail the build if a new reference to a legacy GUC name is introduced in non-migration source
 
 #### Scenario: Test suite catches session-scope misuse
 - **WHEN** a new query is introduced that writes `app.tenant_id` with session scope
-- **THEN** a dedicated `cargo test` target SHALL fail by detecting a pooled-connection leak: it acquires a connection, sets context to tenant A, returns the connection to the pool, acquires a fresh connection, and asserts that `current_setting('app.tenant_id', true)` returns empty rather than tenant A's identifier
+- **THEN** the `session_variable_hygiene` test SHALL fail by detecting a pooled-connection leak: it acquires a connection, sets context to tenant A, returns the connection to the pool, acquires a fresh connection, and asserts that `current_setting('app.tenant_id', true)` returns empty rather than tenant A's identifier
+
+### Requirement: RLS End-to-End Verification
+The system SHALL maintain an integration test suite that exercises every RLS-enabled PostgreSQL table under the non-BYPASSRLS `aeterna_app` role on every CI run. This suite is the permanent regression guard that prevents a future refactor from silently regressing tenant isolation, and is the source of truth for whether the `with_tenant_context` helper correctly scopes every code path.
+
+#### Scenario: Grant pre-flight enumerates RLS tables
+- **WHEN** the integration test suite starts
+- **THEN** a pre-flight query SHALL enumerate every table in `pg_tables` where `rowsecurity = true`
+- **AND** SHALL assert that `aeterna_app` has been granted at minimum `SELECT` on each such table
+- **AND** SHALL fail the run with a message naming the missing table if any grant is absent, so that adding a new RLS-protected table without updating the grant fails CI
+
+#### Scenario: RLS isolation is verified per table
+- **WHEN** the integration test suite runs
+- **THEN** for every table with `ENABLE ROW LEVEL SECURITY`, there SHALL be a test that connects as `aeterna_app`, begins a transaction, seeds rows for two distinct tenants, sets `app.tenant_id` to one tenant via `set_config(..., true)`, and asserts that a `SELECT *` returns only that tenant's rows
+- **AND** for every such table there SHALL be a test asserting that without setting `app.tenant_id`, the same `SELECT *` returns zero rows
+- **AND** for every such table there SHALL be a test asserting that a query for rows belonging to a different tenant (by explicit `WHERE id = $foreign_id`) returns zero rows
+
+#### Scenario: Handler-level list paths are exercised under RLS
+- **WHEN** the integration test suite runs
+- **THEN** the `/user`, `/project`, `/org`, and `/govern/audit` list endpoints SHALL be exercised against a test server whose pool connects as `aeterna_app`
+- **AND** each list SHALL return only the authenticated tenant's rows
+- **AND** attempting a request with no resolved tenant context SHALL either return `400 select_tenant` (at the middleware layer) or an empty list (at the RLS layer) — never rows from another tenant

--- a/openspec/changes/decide-rls-enforcement-model/specs/runtime-security-hardening/spec.md
+++ b/openspec/changes/decide-rls-enforcement-model/specs/runtime-security-hardening/spec.md
@@ -1,13 +1,13 @@
 ## MODIFIED Requirements
 
 ### Requirement: Backend-Specific Persistence Isolation
-The system SHALL define and enforce tenant isolation explicitly for each persistence backend used in production-capable deployments. On PostgreSQL, the authoritative enforcement layer is PostgreSQL row-level security policies evaluated against a transaction-scoped `app.tenant_id` GUC; the repository layer's explicit `WHERE tenant_id = $N` clauses remain as a required second layer of defense in depth.
+The system SHALL define and enforce tenant isolation explicitly for each persistence backend used in production-capable deployments. On PostgreSQL, the authoritative enforcement layer SHALL be row-level security policies evaluated against a transaction-scoped `app.tenant_id` GUC; the repository layer's `WHERE tenant_id = $N` clauses remain as required second-layer defense in depth.
 
 #### Scenario: PostgreSQL tenant isolation is enforced by row-level security
 - **WHEN** PostgreSQL stores tenant-scoped data
-- **THEN** the production application database role SHALL NOT have `BYPASSRLS` and SHALL NOT be the table owner of any tenant-scoped table
+- **THEN** the default application database role SHALL NOT have `BYPASSRLS` and SHALL NOT be the table owner of any tenant-scoped table
 - **AND** every tenant-scoped table SHALL have `ENABLE ROW LEVEL SECURITY` with at least one policy keyed on `current_setting('app.tenant_id', true)`
-- **AND** every request-scoped query path SHALL acquire its database connection through the `with_tenant_context` helper (or equivalent) that opens an explicit transaction, issues `SET LOCAL app.tenant_id = $1`, runs the query body, and commits or rolls back
+- **AND** every request-scoped query path SHALL acquire its database connection through the `with_tenant_context` helper that opens an explicit transaction, issues `SET LOCAL app.tenant_id = $1`, runs the query body, and commits or rolls back
 - **AND** every repository-layer query against a tenant-scoped table SHALL additionally include an explicit `WHERE tenant_id = $N` clause (or equivalent `company_id` clause for governance tables) as defense in depth on top of the RLS policy
 - **AND** documentation (`AGENTS.md`, `DEVELOPER_GUIDE.md`) SHALL state the two-layer model: RLS is authoritative, the `WHERE` clause is required defense in depth, neither is optional
 
@@ -30,53 +30,74 @@ The system SHALL define and enforce tenant isolation explicitly for each persist
 
 ## ADDED Requirements
 
-### Requirement: Non-BYPASSRLS Application Role in Production
-The system SHALL provision a dedicated PostgreSQL role (`aeterna_app`) that does NOT have `BYPASSRLS` and SHALL use this role for all production request-scoped database connections. The legacy BYPASSRLS role remains available only behind a feature flag for emergency rollback.
+### Requirement: Two-Role PostgreSQL Access Model
+The system SHALL provision two distinct PostgreSQL roles and SHALL route every application connection through one of them. The default role (`aeterna_app`) SHALL NOT have `BYPASSRLS`; the administrative role (`aeterna_admin`) SHALL have `BYPASSRLS` and SHALL be used only through a narrow, audited helper. No third connection path SHALL exist.
 
-#### Scenario: Production pool opens connections as aeterna_app
-- **WHEN** the application starts in production
-- **THEN** `AETERNA_DB_ROLE` SHALL resolve to `rls` (the default after Bundle A.4's rollout soak)
-- **AND** the connection pool SHALL authenticate as `aeterna_app` using the password supplied via `APP_DB_PASSWORD`
-- **AND** the startup log SHALL emit `db_role=rls` at `INFO` level so the effective role is visible in post-incident review
-
-#### Scenario: aeterna_app lacks BYPASSRLS
+#### Scenario: Both roles exist with the correct attributes
 - **WHEN** the migration suite is applied against a fresh database
-- **THEN** the role `aeterna_app` SHALL exist
-- **AND** `pg_roles.rolbypassrls` SHALL be `false` for `aeterna_app`
-- **AND** `pg_roles.rolsuper` SHALL be `false` for `aeterna_app`
+- **THEN** the role `aeterna_app` SHALL exist with `rolbypassrls = false` and `rolsuper = false`
+- **AND** the role `aeterna_admin` SHALL exist with `rolbypassrls = true` and `rolsuper = false`
 - **AND** `aeterna_app` SHALL hold `USAGE` on the application schema and `SELECT, INSERT, UPDATE, DELETE` on every table that has `ENABLE ROW LEVEL SECURITY`
+- **AND** `aeterna_admin` SHALL hold `USAGE` on the application schema and `SELECT, INSERT, UPDATE, DELETE` on all application tables
 
-#### Scenario: Rollback escape hatch is operationally documented
-- **WHEN** an operator needs to revert to the legacy BYPASSRLS role
-- **THEN** setting `AETERNA_DB_ROLE=bypassrls` and performing a rolling pool restart SHALL be sufficient to switch the effective role
-- **AND** the rollback SHALL complete in under 5 minutes per region per `docs/ops/rls_rollback.md`
-- **AND** the bypass path SHALL be removed in Bundle A.5 after a minimum 4-week prod soak under `rls`
+#### Scenario: Application wires two connection pools
+- **WHEN** the application builds its shared state
+- **THEN** `AppState` SHALL expose `pool: PgPool` that opens connections as `aeterna_app` using `DATABASE_URL`
+- **AND** SHALL expose `admin_pool: PgPool` that opens connections as `aeterna_admin` using `DATABASE_URL_ADMIN`
+- **AND** the admin pool SHALL be size-capped (`max_connections = 4` or lower) to make accidental hot-loop use of the admin pool a visible capacity signal rather than a silent privilege escalation
 
 ### Requirement: Per-Request Transaction-Scoped Tenant Context
-Every code path that reads from or writes to a tenant-scoped PostgreSQL table SHALL acquire its connection through a helper that opens an explicit transaction, sets `app.tenant_id` transaction-locally, and commits or rolls back before returning the connection to the pool. Direct `pool.acquire()` or `pool.begin()` on tenant-scoped paths SHALL be forbidden.
+Every code path that reads from or writes to a tenant-scoped PostgreSQL table via the default pool SHALL acquire its connection through a helper that opens an explicit transaction, sets `app.tenant_id` transaction-locally, and commits or rolls back before returning the connection. Direct `state.pool.acquire()` or `state.pool.begin()` on tenant-scoped paths SHALL be forbidden.
 
 #### Scenario: Request handlers use with_tenant_context
-- **WHEN** a request handler queries a tenant-scoped table
-- **THEN** the handler SHALL call `with_tenant_context(&ctx, |tx| async { … })` (or an equivalent async-worker-scoped helper)
+- **WHEN** a request handler queries a tenant-scoped table under a resolved tenant context
+- **THEN** the handler SHALL call `with_tenant_context(&ctx, |tx| async { … })`
 - **AND** the helper SHALL issue `BEGIN`, `SET LOCAL app.tenant_id = $1`, the handler body, and `COMMIT`/`ROLLBACK` in that order
-- **AND** the handler SHALL NOT call `self.pool.acquire()` or `self.pool.begin()` directly on a tenant-scoped path
+- **AND** the handler SHALL NOT call `state.pool.acquire()` or `state.pool.begin()` directly on a tenant-scoped path
 
-#### Scenario: Async workers carry their own tenant context
-- **WHEN** an async worker (sync, webhook, backup, GDPR) processes a job that touches tenant-scoped tables
+#### Scenario: Async per-tenant workers carry their own tenant context
+- **WHEN** an async worker (sync, per-tenant backup, per-tenant GDPR export) processes a job that touches tenant-scoped tables
 - **THEN** the worker SHALL read the tenant identifier from its job record
-- **AND** SHALL construct a `TenantContext` from that identifier
+- **AND** SHALL construct a `TenantContext` via `TenantContext::from_scheduled_job(tenant_id, job_id)`
 - **AND** SHALL acquire its connection through `with_tenant_context` using that context
 - **AND** a job that touches tenant-scoped tables without an associated tenant identifier SHALL fail fast rather than running unscoped
 
 #### Scenario: Direct pool access is lint-enforced
-- **WHEN** a contributor introduces a call to `self.pool.acquire()` or `self.pool.begin()` outside of `with_tenant_context`
-- **THEN** the CI `deny_lint` SHALL fail the build unless the call site carries an `#[allow(direct_pool_access)]` attribute with a justification comment documenting why the path is tenant-context-free (e.g., health check, schema migration)
+- **WHEN** a contributor introduces a call to `state.pool.acquire()` or `state.pool.begin()` outside of `with_tenant_context`
+- **THEN** the CI lint SHALL fail the build unless the call site carries `#[allow(direct_pool_access)]` with a justification comment documenting why the path is tenant-context-free
+
+### Requirement: Administrative Cross-Tenant Access
+The system SHALL route every legitimate cross-tenant operation (PlatformAdmin `?tenant=*` reads, scheduled cross-tenant maintenance, migration runner) through a single `with_admin_context` helper on a dedicated admin pool. Every call SHALL be audited by the helper itself so cross-tenant access is always traceable.
+
+#### Scenario: PlatformAdmin cross-tenant reads use the admin helper
+- **WHEN** a PlatformAdmin request arrives with `?tenant=*` (or the deprecated `?tenant=all`)
+- **THEN** the handler SHALL resolve the request context to `CrossTenantAll` and SHALL acquire its connection through `with_admin_context(&ctx, |tx| …)`
+- **AND** SHALL NOT use `with_tenant_context` (there is no single tenant to scope to)
+- **AND** the helper SHALL open the transaction on `state.admin_pool` and SHALL NOT issue `SET LOCAL app.tenant_id`
+
+#### Scenario: Scheduled cross-tenant jobs use the system sentinel context
+- **WHEN** a scheduled job runs cross-tenant maintenance (audit compaction, global rate-limit sweep, cross-tenant analytics rollup)
+- **THEN** it SHALL construct a `TenantContext` via `TenantContext::system_ctx()`
+- **AND** SHALL acquire its connection through `with_admin_context(&system_ctx, |tx| …)`
+- **AND** the `system_ctx` sentinel SHALL carry `actor_type = 'system'` so audit rows are attributed to internal system work rather than a human actor
+
+#### Scenario: Scheduled per-tenant jobs enumerate via admin and dispatch via tenant
+- **WHEN** a scheduled job runs per-tenant work (sync, per-tenant backup, per-tenant GDPR export)
+- **THEN** the scheduler SHALL enumerate active tenants via a one-shot `with_admin_context(&system_ctx, |tx| …)` call
+- **AND** SHALL dispatch the per-tenant body through `with_tenant_context(&TenantContext::from_scheduled_job(t, job_id), |tx| …)` for each tenant
+- **AND** the per-tenant body SHALL NOT touch the admin pool
+
+#### Scenario: Every admin access is audited
+- **WHEN** any code path enters `with_admin_context`
+- **THEN** the helper SHALL write a `governance_audit_log` row before returning, carrying `actor_id`, `actor_type`, `admin_scope = true`, and `acting_as_tenant_id = NULL`
+- **AND** the audit write SHALL be inside the helper so no per-call-site bookkeeping is required
+- **AND** a code path that reaches `state.admin_pool` without going through `with_admin_context` SHALL fail the direct-pool-access CI lint
 
 ### Requirement: Tenant Session Variable Hygiene
-Every code path that writes the `app.tenant_id` PostgreSQL session variable SHALL use transaction-scoped writes so that the setting cannot survive on a pooled connection after the originating request completes. The legacy `app.company_id` and `app.current_tenant_id` GUC names SHALL NOT be written by application code; migration 024 normalized the policies to `app.tenant_id` and Bundle A.1 normalizes the app-side.
+Every code path that writes the `app.tenant_id` PostgreSQL session variable SHALL use transaction-scoped writes so the setting cannot survive on a pooled connection after the originating request completes. Legacy `app.company_id` and `app.current_tenant_id` GUC names SHALL NOT be written by application code; migration 024 normalized the policies and Bundle A.1 normalizes the app-side writes.
 
 #### Scenario: set_config uses transaction scope
-- **WHEN** the application calls `set_config('app.tenant_id', $1, ?)` (or the equivalent `SET LOCAL` statement)
+- **WHEN** the application calls `set_config('app.tenant_id', $1, ?)` (or equivalent `SET LOCAL`)
 - **THEN** the call SHALL pass `true` as the third argument (transaction-local) and SHALL be inside an explicit `BEGIN`
 - **AND** the application SHALL NOT pass `false` (session-scoped) anywhere outside of an explicitly-allowlisted diagnostic path
 
@@ -88,25 +109,32 @@ Every code path that writes the `app.tenant_id` PostgreSQL session variable SHAL
 
 #### Scenario: Test suite catches session-scope misuse
 - **WHEN** a new query is introduced that writes `app.tenant_id` with session scope
-- **THEN** the `session_variable_hygiene` test SHALL fail by detecting a pooled-connection leak: it acquires a connection, sets context to tenant A, returns the connection to the pool, acquires a fresh connection, and asserts that `current_setting('app.tenant_id', true)` returns empty rather than tenant A's identifier
+- **THEN** the `session_variable_hygiene` test SHALL fail by detecting a pooled-connection leak: it acquires a connection, sets context to tenant A, returns the connection, acquires a fresh connection, and asserts `current_setting('app.tenant_id', true)` returns empty rather than tenant A's identifier
 
 ### Requirement: RLS End-to-End Verification
-The system SHALL maintain an integration test suite that exercises every RLS-enabled PostgreSQL table under the non-BYPASSRLS `aeterna_app` role on every CI run. This suite is the permanent regression guard that prevents a future refactor from silently regressing tenant isolation, and is the source of truth for whether the `with_tenant_context` helper correctly scopes every code path.
+The system SHALL maintain an integration test suite that exercises every RLS-enabled PostgreSQL table under the non-BYPASSRLS `aeterna_app` role on every CI run, plus every admin-scoped handler under the `aeterna_admin` role. This is the permanent regression guard that prevents future refactors from silently regressing the model.
 
 #### Scenario: Grant pre-flight enumerates RLS tables
 - **WHEN** the integration test suite starts
 - **THEN** a pre-flight query SHALL enumerate every table in `pg_tables` where `rowsecurity = true`
 - **AND** SHALL assert that `aeterna_app` has been granted at minimum `SELECT` on each such table
-- **AND** SHALL fail the run with a message naming the missing table if any grant is absent, so that adding a new RLS-protected table without updating the grant fails CI
+- **AND** SHALL fail the run with a message naming the missing table if any grant is absent
 
 #### Scenario: RLS isolation is verified per table
 - **WHEN** the integration test suite runs
-- **THEN** for every table with `ENABLE ROW LEVEL SECURITY`, there SHALL be a test that connects as `aeterna_app`, begins a transaction, seeds rows for two distinct tenants, sets `app.tenant_id` to one tenant via `set_config(..., true)`, and asserts that a `SELECT *` returns only that tenant's rows
-- **AND** for every such table there SHALL be a test asserting that without setting `app.tenant_id`, the same `SELECT *` returns zero rows
-- **AND** for every such table there SHALL be a test asserting that a query for rows belonging to a different tenant (by explicit `WHERE id = $foreign_id`) returns zero rows
+- **THEN** for every RLS table, there SHALL be a positive test (connect as `aeterna_app`, `BEGIN`, `set_config(..., true)`, `SELECT *`, assert only that tenant's rows)
+- **AND** a negative test (same connection without `set_config`, assert zero rows)
+- **AND** a cross-tenant test (seed rows for A and B, set context to A, query for B's rows by id, assert zero rows)
 
-#### Scenario: Handler-level list paths are exercised under RLS
+#### Scenario: Admin surface is verified under the admin role
 - **WHEN** the integration test suite runs
-- **THEN** the `/user`, `/project`, `/org`, and `/govern/audit` list endpoints SHALL be exercised against a test server whose pool connects as `aeterna_app`
+- **THEN** every PlatformAdmin `?tenant=*` list endpoint SHALL be exercised against a test server wired with both pools
+- **AND** the test SHALL probe the connection's `current_user` to assert the admin pool was chosen
+- **AND** the response SHALL contain rows from multiple tenants
+- **AND** the test SHALL assert a `governance_audit_log` row was written with `admin_scope = true` for each admin access
+
+#### Scenario: Per-tenant handler surface is verified under the default role
+- **WHEN** the integration test suite runs
+- **THEN** per-tenant list endpoints (`/user`, `/project`, `/org`, `/govern/audit` without `?tenant=*`) SHALL be exercised against a test server whose default pool connects as `aeterna_app`
 - **AND** each list SHALL return only the authenticated tenant's rows
-- **AND** attempting a request with no resolved tenant context SHALL either return `400 select_tenant` (at the middleware layer) or an empty list (at the RLS layer) — never rows from another tenant
+- **AND** a request with no resolved tenant context SHALL return `400 select_tenant` (middleware) or an empty list (RLS) — never rows from another tenant

--- a/openspec/changes/decide-rls-enforcement-model/tasks.md
+++ b/openspec/changes/decide-rls-enforcement-model/tasks.md
@@ -1,0 +1,47 @@
+# Tasks
+
+## 1. Decision ratification
+
+- [ ] 1.1 Review `proposal.md` and `design.md` with Christian / Kyriba security reviewer
+- [ ] 1.2 Record the accept/decline decision on issue #58 as a top-level comment referencing this change
+- [ ] 1.3 If declined, document the alternative chosen (Option A or B) and archive this change without merging
+
+## 2. Migration: dedicated non-BYPASSRLS role
+
+- [ ] 2.1 Add `storage/migrations/025_add_rls_test_role.sql` that `CREATE ROLE aeterna_app_rls LOGIN NOBYPASSRLS PASSWORD 'test_only_insecure_override_in_ci'` (idempotent `DO $$ … IF NOT EXISTS …`)
+- [ ] 2.2 Grant `USAGE` on `public` schema to `aeterna_app_rls`
+- [ ] 2.3 Grant `SELECT, INSERT, UPDATE, DELETE` on every table currently having `ENABLE ROW LEVEL SECURITY` (22 tables) to `aeterna_app_rls`
+- [ ] 2.4 Grant `USAGE, SELECT` on every sequence the granted tables depend on
+- [ ] 2.5 Document in the migration file header: "Test-only role. Prod deploys continue to use a BYPASSRLS role (typically `postgres`). See `openspec/specs/runtime-security-hardening/spec.md` ‘RLS Test-Time Enforcement’."
+
+## 3. Session-variable hygiene (Hazard H1)
+
+- [ ] 3.1 `storage/src/postgres.rs:63` — change `set_config('app.tenant_id', $1, false)` to `set_config('app.tenant_id', $1, true)` and wrap the call site in an explicit `BEGIN`/`COMMIT` (the `activate_tenant_context` helper becomes transaction-aware)
+- [ ] 3.2 `cli/src/server/backup_api.rs:1597` — same fix; the surrounding handler already opens a transaction for the backup export, so this is a one-character change plus moving the `set_config` inside the existing `BEGIN`
+- [ ] 3.3 `storage/src/gdpr.rs:407,490,580` — already uses `true`; verify each call is inside an explicit transaction and document the invariant in a module-level `// INVARIANT:` comment
+- [ ] 3.4 `cli/src/server/sync.rs:131,256` — document that `activate_tenant_context` is currently a no-op under the prod BYPASSRLS role; under the test RLS role it is load-bearing. No code change required.
+
+## 4. Integration test suite
+
+- [ ] 4.1 Add `cli/tests/rls_enforcement_test.rs` with a shared `rls_pool()` helper that clones `DATABASE_URL`, replaces the username/password with `aeterna_app_rls` / the role password, and returns a fresh `PgPool`
+- [ ] 4.2 Pre-flight test `rls_role_has_required_grants` — enumerates `pg_tables WHERE rowsecurity = true`, asserts `aeterna_app_rls` has `SELECT` on each (fails with the table name if a grant is missing)
+- [ ] 4.3 Per-table isolation test `rls_isolates_{table}_by_tenant` (parameterized via a `#[rstest]` or macro over the 22 tables) — positive (context set → tenant A rows) + negative (context unset → 0 rows)
+- [ ] 4.4 Handler-level test `rls_list_endpoints_return_only_active_tenant` — spin up the test server with its pool pointed at `aeterna_app_rls`, hit `/user`, `/project`, `/org`, `/govern/audit`, assert only the authenticated tenant's rows
+- [ ] 4.5 Session-variable-leak test `tenant_context_does_not_leak_across_pool_checkouts` — the scenario from spec §"Tenant Session Variable Hygiene" / "Test suite catches session-scope misuse"
+
+## 5. Documentation
+
+- [ ] 5.1 `AGENTS.md` — add a section "Multi-tenancy enforcement model" pointing to `runtime-security-hardening` and stating: prod = app-layer `WHERE tenant_id = ?`, CI = RLS under `aeterna_app_rls`
+- [ ] 5.2 `DEVELOPER_GUIDE.md` — add a subsection describing how to write a new repository query against an RLS-protected table: always `WHERE tenant_id = $N`, never rely on RLS in prod, expect the CI suite to fail if you miss the clause
+- [ ] 5.3 `storage/migrations/README.md` — append a row to the migration index for 025 and a note about the role in the "Conventions" section
+
+## 6. CI wiring
+
+- [ ] 6.1 Verify the CI compose file / action runs `migrations/025_…` as part of the test DB setup (it should — migrations run in order — but document the expectation)
+- [ ] 6.2 Add a CI job step that sets `AETERNA_RLS_TEST_PASSWORD` from a GitHub secret (matches the password used by the migration in dev/test)
+
+## 7. Follow-up (out of scope for this change, filed as new issues on merge)
+
+- [ ] 7.1 File issue: "GUC namespace normalization: migrate remaining `app.company_id` / `app.current_tenant_id` policies to `app.tenant_id`" (continuation of migration 024)
+- [ ] 7.2 File issue: "Repository-layer audit: confirm every SELECT against an RLS-protected table carries a `WHERE tenant_id = ?` clause" — mechanical sqlx-macro-level audit
+- [ ] 7.3 File issue: "`sync.rs` `activate_tenant_context` call sites: either remove as dead code under prod BYPASSRLS, or document them as load-bearing-under-CI"

--- a/openspec/changes/decide-rls-enforcement-model/tasks.md
+++ b/openspec/changes/decide-rls-enforcement-model/tasks.md
@@ -4,44 +4,72 @@
 
 - [ ] 1.1 Review `proposal.md` and `design.md` with Christian / Kyriba security reviewer
 - [ ] 1.2 Record the accept/decline decision on issue #58 as a top-level comment referencing this change
-- [ ] 1.3 If declined, document the alternative chosen (Option A or B) and archive this change without merging
+- [ ] 1.3 Lock the threat model (see `design.md` §2): "compromised or buggy handler on a live production request MUST NOT be able to read another tenant's rows." Subsequent bundles inherit this.
 
-## 2. Migration: dedicated non-BYPASSRLS role
+## 2. Bundle A.1 — Hazard fixes (P0 prerequisite, independently shippable)
 
-- [ ] 2.1 Add `storage/migrations/025_add_rls_test_role.sql` that `CREATE ROLE aeterna_app_rls LOGIN NOBYPASSRLS PASSWORD 'test_only_insecure_override_in_ci'` (idempotent `DO $$ … IF NOT EXISTS …`)
-- [ ] 2.2 Grant `USAGE` on `public` schema to `aeterna_app_rls`
-- [ ] 2.3 Grant `SELECT, INSERT, UPDATE, DELETE` on every table currently having `ENABLE ROW LEVEL SECURITY` (22 tables) to `aeterna_app_rls`
-- [ ] 2.4 Grant `USAGE, SELECT` on every sequence the granted tables depend on
-- [ ] 2.5 Document in the migration file header: "Test-only role. Prod deploys continue to use a BYPASSRLS role (typically `postgres`). See `openspec/specs/runtime-security-hardening/spec.md` ‘RLS Test-Time Enforcement’."
+**Goal:** close Hazards H1 and H2 before any role flip. Safe to merge immediately; no behavior change under BYPASSRLS, essential invariant once BYPASSRLS is revoked. Target: 1 PR, ≤ 1 week.
 
-## 3. Session-variable hygiene (Hazard H1)
+- [ ] 2.1 **H1 — session-scope leak in `storage/src/postgres.rs:63`.** Change `set_config('app.tenant_id', $1, false)` → `set_config('app.tenant_id', $1, true)` and make `activate_tenant_context` require an open transaction. Caller contract documented via rustdoc; a `debug_assert!` at entry checks the connection is inside a transaction (via `SELECT current_setting('transaction_isolation')` side-effect semantics or equivalent).
+- [ ] 2.2 **H1 — `cli/src/server/backup_api.rs:1597`.** Same fix; the handler already opens a transaction for the backup export, so this is a one-character change plus moving the `set_config` call inside the existing `BEGIN` scope.
+- [ ] 2.3 **H1 — `cli/src/server/gdpr.rs:407,490,580`.** Audit each call: `true` is already passed (good), but verify each is inside an explicit transaction and add a module-level `// INVARIANT:` comment pinning the expectation for future edits.
+- [ ] 2.4 **H2 — dual-GUC normalization.** Grep every `set_config` and `current_setting` call in the codebase for the four variants (`app.tenant_id`, `app.company_id`, `app.current_tenant_id`, `app.current_company_id`). Normalize every code-side write to `app.tenant_id`. Every code-side read to `app.tenant_id`. Migration 024 already normalized the policies; this closes the read/write side.
+- [ ] 2.5 **H1 regression test.** `storage/tests/session_variable_hygiene.rs` — acquire a connection from the pool, set `app.tenant_id` via `activate_tenant_context`, return it to the pool, acquire a fresh connection, assert `current_setting('app.tenant_id', true)` returns empty. Fails if anyone reverts to session-scope `set_config`.
+- [ ] 2.6 **H2 regression test.** `storage/tests/guc_namespace.rs` — grep assertion (compile-time via `include_str!`) that no source file outside of `storage/migrations/` contains `app.company_id` or `app.current_tenant_id`. Fails if a new handler re-introduces the legacy namespace.
 
-- [ ] 3.1 `storage/src/postgres.rs:63` — change `set_config('app.tenant_id', $1, false)` to `set_config('app.tenant_id', $1, true)` and wrap the call site in an explicit `BEGIN`/`COMMIT` (the `activate_tenant_context` helper becomes transaction-aware)
-- [ ] 3.2 `cli/src/server/backup_api.rs:1597` — same fix; the surrounding handler already opens a transaction for the backup export, so this is a one-character change plus moving the `set_config` inside the existing `BEGIN`
-- [ ] 3.3 `storage/src/gdpr.rs:407,490,580` — already uses `true`; verify each call is inside an explicit transaction and document the invariant in a module-level `// INVARIANT:` comment
-- [ ] 3.4 `cli/src/server/sync.rs:131,256` — document that `activate_tenant_context` is currently a no-op under the prod BYPASSRLS role; under the test RLS role it is load-bearing. No code change required.
+## 3. Bundle A.2 — Dedicated non-BYPASSRLS role + migration + CI verification (independently shippable)
 
-## 4. Integration test suite
+**Goal:** stand up the `aeterna_app` role, make it grant-complete, and wire a CI suite that runs every RLS-enabled table through it end-to-end. Prod `DATABASE_URL` is NOT changed. Target: 1 PR, ≤ 2 weeks.
 
-- [ ] 4.1 Add `cli/tests/rls_enforcement_test.rs` with a shared `rls_pool()` helper that clones `DATABASE_URL`, replaces the username/password with `aeterna_app_rls` / the role password, and returns a fresh `PgPool`
-- [ ] 4.2 Pre-flight test `rls_role_has_required_grants` — enumerates `pg_tables WHERE rowsecurity = true`, asserts `aeterna_app_rls` has `SELECT` on each (fails with the table name if a grant is missing)
-- [ ] 4.3 Per-table isolation test `rls_isolates_{table}_by_tenant` (parameterized via a `#[rstest]` or macro over the 22 tables) — positive (context set → tenant A rows) + negative (context unset → 0 rows)
-- [ ] 4.4 Handler-level test `rls_list_endpoints_return_only_active_tenant` — spin up the test server with its pool pointed at `aeterna_app_rls`, hit `/user`, `/project`, `/org`, `/govern/audit`, assert only the authenticated tenant's rows
-- [ ] 4.5 Session-variable-leak test `tenant_context_does_not_leak_across_pool_checkouts` — the scenario from spec §"Tenant Session Variable Hygiene" / "Test suite catches session-scope misuse"
+- [ ] 3.1 `storage/migrations/025_add_app_role.sql` — `CREATE ROLE aeterna_app LOGIN NOBYPASSRLS PASSWORD 'managed_via_secret'` (idempotent via `DO $$ … pg_roles WHERE rolname = 'aeterna_app' … $$`). Password is an `${APP_DB_PASSWORD}` placeholder consumed by the migration runner.
+- [ ] 3.2 `GRANT USAGE ON SCHEMA public TO aeterna_app`.
+- [ ] 3.3 `GRANT SELECT, INSERT, UPDATE, DELETE` on every table currently having `rowsecurity = true` (22 tables) to `aeterna_app`. Enumerated explicitly — no `GRANT … ON ALL TABLES` catch-all, so adding a new RLS-protected table without updating the grant fails the A.2.5 pre-flight.
+- [ ] 3.4 `GRANT USAGE, SELECT` on every sequence the granted tables depend on.
+- [ ] 3.5 Migration header documents: "Non-BYPASSRLS application role. Bundle A.4 flips `DATABASE_URL` to this role. See `openspec/changes/decide-rls-enforcement-model/proposal.md`."
+- [ ] 3.6 **CI suite — `cli/tests/rls_enforcement_test.rs`.** For every table with `rowsecurity = true`:
+  - [ ] 3.6.1 Pre-flight: enumerate `pg_tables WHERE rowsecurity = true`; assert each has been granted `SELECT` to `aeterna_app`; fail with a named-table error if a grant is missing.
+  - [ ] 3.6.2 Positive path: open a connection as `aeterna_app`, `BEGIN`, `set_config('app.tenant_id', tenant_a, true)`, `SELECT *` — assert only tenant_a's rows.
+  - [ ] 3.6.3 Negative path: same connection without `set_config` — assert zero rows returned.
+  - [ ] 3.6.4 Cross-tenant path: seed rows for tenants A and B, set context to A, attempt `SELECT` for B's rows by WHERE id — assert zero rows.
+- [ ] 3.7 **CI suite — handler-level `cli/tests/rls_handler_smoke.rs`.** Run `/user`, `/project`, `/org`, `/govern/audit` list endpoints against a test server whose pool connects as `aeterna_app`. Assert each list returns only the authenticated tenant's rows; assert a request with no resolved tenant context returns 400 `select_tenant` or an empty list (never foreign rows).
+- [ ] 3.8 Document in `DEVELOPER_GUIDE.md` how to run the A.2 suites locally (`docker compose -f docker-compose.rls.yml up` pattern).
 
-## 5. Documentation
+## 4. Bundle A.3 — Repository call-site refactor (multi-PR, wave-by-wave)
 
-- [ ] 5.1 `AGENTS.md` — add a section "Multi-tenancy enforcement model" pointing to `runtime-security-hardening` and stating: prod = app-layer `WHERE tenant_id = ?`, CI = RLS under `aeterna_app_rls`
-- [ ] 5.2 `DEVELOPER_GUIDE.md` — add a subsection describing how to write a new repository query against an RLS-protected table: always `WHERE tenant_id = $N`, never rely on RLS in prod, expect the CI suite to fail if you miss the clause
-- [ ] 5.3 `storage/migrations/README.md` — append a row to the migration index for 025 and a note about the role in the "Conventions" section
+**Goal:** thread per-request transaction-scoped tenant context through every RLS-protected query. Each wave is a standalone PR, each wave is independently revertable, each wave runs against the A.2 CI suite so regressions surface immediately. Target: 4–6 PRs, ≤ 3 weeks.
 
-## 6. CI wiring
+- [ ] 4.1 **Helper — `storage/src/postgres.rs::with_tenant_context`.**
+  - Signature: `async fn with_tenant_context<F, T>(&self, ctx: &TenantContext, body: F) -> Result<T> where F: FnOnce(&mut PgConnection) -> BoxFuture<Result<T>>`.
+  - Implementation: `self.pool.begin()` → `SET LOCAL app.tenant_id = $1` → body(&mut tx) → `tx.commit()`.
+  - Rustdoc states every RLS-protected query MUST acquire its connection this way; direct `pool.acquire()` is forbidden on RLS paths and will be enforced by lint in Bundle A.5.
+- [ ] 4.2 **Wave 1 — `user_api.rs` + `team_api.rs` + `org_api.rs` + `project_api.rs` list/get/create/update/delete paths.** Refactor each call site. CI suite (A.2) proves per-request isolation post-refactor. PR size target: ~25 call sites.
+- [ ] 4.3 **Wave 2 — `govern_api.rs` + `govern_policy.rs` + audit write paths.** ~15 call sites.
+- [ ] 4.4 **Wave 3 — `memory_api.rs` + `knowledge_api.rs` + ingest paths.** ~20 call sites.
+- [ ] 4.5 **Wave 4 — `sync.rs` + `webhook.rs` + async worker paths.** Async workers need their own tenant-context acquisition pattern (they don't have a request); establish and document the pattern. ~15 call sites.
+- [ ] 4.6 **Wave 5 — `backup_api.rs` + `gdpr.rs` + admin paths.** These already did manual `set_config` (fixed in A.1); convert to the helper. ~10 call sites.
+- [ ] 4.7 **Wave 6 — sweep.** Audit tool: `storage/tools/find_unwrapped_queries.sh` that greps for `self.pool.acquire()` / `self.pool.begin()` outside of `with_tenant_context`. Any remaining sites either (a) are RLS-protected and the sweep wave fixes them, or (b) are documented as intentionally context-free (e.g., health checks) with an `#[allow(direct_pool_access)]` attribute and a justification comment.
+- [ ] 4.8 Add CI `deny_lint` (warn-level) that fails on direct `self.pool.acquire()` / `.begin()` outside the allowlist. Graduates to deny-level in Bundle A.5.
 
-- [ ] 6.1 Verify the CI compose file / action runs `migrations/025_…` as part of the test DB setup (it should — migrations run in order — but document the expectation)
-- [ ] 6.2 Add a CI job step that sets `AETERNA_RLS_TEST_PASSWORD` from a GitHub secret (matches the password used by the migration in dev/test)
+## 5. Bundle A.4 — Prod flip (feature-flagged, canary-first)
 
-## 7. Follow-up (out of scope for this change, filed as new issues on merge)
+**Goal:** change the prod connection role from the legacy BYPASSRLS user to `aeterna_app`. Rollback is a single env-var change. Target: 1 PR to land the flag, then operational rollout.
 
-- [ ] 7.1 File issue: "GUC namespace normalization: migrate remaining `app.company_id` / `app.current_tenant_id` policies to `app.tenant_id`" (continuation of migration 024)
-- [ ] 7.2 File issue: "Repository-layer audit: confirm every SELECT against an RLS-protected table carries a `WHERE tenant_id = ?` clause" — mechanical sqlx-macro-level audit
-- [ ] 7.3 File issue: "`sync.rs` `activate_tenant_context` call sites: either remove as dead code under prod BYPASSRLS, or document them as load-bearing-under-CI"
+- [ ] 5.1 Add `AETERNA_DB_ROLE` env var (`bypassrls|rls`, default `bypassrls`) consumed in `cli/src/server/app_state.rs` when building the pool.
+- [ ] 5.2 `bypassrls` keeps the existing `DATABASE_URL` behavior.
+- [ ] 5.3 `rls` composes a new connection string pointing at `aeterna_app` with the password from `APP_DB_PASSWORD`.
+- [ ] 5.4 Startup log prints the effective role (`info!("db_role={role}")`) — searchable post-incident.
+- [ ] 5.5 Flag-land PR includes zero env changes in deployed config: prod keeps `bypassrls` at merge time.
+- [ ] 5.6 **Canary rollout** (ops-tracked, not a PR): flip `AETERNA_DB_ROLE=rls` in `dev` first, then `staging`, then per-region prod canaries. Minimum 2-week soak on staging before any prod region.
+- [ ] 5.7 **Rollback runbook** in `docs/ops/rls_rollback.md`: flip env var → rolling pool restart → verify log line — under 5 minutes per region.
+- [ ] 5.8 Post-flip observability: Grafana panel for `pg_stat_activity.state = 'active' transaction_duration_ms` distribution (detect BEGIN-per-request overhead regression).
+
+## 6. Bundle A.5 — Remove escape hatch + ratchet (independently shippable)
+
+**Goal:** remove the `bypassrls` code path once all environments have soaked on `rls` for ≥ 4 weeks. Graduate the lint to deny. Close Hazard H3. Target: 1 PR.
+
+- [ ] 6.1 Delete the `bypassrls` branch in the pool builder; `AETERNA_DB_ROLE` env var becomes a no-op (or is removed after a deprecation cycle).
+- [ ] 6.2 Delete the orphan `activate_tenant_context` calls in `cli/src/server/sync.rs:131,256` (Hazard H3) — they become redundant once every call site uses `with_tenant_context`.
+- [ ] 6.3 Graduate the A.3.8 `deny_lint` from warn to deny.
+- [ ] 6.4 Update `AGENTS.md` to describe the final two-layer model: RLS is authoritative, app-layer `WHERE tenant_id = ?` is defense in depth. Both remain required.
+- [ ] 6.5 Update `DEVELOPER_GUIDE.md` with the `with_tenant_context` pattern as the canonical query-acquisition idiom.
+- [ ] 6.6 Close issue #58 referencing the merged A.5 PR.

--- a/openspec/changes/decide-rls-enforcement-model/tasks.md
+++ b/openspec/changes/decide-rls-enforcement-model/tasks.md
@@ -2,74 +2,76 @@
 
 ## 1. Decision ratification
 
-- [ ] 1.1 Review `proposal.md` and `design.md` with Christian / Kyriba security reviewer
-- [ ] 1.2 Record the accept/decline decision on issue #58 as a top-level comment referencing this change
-- [ ] 1.3 Lock the threat model (see `design.md` §2): "compromised or buggy handler on a live production request MUST NOT be able to read another tenant's rows." Subsequent bundles inherit this.
+- [ ] 1.1 Review `proposal.md` and `design.md` with reviewing architect
+- [ ] 1.2 Record the decision on issue #58 as a top-level comment referencing this change
+- [ ] 1.3 Lock the dual-role/dual-pool design (see `design.md` §4) as the target state
 
-## 2. Bundle A.1 — Hazard fixes (P0 prerequisite, independently shippable)
+## 2. Bundle A.1 — Hazard fixes (prerequisite, independently shippable)
 
-**Goal:** close Hazards H1 and H2 before any role flip. Safe to merge immediately; no behavior change under BYPASSRLS, essential invariant once BYPASSRLS is revoked. Target: 1 PR, ≤ 1 week.
+**Goal:** close H1 and H2 before the role flip. No behavior change under BYPASSRLS; essential invariant once BYPASSRLS is gone. Target: 1 PR, ≤ 1 week.
 
-- [ ] 2.1 **H1 — session-scope leak in `storage/src/postgres.rs:63`.** Change `set_config('app.tenant_id', $1, false)` → `set_config('app.tenant_id', $1, true)` and make `activate_tenant_context` require an open transaction. Caller contract documented via rustdoc; a `debug_assert!` at entry checks the connection is inside a transaction (via `SELECT current_setting('transaction_isolation')` side-effect semantics or equivalent).
-- [ ] 2.2 **H1 — `cli/src/server/backup_api.rs:1597`.** Same fix; the handler already opens a transaction for the backup export, so this is a one-character change plus moving the `set_config` call inside the existing `BEGIN` scope.
-- [ ] 2.3 **H1 — `cli/src/server/gdpr.rs:407,490,580`.** Audit each call: `true` is already passed (good), but verify each is inside an explicit transaction and add a module-level `// INVARIANT:` comment pinning the expectation for future edits.
-- [ ] 2.4 **H2 — dual-GUC normalization.** Grep every `set_config` and `current_setting` call in the codebase for the four variants (`app.tenant_id`, `app.company_id`, `app.current_tenant_id`, `app.current_company_id`). Normalize every code-side write to `app.tenant_id`. Every code-side read to `app.tenant_id`. Migration 024 already normalized the policies; this closes the read/write side.
-- [ ] 2.5 **H1 regression test.** `storage/tests/session_variable_hygiene.rs` — acquire a connection from the pool, set `app.tenant_id` via `activate_tenant_context`, return it to the pool, acquire a fresh connection, assert `current_setting('app.tenant_id', true)` returns empty. Fails if anyone reverts to session-scope `set_config`.
-- [ ] 2.6 **H2 regression test.** `storage/tests/guc_namespace.rs` — grep assertion (compile-time via `include_str!`) that no source file outside of `storage/migrations/` contains `app.company_id` or `app.current_tenant_id`. Fails if a new handler re-introduces the legacy namespace.
+- [ ] 2.1 **H1 — `storage/src/postgres.rs:63`.** Change `set_config('app.tenant_id', $1, false)` → `set_config('app.tenant_id', $1, true)`. Document that `activate_tenant_context` requires an open transaction; add a `debug_assert!` at entry that verifies the connection is inside a transaction.
+- [ ] 2.2 **H1 — `cli/src/server/backup_api.rs:1597`.** Move the `set_config` call inside the existing `BEGIN` scope and flip the third argument to `true`.
+- [ ] 2.3 **H1 — `cli/src/server/gdpr.rs:407,490,580`.** `true` is already passed; verify each is inside an explicit transaction and add a module-level `// INVARIANT:` comment pinning the expectation.
+- [ ] 2.4 **H2 — dual-GUC normalization on the app side.** Grep the entire codebase for the four GUC names (`app.tenant_id`, `app.company_id`, `app.current_tenant_id`, `app.current_company_id`). Normalize every app-side `set_config` and `current_setting` call to `app.tenant_id`. Migration files are not touched (they're historical record).
+- [ ] 2.5 **H1 regression test — `storage/tests/session_variable_hygiene.rs`.** Acquire a connection, set `app.tenant_id` via `activate_tenant_context`, return it, acquire a fresh connection, assert `current_setting('app.tenant_id', true)` returns empty. Fails if anyone reverts to session-scope.
+- [ ] 2.6 **H2 regression test — `storage/tests/guc_namespace.rs`.** Compile-time grep (via `include_str!` over every `*.rs` under `cli/src/` and `storage/src/`) that asserts no legacy GUC name appears outside the migrations directory.
 
-## 3. Bundle A.2 — Dedicated non-BYPASSRLS role + migration + CI verification (independently shippable)
+## 3. Bundle A.2 — Roles, migrations, dual pools, CI verification (independently shippable)
 
-**Goal:** stand up the `aeterna_app` role, make it grant-complete, and wire a CI suite that runs every RLS-enabled table through it end-to-end. Prod `DATABASE_URL` is NOT changed. Target: 1 PR, ≤ 2 weeks.
+**Goal:** stand up both roles, wire both pools, land both helpers, ship the permanent RLS regression guard. `DATABASE_URL` stays on the current role. Target: 1 PR, ≤ 2 weeks.
 
-- [ ] 3.1 `storage/migrations/025_add_app_role.sql` — `CREATE ROLE aeterna_app LOGIN NOBYPASSRLS PASSWORD 'managed_via_secret'` (idempotent via `DO $$ … pg_roles WHERE rolname = 'aeterna_app' … $$`). Password is an `${APP_DB_PASSWORD}` placeholder consumed by the migration runner.
-- [ ] 3.2 `GRANT USAGE ON SCHEMA public TO aeterna_app`.
-- [ ] 3.3 `GRANT SELECT, INSERT, UPDATE, DELETE` on every table currently having `rowsecurity = true` (22 tables) to `aeterna_app`. Enumerated explicitly — no `GRANT … ON ALL TABLES` catch-all, so adding a new RLS-protected table without updating the grant fails the A.2.5 pre-flight.
-- [ ] 3.4 `GRANT USAGE, SELECT` on every sequence the granted tables depend on.
-- [ ] 3.5 Migration header documents: "Non-BYPASSRLS application role. Bundle A.4 flips `DATABASE_URL` to this role. See `openspec/changes/decide-rls-enforcement-model/proposal.md`."
-- [ ] 3.6 **CI suite — `cli/tests/rls_enforcement_test.rs`.** For every table with `rowsecurity = true`:
-  - [ ] 3.6.1 Pre-flight: enumerate `pg_tables WHERE rowsecurity = true`; assert each has been granted `SELECT` to `aeterna_app`; fail with a named-table error if a grant is missing.
-  - [ ] 3.6.2 Positive path: open a connection as `aeterna_app`, `BEGIN`, `set_config('app.tenant_id', tenant_a, true)`, `SELECT *` — assert only tenant_a's rows.
-  - [ ] 3.6.3 Negative path: same connection without `set_config` — assert zero rows returned.
-  - [ ] 3.6.4 Cross-tenant path: seed rows for tenants A and B, set context to A, attempt `SELECT` for B's rows by WHERE id — assert zero rows.
-- [ ] 3.7 **CI suite — handler-level `cli/tests/rls_handler_smoke.rs`.** Run `/user`, `/project`, `/org`, `/govern/audit` list endpoints against a test server whose pool connects as `aeterna_app`. Assert each list returns only the authenticated tenant's rows; assert a request with no resolved tenant context returns 400 `select_tenant` or an empty list (never foreign rows).
-- [ ] 3.8 Document in `DEVELOPER_GUIDE.md` how to run the A.2 suites locally (`docker compose -f docker-compose.rls.yml up` pattern).
+### 3.1 Migration
 
-## 4. Bundle A.3 — Repository call-site refactor (multi-PR, wave-by-wave)
+- [ ] 3.1.1 `storage/migrations/025_add_app_roles.sql`. Idempotent `CREATE ROLE` via `DO $$ … pg_roles WHERE rolname = … $$`.
+- [ ] 3.1.2 `CREATE ROLE aeterna_app LOGIN NOBYPASSRLS PASSWORD :'app_password'`.
+- [ ] 3.1.3 `CREATE ROLE aeterna_admin LOGIN BYPASSRLS PASSWORD :'admin_password'`.
+- [ ] 3.1.4 `GRANT USAGE ON SCHEMA public TO aeterna_app, aeterna_admin`.
+- [ ] 3.1.5 `GRANT SELECT, INSERT, UPDATE, DELETE` on every table currently having `rowsecurity = true` to `aeterna_app`. Enumerated explicitly (no `GRANT … ON ALL TABLES` catch-all) so missing a grant on a new RLS table fails the A.2.5.1 pre-flight.
+- [ ] 3.1.6 `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO aeterna_admin` — `aeterna_admin` is BYPASSRLS and operates globally, so a broad grant is correct.
+- [ ] 3.1.7 `GRANT USAGE, SELECT` on every sequence both roles need.
+- [ ] 3.1.8 Migration header documents the dual-role design and points to `openspec/changes/decide-rls-enforcement-model/proposal.md`.
 
-**Goal:** thread per-request transaction-scoped tenant context through every RLS-protected query. Each wave is a standalone PR, each wave is independently revertable, each wave runs against the A.2 CI suite so regressions surface immediately. Target: 4–6 PRs, ≤ 3 weeks.
+### 3.2 AppState + helpers
 
-- [ ] 4.1 **Helper — `storage/src/postgres.rs::with_tenant_context`.**
-  - Signature: `async fn with_tenant_context<F, T>(&self, ctx: &TenantContext, body: F) -> Result<T> where F: FnOnce(&mut PgConnection) -> BoxFuture<Result<T>>`.
-  - Implementation: `self.pool.begin()` → `SET LOCAL app.tenant_id = $1` → body(&mut tx) → `tx.commit()`.
-  - Rustdoc states every RLS-protected query MUST acquire its connection this way; direct `pool.acquire()` is forbidden on RLS paths and will be enforced by lint in Bundle A.5.
-- [ ] 4.2 **Wave 1 — `user_api.rs` + `team_api.rs` + `org_api.rs` + `project_api.rs` list/get/create/update/delete paths.** Refactor each call site. CI suite (A.2) proves per-request isolation post-refactor. PR size target: ~25 call sites.
-- [ ] 4.3 **Wave 2 — `govern_api.rs` + `govern_policy.rs` + audit write paths.** ~15 call sites.
-- [ ] 4.4 **Wave 3 — `memory_api.rs` + `knowledge_api.rs` + ingest paths.** ~20 call sites.
-- [ ] 4.5 **Wave 4 — `sync.rs` + `webhook.rs` + async worker paths.** Async workers need their own tenant-context acquisition pattern (they don't have a request); establish and document the pattern. ~15 call sites.
-- [ ] 4.6 **Wave 5 — `backup_api.rs` + `gdpr.rs` + admin paths.** These already did manual `set_config` (fixed in A.1); convert to the helper. ~10 call sites.
-- [ ] 4.7 **Wave 6 — sweep.** Audit tool: `storage/tools/find_unwrapped_queries.sh` that greps for `self.pool.acquire()` / `self.pool.begin()` outside of `with_tenant_context`. Any remaining sites either (a) are RLS-protected and the sweep wave fixes them, or (b) are documented as intentionally context-free (e.g., health checks) with an `#[allow(direct_pool_access)]` attribute and a justification comment.
-- [ ] 4.8 Add CI `deny_lint` (warn-level) that fails on direct `self.pool.acquire()` / `.begin()` outside the allowlist. Graduates to deny-level in Bundle A.5.
+- [ ] 3.2.1 `AppState` grows `admin_pool: PgPool` alongside the existing `pool: PgPool`.
+- [ ] 3.2.2 Admin pool size capped at 4 (`PgPoolOptions::new().max_connections(4)`) — admin operations are rare, constraining the pool makes accidental hot-loop use of the admin pool a visible error.
+- [ ] 3.2.3 Admin pool connection string sourced from `DATABASE_URL_ADMIN` env var. Default: same host/db as `DATABASE_URL`, credentials swapped to `aeterna_admin` / `APP_DB_ADMIN_PASSWORD`.
+- [ ] 3.2.4 `storage/src/postgres.rs::with_tenant_context` — signature `async fn with_tenant_context<F, T>(&self, ctx: &TenantContext, body: F) -> Result<T>` where `F: FnOnce(&mut Transaction<'_, Postgres>) -> BoxFuture<Result<T>>`. Implementation: `self.pool.begin()` → `SET LOCAL app.tenant_id = $1` → `body(&mut tx)` → `tx.commit()`. Rustdoc states this is the only valid way to reach `state.pool` on an RLS-protected path.
+- [ ] 3.2.5 `storage/src/postgres.rs::with_admin_context` — same shape but uses `self.admin_pool.begin()` and does NOT issue `SET LOCAL`. Rustdoc states every call is admin-only and is auto-audited per A.2.2.7.
+- [ ] 3.2.6 `TenantContext::system_ctx()` sentinel constructor — represents "no human actor, internal system." Carries `actor_type = 'system'` for audit attribution.
+- [ ] 3.2.7 `TenantContext::from_scheduled_job(tenant_id, job_id)` constructor — used by per-tenant scheduled work (see proposal.md "Scheduled jobs pattern").
+- [ ] 3.2.8 Admin audit wrapper: every `with_admin_context` call records an audit row with `actor_id`, `actor_type`, `admin_scope = true`, `acting_as_tenant_id = NULL`. Implementation goes in the helper itself so it cannot be bypassed.
 
-## 5. Bundle A.4 — Prod flip (feature-flagged, canary-first)
+### 3.3 CI verification suite
 
-**Goal:** change the prod connection role from the legacy BYPASSRLS user to `aeterna_app`. Rollback is a single env-var change. Target: 1 PR to land the flag, then operational rollout.
+- [ ] 3.3.1 `cli/tests/rls_enforcement_test.rs` — pre-flight: enumerate `pg_tables WHERE rowsecurity = true`; assert every such table has `SELECT` granted to `aeterna_app`; fail with a named-table error if any grant is missing.
+- [ ] 3.3.2 For every RLS table: positive path (connect as `aeterna_app`, `BEGIN`, `set_config('app.tenant_id', tenant_a, true)`, `SELECT *`, assert only tenant_a's rows).
+- [ ] 3.3.3 For every RLS table: negative path (same connection without `set_config`, assert zero rows).
+- [ ] 3.3.4 For every RLS table: cross-tenant path (seed rows for A and B, set context to A, `SELECT * WHERE id = $b_id`, assert zero rows).
+- [ ] 3.3.5 `cli/tests/rls_admin_surface_test.rs` — PlatformAdmin list endpoints (`/user`, `/project`, `/org`, `/govern/audit`) with `?tenant=*` exercised through a test server wired with both pools. Assert the admin pool is chosen (via a probe that checks the connection's `current_user`) and that cross-tenant rows are returned.
+- [ ] 3.3.6 `cli/tests/rls_handler_smoke.rs` — per-tenant list endpoints exercised with a test server whose default pool connects as `aeterna_app`. Assert each list returns only the authenticated tenant's rows; assert a request with no resolved tenant context returns `400 select_tenant` (middleware) or empty list (RLS).
+- [ ] 3.3.7 `cli/tests/admin_pool_access_lint.rs` — compile-time grep asserting no code path outside `with_admin_context` references `state.admin_pool` directly. Warn-level in A.2; graduates to deny in A.3's last wave.
 
-- [ ] 5.1 Add `AETERNA_DB_ROLE` env var (`bypassrls|rls`, default `bypassrls`) consumed in `cli/src/server/app_state.rs` when building the pool.
-- [ ] 5.2 `bypassrls` keeps the existing `DATABASE_URL` behavior.
-- [ ] 5.3 `rls` composes a new connection string pointing at `aeterna_app` with the password from `APP_DB_PASSWORD`.
-- [ ] 5.4 Startup log prints the effective role (`info!("db_role={role}")`) — searchable post-incident.
-- [ ] 5.5 Flag-land PR includes zero env changes in deployed config: prod keeps `bypassrls` at merge time.
-- [ ] 5.6 **Canary rollout** (ops-tracked, not a PR): flip `AETERNA_DB_ROLE=rls` in `dev` first, then `staging`, then per-region prod canaries. Minimum 2-week soak on staging before any prod region.
-- [ ] 5.7 **Rollback runbook** in `docs/ops/rls_rollback.md`: flip env var → rolling pool restart → verify log line — under 5 minutes per region.
-- [ ] 5.8 Post-flip observability: Grafana panel for `pg_stat_activity.state = 'active' transaction_duration_ms` distribution (detect BEGIN-per-request overhead regression).
+### 3.4 Docs
 
-## 6. Bundle A.5 — Remove escape hatch + ratchet (independently shippable)
+- [ ] 3.4.1 `DEVELOPER_GUIDE.md` — document the two-helper pattern, the scheduled-jobs pattern, and the `system_ctx` sentinel.
+- [ ] 3.4.2 `AGENTS.md` — add a short "RLS enforcement" section: RLS is authoritative, app-layer `WHERE tenant_id = ?` is required DiD, direct pool access is forbidden outside the two helpers.
 
-**Goal:** remove the `bypassrls` code path once all environments have soaked on `rls` for ≥ 4 weeks. Graduate the lint to deny. Close Hazard H3. Target: 1 PR.
+## 4. Bundle A.3 — Call-site refactor + cutover (multi-PR, wave-by-wave)
 
-- [ ] 6.1 Delete the `bypassrls` branch in the pool builder; `AETERNA_DB_ROLE` env var becomes a no-op (or is removed after a deprecation cycle).
-- [ ] 6.2 Delete the orphan `activate_tenant_context` calls in `cli/src/server/sync.rs:131,256` (Hazard H3) — they become redundant once every call site uses `with_tenant_context`.
-- [ ] 6.3 Graduate the A.3.8 `deny_lint` from warn to deny.
-- [ ] 6.4 Update `AGENTS.md` to describe the final two-layer model: RLS is authoritative, app-layer `WHERE tenant_id = ?` is defense in depth. Both remain required.
-- [ ] 6.5 Update `DEVELOPER_GUIDE.md` with the `with_tenant_context` pattern as the canonical query-acquisition idiom.
-- [ ] 6.6 Close issue #58 referencing the merged A.5 PR.
+**Goal:** thread every RLS-protected query through `with_tenant_context`; thread every admin-scope query through `with_admin_context`. Each wave is an independent PR, each wave runs against the A.2 CI suite. Final wave flips `DATABASE_URL` to `aeterna_app`. Target: 4–6 PRs, ≤ 3 weeks.
+
+- [ ] 4.1 **Wave 1 — `user_api.rs` + `team_api.rs` + `org_api.rs` + `project_api.rs`.** Refactor list/get/create/update/delete paths to `with_tenant_context`. Per-request admin paths (`?tenant=*`) route through `with_admin_context`. ~25 call sites.
+- [ ] 4.2 **Wave 2 — `govern_api.rs` + `govern_policy.rs` + audit write paths.** ~15 call sites. Audit write paths use whichever helper the originating handler is in — `with_tenant_context` for tenant-scoped writes, `with_admin_context` for admin writes.
+- [ ] 4.3 **Wave 3 — `memory_api.rs` + `knowledge_api.rs` + ingest paths.** ~20 call sites.
+- [ ] 4.4 **Wave 4 — `sync.rs` + `webhook.rs` + async worker paths.** Workers use `with_tenant_context(&TenantContext::from_scheduled_job(t, job_id), …)` for per-tenant work and `with_admin_context(&system_ctx, …)` for cross-tenant maintenance. ~15 call sites.
+- [ ] 4.5 **Wave 5 — `backup_api.rs` + `gdpr.rs` + admin paths.** Convert manual `set_config` call sites (now fixed by A.1) to the helper pattern. Global admin operations route through `with_admin_context`. ~10 call sites.
+- [ ] 4.6 **Wave 6 — sweep + cutover.** Final wave:
+  - [ ] 4.6.1 `storage/tools/find_unwrapped_queries.sh` audit — any remaining direct `self.pool.acquire()` / `self.pool.begin()` / `self.admin_pool.*` outside the helpers either (a) gets refactored or (b) carries `#[allow(direct_pool_access)]` with a justification comment.
+  - [ ] 4.6.2 Flip `DATABASE_URL` in `docker-compose.yml` and every `.env.example` to `postgres://aeterna_app:${APP_DB_PASSWORD}@…`.
+  - [ ] 4.6.3 Add `DATABASE_URL_ADMIN=postgres://aeterna_admin:${APP_DB_ADMIN_PASSWORD}@…` to every `.env.example`.
+  - [ ] 4.6.4 Delete the orphan `activate_tenant_context` calls in `cli/src/server/sync.rs:131,256` (Hazard H3).
+  - [ ] 4.6.5 Graduate both lints (direct-pool-access in A.2.3.7 and admin-pool-access) from warn to deny.
+  - [ ] 4.6.6 Update `AGENTS.md` to state the final model is in effect; update `DEVELOPER_GUIDE.md` with `with_tenant_context` / `with_admin_context` as canonical.
+  - [ ] 4.6.7 Close issue #58 referencing the merged wave 6 PR.


### PR DESCRIPTION
Resolves #58.

## Decision

**Option A — activate PostgreSQL row-level security on every request-scoped connection**, implemented with a **two-role / two-pool / two-helper** design:

| Role | Pool | `BYPASSRLS` | Used by |
|---|---|---|---|
| `aeterna_app` | `state.pool` (normal size) | No | 99% of traffic — every per-tenant request, async per-tenant workers |
| `aeterna_admin` | `state.admin_pool` (size=4) | Yes | PlatformAdmin `?tenant=*`, scheduled cross-tenant jobs, migration runner |

```rust
with_tenant_context(&ctx, |tx| …)   // default pool, BEGIN + SET LOCAL app.tenant_id + body + COMMIT
with_admin_context(&ctx, |tx| …)    // admin pool, BEGIN + body + COMMIT, auto-audit inside helper
```

Context-driven routing: `ctx.scope = Tenant | CrossTenantSingle` → tenant helper; `ctx.scope = CrossTenantAll` with PA actor → admin helper. Scheduled per-tenant jobs enumerate via admin helper, dispatch per-tenant work via tenant helper. Scheduled cross-tenant jobs use `with_admin_context(&system_ctx, …)` where `system_ctx` is a sentinel with `actor_type = 'system'`.

Every `with_admin_context` call writes a `governance_audit_log` row from inside the helper — cross-tenant access is always traceable without per-call-site bookkeeping.

## Pre-production simplification

No production environment or users exist yet. The previous revision contained a Bundle A.4 feature flag + canary rollout and a Bundle A.5 escape-hatch removal, both written under a "prod exists" assumption. Both collapse into **Bundle A.3 wave 6**: one commit flips `DATABASE_URL` + `DATABASE_URL_ADMIN`, deletes the orphan `activate_tenant_context` calls in `sync.rs` (Hazard H3), and graduates the direct-pool-access lint from warn to deny. No feature flag, no soak, no rollback runbook. If a prod deployment is later stood up, that operational posture returns as a separate change.

## 3 stacked bundles

| Bundle | Scope | Independent? |
|---|---|---|
| **A.1** | Hazard fixes (H1 session-scope `set_config`, H2 dual-GUC namespace on app side) | ✅ yes |
| **A.2** | Roles + migration 025 + dual pools + both helpers + `system_ctx` / `from_scheduled_job` + admin audit wrapper + CI suite (RLS per-table + admin surface + handler smoke + lint) | ✅ yes (parallel with A.1) |
| **A.3** | Call-site refactor in 6 waves (user/org/project/team → governance/audit → memory/knowledge → sync/webhook → backup/gdpr → sweep+cutover). Wave 6 is the `DATABASE_URL` flip. | ✅ waves independent; depends on A.2 |

A.1 and A.2 can merge in either order. A.3's waves land sequentially against A.2's base. A.3 wave 6 is the single commit that turns RLS from "tested" to "enforced."

## What’s in this PR

- `openspec/changes/decide-rls-enforcement-model/proposal.md` — decision + dual-role design + 3-bundle plan
- `openspec/changes/decide-rls-enforcement-model/design.md` — option analysis, §4 dual-role/dual-pool design (four concepts introduced together), §5 implementation strategy including pre-prod simplification rationale, §6 risk register (H1–H6), §7 open questions (migration runner role, pgbouncer auth, audit volume)
- `openspec/changes/decide-rls-enforcement-model/tasks.md` — 3-bundle itemized work plan
- `openspec/changes/decide-rls-enforcement-model/specs/runtime-security-hardening/spec.md` — 5 normative Requirements (1 MODIFIED, 4 ADDED)
- `openspec/changes/decide-rls-enforcement-model/README.md` — 1-screen summary

`openspec validate decide-rls-enforcement-model --strict` ✅ passes.

## Spec delta summary

- **MODIFIED** `Backend-Specific Persistence Isolation` — RLS is authoritative, `WHERE` clause is required DiD
- **ADDED** `Two-Role PostgreSQL Access Model`
- **ADDED** `Per-Request Transaction-Scoped Tenant Context`
- **ADDED** `Administrative Cross-Tenant Access` (covers PA, `system_ctx`, scheduled per-tenant + cross-tenant jobs, audit guarantee)
- **ADDED** `Tenant Session Variable Hygiene`
- **ADDED** `RLS End-to-End Verification` (grant preflight, per-table positive/negative/cross-tenant, admin surface under admin role, per-tenant surface under default role)

## Commit trail

The RFC has been through three revisions on this branch: (1) initial C recommendation, (2) pivot to A after architect override, (3) this revision — dual-role design + pre-prod simplification. Each revision is a standalone commit for review traceability.

## Next

Bundle A.1 lands on its own branch as the immediate follow-up PR.