### PR TITLE
feat(rls): Bundle A.1 — hazard fixes H1 + H2 (#58)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8036,6 +8036,7 @@ dependencies = [
  "tracing",
  "utils",
  "uuid",
+ "walkdir",
  "wiremock",
 ]
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -51,6 +51,7 @@ anyhow.workspace = true
 [dev-dependencies]
 testing.workspace = true
 tokio-test = "0.4"
+walkdir.workspace = true
 adapters.workspace = true
 knowledge.workspace = true
 config.workspace = true

--- a/storage/src/gdpr.rs
+++ b/storage/src/gdpr.rs
@@ -5,6 +5,31 @@
 /// - Data export (data portability)
 /// - Consent management
 /// - Audit trail for data access
+///
+/// # INVARIANT — transaction-scoped GUC hygiene
+///
+/// Every RLS-protected query in this module MUST rely on one of two
+/// isolation mechanisms:
+///
+///   1. An explicit `WHERE tenant_id = $1` (and, where applicable,
+///      `user_id = $2`) clause on the query itself. This is the current
+///      defense-in-depth in every method below. Do not remove it.
+///
+///   2. (Future, Bundle A.3 Wave 5) a `with_tenant_context(&ctx, |tx| …)`
+///      wrapper that opens a transaction, sets `app.tenant_id` on that
+///      transaction only, and runs every subsequent query through `&mut *tx`
+///      so they all share the same RLS-protected connection.
+///
+/// What this module MUST NOT do is call `SELECT set_config('app.tenant_id',
+/// …, true)` against `&self.pool` directly. `SET LOCAL` outside an active
+/// transaction is a silent no-op (H1 in the RLS enforcement RFC), and even
+/// if it weren't, the next query acquires a different pooled connection
+/// that has never seen the setting. Three such calls previously lived at
+/// lines 407, 490, 580 of this file and were removed in the A.1 hazard-fix
+/// bundle (issue #58) — exactly as the analogous call in `backup_api.rs`
+/// was removed in issue #57. The explicit `WHERE` clauses in every method
+/// were always the real isolation mechanism; the `set_config` lines were
+/// dead code.
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -404,10 +429,10 @@ impl GdprOperations for PostgresGdprStorage {
         user_id: &str,
         redis: &redis::aio::ConnectionManager,
     ) -> Result<GdprDeleteResult, GdprError> {
-        sqlx::query("SELECT set_config('app.tenant_id', $1, true)")
-            .bind(tenant_id)
-            .execute(&self.pool)
-            .await?;
+        // RLS activation via `with_tenant_context` is deferred to Bundle A.3
+        // Wave 5 (issue #58). Every query below filters by `tenant_id`
+        // explicitly, which is the real defense-in-depth mechanism. See the
+        // module-level INVARIANT comment for rationale.
 
         self.log_data_access(
             tenant_id,
@@ -486,11 +511,9 @@ impl GdprOperations for PostgresGdprStorage {
         tenant_id: &str,
         user_id: &str,
     ) -> Result<UserDataExport, GdprError> {
-        // Set tenant context for RLS
-        sqlx::query("SELECT set_config('app.tenant_id', $1, true)")
-            .bind(tenant_id)
-            .execute(&self.pool)
-            .await?;
+        // RLS activation via `with_tenant_context` is deferred to Bundle A.3
+        // Wave 5 (issue #58). Every query below filters by `tenant_id`
+        // explicitly. See the module-level INVARIANT comment.
 
         // Export memories
         let memories: Vec<serde_json::Value> = sqlx::query_scalar(
@@ -576,11 +599,9 @@ impl GdprOperations for PostgresGdprStorage {
         user_id: &str,
         strategy: AnonymizationStrategy,
     ) -> Result<(), GdprError> {
-        // Set tenant context for RLS
-        sqlx::query("SELECT set_config('app.tenant_id', $1, true)")
-            .bind(tenant_id)
-            .execute(&self.pool)
-            .await?;
+        // RLS activation via `with_tenant_context` is deferred to Bundle A.3
+        // Wave 5 (issue #58). Every query below filters by `tenant_id`
+        // explicitly. See the module-level INVARIANT comment.
 
         // Log the anonymization action
         self.log_data_access(

--- a/storage/src/postgres.rs
+++ b/storage/src/postgres.rs
@@ -69,10 +69,27 @@ impl PostgresBackend {
     ///   across pooled connections.
     /// - Issue #58: policies may still be a no-op in prod if the connection
     ///   role has `BYPASSRLS` — orthogonal, deferred.
+    ///
+    /// # Hazard H1 status
+    ///
+    /// The "SET LOCAL outside a transaction is a silent no-op" hazard (H1 in
+    /// the RLS enforcement RFC) is now **compile-time impossible** on this
+    /// function: the `&mut Transaction` parameter type cannot be constructed
+    /// outside an active `begin()`. Any legacy caller that passed a raw
+    /// `&PgPool` or `PoolConnection` will fail to compile. The
+    /// `debug_assert!` below guards against another regression class
+    /// (empty tenant_id producing a policy-evaluating-against-empty-string
+    /// that silently matches nothing).
     pub async fn activate_tenant_context(
         tx: &mut sqlx::Transaction<'_, Postgres>,
         tenant_id: &str,
     ) -> Result<(), PostgresError> {
+        debug_assert!(
+            !tenant_id.is_empty(),
+            "activate_tenant_context called with empty tenant_id — this would \
+             make every RLS policy evaluate against an empty string and \
+             silently match zero rows. Upstream bug in context resolution."
+        );
         sqlx::query("SELECT set_config('app.tenant_id', $1, true)")
             .bind(tenant_id)
             .execute(&mut **tx)

--- a/storage/src/rls_migration.rs
+++ b/storage/src/rls_migration.rs
@@ -62,7 +62,12 @@ async fn enable_company_rls_for_table(pool: &PgPool, table: &str) -> Result<(), 
         .await
         .ok();
 
-    let company_scope = "company_id = current_setting('app.company_id', true)::uuid";
+    // H2 normalization (issue #58 Bundle A.1): the single canonical app-side
+    // GUC is `app.tenant_id`. Tables with a `company_id` column (where
+    // company_id == tenant UUID) scope their RLS policy on that GUC. The old
+    // legacy-company GUC name is retired on the app side; see the H2
+    // regression test `storage/tests/guc_namespace.rs` for the tripwire.
+    let company_scope = "company_id = current_setting('app.tenant_id', true)::uuid";
     let create_policy = format!(
         "CREATE POLICY {} ON {} FOR ALL USING ({}) WITH CHECK ({})",
         policy_name, table, company_scope, company_scope
@@ -90,7 +95,8 @@ async fn enable_company_rls_for_approval_decisions(pool: &PgPool) -> Result<(), 
         .await
         .ok();
 
-    let company_scope = "EXISTS (SELECT 1 FROM approval_requests ar WHERE ar.id = approval_decisions.request_id AND ar.company_id = current_setting('app.company_id', true)::uuid)";
+    // H2 normalization: see note in `enable_company_rls_for_<prev>` above.
+    let company_scope = "EXISTS (SELECT 1 FROM approval_requests ar WHERE ar.id = approval_decisions.request_id AND ar.company_id = current_setting('app.tenant_id', true)::uuid)";
     let create_policy = format!(
         "CREATE POLICY {} ON {} FOR ALL USING ({}) WITH CHECK ({})",
         policy_name, table, company_scope, company_scope

--- a/storage/tests/guc_namespace.rs
+++ b/storage/tests/guc_namespace.rs
@@ -50,7 +50,10 @@ fn is_rust_source(path: &Path) -> bool {
 #[test]
 fn no_legacy_guc_names_in_app_side_source() {
     let root = workspace_root();
-    let scan_dirs = [root.join("cli").join("src"), root.join("storage").join("src")];
+    let scan_dirs = [
+        root.join("cli").join("src"),
+        root.join("storage").join("src"),
+    ];
 
     let forbidden = forbidden_guc_tokens();
     let mut offenders: Vec<(PathBuf, String, usize)> = Vec::new();
@@ -76,11 +79,7 @@ fn no_legacy_guc_names_in_app_side_source() {
             for (line_no, line) in contents.lines().enumerate() {
                 for token in &forbidden {
                     if line.contains(token.as_str()) {
-                        offenders.push((
-                            path.to_path_buf(),
-                            token.clone(),
-                            line_no + 1,
-                        ));
+                        offenders.push((path.to_path_buf(), token.clone(), line_no + 1));
                     }
                 }
             }

--- a/storage/tests/guc_namespace.rs
+++ b/storage/tests/guc_namespace.rs
@@ -1,0 +1,118 @@
+//! H2 regression test — single canonical app-side GUC namespace.
+//!
+//! The RLS enforcement model (issue #58) fixes the canonical session variable
+//! at `app.tenant_id`. Any Rust source file on the app side that names a
+//! legacy GUC — `app.company_id`, `app.current_tenant_id`,
+//! `app.current_company_id` — is a latent dual-namespace hazard (H2): the
+//! app sets one name, the policy reads another, and the policy silently
+//! evaluates against an empty string.
+//!
+//! This test walks `cli/src/` and `storage/src/` recursively and fails if
+//! any `.rs` file mentions a legacy GUC name. Migration files (emit SQL
+//! that is a historical record) and test files (may reference the legacy
+//! names as quoted regression sentinels, as this file does) are excluded.
+//!
+//! Task: §2.6 of `openspec/changes/decide-rls-enforcement-model/tasks.md`.
+
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Legacy GUC names that MUST NOT appear in app-side source files.
+///
+/// These literals are strings split across concatenation so that the test
+/// file itself does not contain the legacy token as a contiguous substring,
+/// which would cause the test to flag itself when scanning the `storage/`
+/// tree if someone ever moved it into `storage/src/`.
+fn forbidden_guc_tokens() -> Vec<String> {
+    vec![
+        // "app." + "company_id"
+        format!("{}{}", "app.", "company_id"),
+        // "app." + "current_tenant_id"
+        format!("{}{}", "app.", "current_tenant_id"),
+        // "app." + "current_company_id"
+        format!("{}{}", "app.", "current_company_id"),
+    ]
+}
+
+/// Resolve the workspace root from this test’s manifest dir (`storage/`).
+fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .expect("storage crate must have a parent (the workspace root)")
+        .to_path_buf()
+}
+
+fn is_rust_source(path: &Path) -> bool {
+    path.extension().is_some_and(|e| e == "rs")
+}
+
+#[test]
+fn no_legacy_guc_names_in_app_side_source() {
+    let root = workspace_root();
+    let scan_dirs = [root.join("cli").join("src"), root.join("storage").join("src")];
+
+    let forbidden = forbidden_guc_tokens();
+    let mut offenders: Vec<(PathBuf, String, usize)> = Vec::new();
+
+    for dir in &scan_dirs {
+        if !dir.exists() {
+            panic!(
+                "Scan directory {} does not exist. The workspace layout \
+                 changed — update this test.",
+                dir.display()
+            );
+        }
+
+        for entry in WalkDir::new(dir).into_iter().filter_map(Result::ok) {
+            let path: &Path = entry.path();
+            if !is_rust_source(path) {
+                continue;
+            }
+            let contents = match std::fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            for (line_no, line) in contents.lines().enumerate() {
+                for token in &forbidden {
+                    if line.contains(token.as_str()) {
+                        offenders.push((
+                            path.to_path_buf(),
+                            token.clone(),
+                            line_no + 1,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "H2 regression: legacy GUC name(s) found in app-side source. \
+         The single canonical app-side GUC is `app.tenant_id`. Offenders:\n{}",
+        offenders
+            .iter()
+            .map(|(p, t, l)| format!("  {}:{}  ({})", p.display(), l, t))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+#[test]
+fn scan_dirs_resolve_from_cargo_manifest_dir() {
+    // Sanity: the workspace layout assumed by this regression test actually
+    // exists. Guards against a workspace refactor that would make the scan
+    // above silently cover zero files.
+    let root = workspace_root();
+    assert!(
+        root.join("cli").join("src").is_dir(),
+        "cli/src not found at {}",
+        root.display()
+    );
+    assert!(
+        root.join("storage").join("src").is_dir(),
+        "storage/src not found at {}",
+        root.display()
+    );
+}

--- a/storage/tests/persistence_isolation_test.rs
+++ b/storage/tests/persistence_isolation_test.rs
@@ -171,7 +171,7 @@ mod postgres_isolation {
         let approver_id = Uuid::new_v4();
 
         let mut owner_conn = backend.pool().acquire().await.expect("owner connection");
-        sqlx::query("SELECT set_config('app.company_id', $1, false)")
+        sqlx::query("SELECT set_config('app.tenant_id', $1, false)")
             .bind(company_a.to_string())
             .execute(owner_conn.as_mut())
             .await
@@ -235,7 +235,7 @@ mod postgres_isolation {
         assert_eq!(visible_to_owner, (1, 1, 1, 1));
 
         let mut attacker_conn = backend.pool().acquire().await.expect("attacker connection");
-        sqlx::query("SELECT set_config('app.company_id', $1, false)")
+        sqlx::query("SELECT set_config('app.tenant_id', $1, false)")
             .bind(company_b.to_string())
             .execute(attacker_conn.as_mut())
             .await

--- a/storage/tests/session_variable_hygiene.rs
+++ b/storage/tests/session_variable_hygiene.rs
@@ -1,0 +1,77 @@
+//! H1 regression test — session-variable hygiene on `app.tenant_id`.
+//!
+//! Verifies the invariant documented in `PostgresBackend::activate_tenant_context`:
+//! after a transaction that called `set_config('app.tenant_id', …, true)` commits,
+//! subsequent connections drawn from the pool MUST NOT observe the setting.
+//!
+//! Fails loudly if anyone reverts the third argument to `false` (session-scoped)
+//! or if anyone else introduces a session-scoped `set_config` on the app GUC.
+//! This is the tripwire for hazard H1 in the RLS enforcement RFC (issue #58).
+
+use storage::postgres::PostgresBackend;
+use testing::postgres;
+
+async fn create_test_backend() -> Option<PostgresBackend> {
+    let fixture = postgres().await?;
+    let backend = PostgresBackend::new(fixture.url()).await.ok()?;
+    backend.initialize_schema().await.ok()?;
+    Some(backend)
+}
+
+/// The tenant_id we set in the "poisoning" transaction. If H1 ever regresses
+/// (session-scope set_config), this string leaks to subsequent connections.
+const MARKER_TENANT: &str = "h1-regression-marker-tenant";
+
+#[tokio::test]
+async fn session_variable_does_not_leak_across_pooled_connections() {
+    let Some(backend) = create_test_backend().await else {
+        eprintln!("Skipping H1 regression test: Docker not available");
+        return;
+    };
+
+    // Phase 1 — run a transaction that activates the tenant context, then
+    // commits. On COMMIT, `SET LOCAL` must be discarded.
+    {
+        let mut tx = backend
+            .pool()
+            .begin()
+            .await
+            .expect("begin phase-1 transaction");
+        PostgresBackend::activate_tenant_context(&mut tx, MARKER_TENANT)
+            .await
+            .expect("activate_tenant_context should succeed");
+
+        // Sanity: inside the transaction, the setting IS visible.
+        let (inside,): (String,) =
+            sqlx::query_as("SELECT current_setting('app.tenant_id', true)")
+                .fetch_one(&mut *tx)
+                .await
+                .expect("inside-tx current_setting must succeed");
+        assert_eq!(
+            inside, MARKER_TENANT,
+            "inside the transaction the GUC must reflect what we set"
+        );
+
+        tx.commit().await.expect("commit phase-1 transaction");
+    }
+
+    // Phase 2 — exhaust a batch of fresh connections. Every one of them
+    // MUST observe an empty `app.tenant_id`. We loop because pool
+    // assignment is non-deterministic: the guarantee we need is "no pooled
+    // connection ever leaks this setting," not "the very next acquire."
+    let pool = backend.pool().clone();
+    for attempt in 0..16 {
+        let (leaked,): (String,) =
+            sqlx::query_as("SELECT current_setting('app.tenant_id', true)")
+                .fetch_one(&pool)
+                .await
+                .expect("phase-2 current_setting must succeed");
+        assert_eq!(
+            leaked, "",
+            "H1 regression on attempt {attempt}: a pooled connection observed \
+             `app.tenant_id = {leaked:?}` after the setting transaction had \
+             committed. The third argument of set_config must be `true` \
+             (transaction-scoped)."
+        );
+    }
+}

--- a/storage/tests/session_variable_hygiene.rs
+++ b/storage/tests/session_variable_hygiene.rs
@@ -42,11 +42,10 @@ async fn session_variable_does_not_leak_across_pooled_connections() {
             .expect("activate_tenant_context should succeed");
 
         // Sanity: inside the transaction, the setting IS visible.
-        let (inside,): (String,) =
-            sqlx::query_as("SELECT current_setting('app.tenant_id', true)")
-                .fetch_one(&mut *tx)
-                .await
-                .expect("inside-tx current_setting must succeed");
+        let (inside,): (String,) = sqlx::query_as("SELECT current_setting('app.tenant_id', true)")
+            .fetch_one(&mut *tx)
+            .await
+            .expect("inside-tx current_setting must succeed");
         assert_eq!(
             inside, MARKER_TENANT,
             "inside the transaction the GUC must reflect what we set"
@@ -61,11 +60,10 @@ async fn session_variable_does_not_leak_across_pooled_connections() {
     // connection ever leaks this setting," not "the very next acquire."
     let pool = backend.pool().clone();
     for attempt in 0..16 {
-        let (leaked,): (String,) =
-            sqlx::query_as("SELECT current_setting('app.tenant_id', true)")
-                .fetch_one(&pool)
-                .await
-                .expect("phase-2 current_setting must succeed");
+        let (leaked,): (String,) = sqlx::query_as("SELECT current_setting('app.tenant_id', true)")
+            .fetch_one(&pool)
+            .await
+            .expect("phase-2 current_setting must succeed");
         assert_eq!(
             leaked, "",
             "H1 regression on attempt {attempt}: a pooled connection observed \


### PR DESCRIPTION
Implements **Bundle A.1** of the RLS enforcement model decision (RFC in #72, resolves part of #58).

Pre-production hardening: close the two hazards (H1, H2) that would become live cross-tenant leaks the moment the application role loses `BYPASSRLS` in Bundle A.3 Wave 6.

## H1 — Session-scoped `set_config` leaks across pooled connections

The primary `PostgresBackend::activate_tenant_context` was already fixed in #57 (third arg `true`, signature takes `&mut Transaction`). This PR:

- Adds `debug_assert!` for non-empty `tenant_id` (guards against policies silently evaluating against empty string).
- Upgrades rustdoc: H1 is now **compile-time impossible** on this function — the `&mut Transaction` parameter type rejects non-transaction callers at the type level.
- **Removes 3 latent-H1 sites in `storage/src/gdpr.rs`** (in `delete_user_data`, `export_user_data`, `anonymize_user_data`) that called `set_config` against `&self.pool` directly. `SET LOCAL` outside a transaction is a silent no-op, and the next query acquires a different pooled connection anyway. These calls were dead code — every query in each method already filters by `tenant_id` explicitly. Same pattern as backup_api.rs in #57.
- Adds a **module-level `INVARIANT` doc-comment** to gdpr.rs pinning the expectation: defense-in-depth `WHERE` clauses stay; `set_config` against `&self.pool` is forbidden; proper `with_tenant_context` wrapping belongs in Bundle A.3 Wave 5.

## H2 — Dual GUC namespace (`app.tenant_id` vs `app.company_id`)

Migration 024 already normalized server-side policies. This PR normalizes the **app side**:

- `storage/src/rls_migration.rs`: the two policy-emission sites for `approval_requests` / `approval_decisions` (company-scoped tables) now read `current_setting('app.tenant_id', …)`, not `'app.company_id'`. Column name `company_id` stays unchanged; the GUC is unified.
- `storage/tests/persistence_isolation_test.rs`: two test `set_config` calls normalized to `app.tenant_id`.

Without this, the moment BYPASSRLS is lifted the `approval_requests` policy reads `app.company_id` (never set by the app), casts `''::uuid` → error → policy denies all rows → every approval flow breaks.

## Regression tests (permanent tripwires)

**`storage/tests/session_variable_hygiene.rs`** — H1 tripwire. Activates `app.tenant_id` inside a transaction, commits, then exhausts 16 fresh pooled connections asserting each observes an empty setting. Fails immediately if anyone reverts `set_config` to session scope.

**`storage/tests/guc_namespace.rs`** — H2 tripwire. Walks `cli/src/` and `storage/src/` at test time, fails if any `.rs` file contains `app.company_id`, `app.current_tenant_id`, or `app.current_company_id`. Migrations and tests excluded. Token construction uses `format!()` so the test does not flag its own self-documentation. **Passes on the current tree.**

## Scope deviations from `tasks.md` (documented, not silent)

| Task | Planned | Actual | Why |
|---|---|---|---|
| 2.1 | Runtime `debug_assert!` that connection is inside a transaction | `debug_assert!` on empty `tenant_id` + rustdoc noting compile-time enforcement | `&mut Transaction` makes the tx-invariant compile-time enforced; the empty-string case is the only runtime regression class left |
| 2.2 | Move `set_config` inside BEGIN in `backup_api.rs:1597` | No change needed | Already fully closed in #57; verified during recon |
| 2.3 | Verify gdpr.rs calls are in transactions + add INVARIANT comment | Removed the 3 broken `set_config` calls + added INVARIANT comment | Calls were NOT in transactions — wrapping 3 methods + threading `&mut tx` through nested helpers is invasive and belongs in A.3 Wave 5 where it is already scheduled |

All deviations are safer/smaller than the original plan and do not weaken the closure of H1 or H2.

## Verification

- `cargo check --workspace --all-targets` ✅
- `cargo clippy --workspace --all-targets -- -D clippy::correctness -D clippy::suspicious` ✅
- `cargo test --test guc_namespace` ✅ 2 passed (non-Docker, runs locally)
- `cargo test --test session_variable_hygiene` requires Docker — runs in CI against the postgres fixture

## What is NOT in this PR

- `aeterna_app` / `aeterna_admin` role migration → **Bundle A.2**
- `with_tenant_context` / `with_admin_context` helpers → **Bundle A.2**
- Call-site refactor of the ~100 repository query sites → **Bundle A.3** (6 waves)
- `DATABASE_URL` cutover to `aeterna_app` → **Bundle A.3 Wave 6**
- Deletion of the orphan `activate_tenant_context` calls in `sync.rs` (Hazard H3) → **Bundle A.3 Wave 6**

## Files changed

```
Cargo.lock                                  |   1 +
storage/Cargo.toml                          |   1 +
storage/src/gdpr.rs                         |  49 ++++++++----
storage/src/postgres.rs                     |  17 ++++
storage/src/rls_migration.rs                |  10 ++-
storage/tests/guc_namespace.rs              | 118 ++++++++++++++++++++++++++++
storage/tests/persistence_isolation_test.rs |   4 +-
storage/tests/session_variable_hygiene.rs   |  77 ++++++++++++++++++
8 files changed, 259 insertions(+), 18 deletions(-)
```

---

Resolves the A.1 portion of #58. Next: Bundle A.2 (roles + dual pools + helpers + CI verification suite).
