### PR TITLE
refactor(storage): make log_event transaction-scoped (A.3 Wave 1, Cluster 3)

### DIFF
--- a/cli/src/server/org_api.rs
+++ b/cli/src/server/org_api.rs
@@ -258,6 +258,7 @@ async fn create_org(
         Ok(()) => {
             persist_event(
                 &state,
+                &ctx,
                 &GovernanceEvent::UnitCreated {
                     unit_id: unit.id.clone(),
                     unit_type: unit.unit_type,
@@ -359,6 +360,7 @@ async fn add_member(
         Ok(()) => {
             persist_event(
                 &state,
+                &ctx,
                 &GovernanceEvent::RoleAssigned {
                     user_id: user_id.clone(),
                     unit_id: org_id.clone(),
@@ -627,8 +629,19 @@ fn parse_tenant_role(value: &str) -> Result<RoleIdentifier, axum::response::Resp
     Ok(role)
 }
 
-async fn persist_event(state: &AppState, event: &GovernanceEvent) {
-    let _ = state.postgres.log_event(event).await;
+async fn persist_event(state: &AppState, ctx: &TenantContext, event: &GovernanceEvent) {
+    // Clone so the boxed future owns the event and satisfies the `'static`
+    // bound required by `with_tenant_context`'s HRTB. See the contract in
+    // `PostgresBackend::log_event`.
+    let event_owned = event.clone();
+    let _ = state
+        .postgres
+        .with_tenant_context(ctx, move |tx| {
+            Box::pin(async move {
+                storage::postgres::PostgresBackend::log_event(tx, &event_owned).await
+            })
+        })
+        .await;
     let _ = state
         .postgres
         .persist_event(PersistentEvent::new(event.clone()))

--- a/cli/src/server/project_api.rs
+++ b/cli/src/server/project_api.rs
@@ -315,6 +315,7 @@ async fn create_project(
         Ok(()) => {
             persist_event(
                 &state,
+                &ctx,
                 &GovernanceEvent::UnitCreated {
                     unit_id: unit.id.clone(),
                     unit_type: unit.unit_type,
@@ -415,6 +416,7 @@ async fn add_member(
         Ok(()) => {
             persist_event(
                 &state,
+                &ctx,
                 &GovernanceEvent::RoleAssigned {
                     user_id: user_id.clone(),
                     unit_id: project_id.clone(),
@@ -870,8 +872,19 @@ fn parse_project_role(value: &str) -> Result<RoleIdentifier, axum::response::Res
     Ok(role)
 }
 
-async fn persist_event(state: &AppState, event: &GovernanceEvent) {
-    let _ = state.postgres.log_event(event).await;
+async fn persist_event(state: &AppState, ctx: &TenantContext, event: &GovernanceEvent) {
+    // Clone so the boxed future owns the event and satisfies the `'static`
+    // bound required by `with_tenant_context`'s HRTB. See the contract in
+    // `PostgresBackend::log_event`.
+    let event_owned = event.clone();
+    let _ = state
+        .postgres
+        .with_tenant_context(ctx, move |tx| {
+            Box::pin(async move {
+                storage::postgres::PostgresBackend::log_event(tx, &event_owned).await
+            })
+        })
+        .await;
     let _ = state
         .postgres
         .persist_event(PersistentEvent::new(event.clone()))

--- a/cli/src/server/team_api.rs
+++ b/cli/src/server/team_api.rs
@@ -153,6 +153,7 @@ async fn create_team(
         Ok(()) => {
             persist_event(
                 &state,
+                &ctx,
                 &GovernanceEvent::UnitCreated {
                     unit_id: unit.id.clone(),
                     unit_type: unit.unit_type,
@@ -253,6 +254,7 @@ async fn add_member(
         Ok(()) => {
             persist_event(
                 &state,
+                &ctx,
                 &GovernanceEvent::RoleAssigned {
                     user_id: user_id.clone(),
                     unit_id: team_id.clone(),
@@ -520,8 +522,23 @@ fn parse_team_role(value: &str) -> Result<RoleIdentifier, axum::response::Respon
     Ok(role)
 }
 
-async fn persist_event(state: &AppState, event: &GovernanceEvent) {
-    let _ = state.postgres.log_event(event).await;
+async fn persist_event(state: &AppState, ctx: &TenantContext, event: &GovernanceEvent) {
+    // Write the governance event inside a per-tenant transaction so the
+    // `governance_events` RLS policy (keyed on `app.tenant_id`) admits the
+    // INSERT. See `PostgresBackend::log_event` rustdoc for the contract.
+    //
+    // We clone `event` into the closure so the boxed future owns its
+    // payload and satisfies the `'static` bound required by
+    // `with_tenant_context`'s HRTB.
+    let event_owned = event.clone();
+    let _ = state
+        .postgres
+        .with_tenant_context(ctx, move |tx| {
+            Box::pin(async move {
+                storage::postgres::PostgresBackend::log_event(tx, &event_owned).await
+            })
+        })
+        .await;
     let _ = state
         .postgres
         .persist_event(PersistentEvent::new(event.clone()))

--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -891,11 +891,7 @@ async fn create_tenant(
                 tenant_id: record.id.clone(),
                 timestamp: now,
             };
-            let _ = state.postgres.log_event(&tenant_event).await;
-            let _ = state
-                .postgres
-                .persist_event(PersistentEvent::new(tenant_event))
-                .await;
+            persist_governance_event(&state, &ctx, &tenant_event).await;
             audit_tenant_action(
                 &state,
                 &ctx,
@@ -1017,11 +1013,7 @@ async fn update_tenant(
                 tenant_id: record.id.clone(),
                 timestamp: now,
             };
-            let _ = state.postgres.log_event(&tenant_event).await;
-            let _ = state
-                .postgres
-                .persist_event(PersistentEvent::new(tenant_event))
-                .await;
+            persist_governance_event(&state, &ctx, &tenant_event).await;
             audit_tenant_action(
                 &state,
                 &ctx,
@@ -1070,11 +1062,7 @@ async fn deactivate_tenant(
                 tenant_id: record.id.clone(),
                 timestamp: now,
             };
-            let _ = state.postgres.log_event(&tenant_event).await;
-            let _ = state
-                .postgres
-                .persist_event(PersistentEvent::new(tenant_event))
-                .await;
+            persist_governance_event(&state, &ctx, &tenant_event).await;
             audit_tenant_action(
                 &state,
                 &ctx,
@@ -1387,7 +1375,7 @@ async fn set_tenant_repository_binding(
                     timestamp: now,
                 }
             };
-            persist_governance_event(state.as_ref(), &event).await;
+            persist_governance_event(state.as_ref(), &ctx, &event).await;
             state.tenant_repo_resolver.invalidate(&binding.tenant_id);
             audit_tenant_action(
                 state.as_ref(),
@@ -1557,6 +1545,7 @@ async fn create_hierarchy_unit(
         Ok(()) => {
             persist_governance_event(
                 state.as_ref(),
+                &ctx,
                 &GovernanceEvent::UnitCreated {
                     unit_id: unit.id.clone(),
                     unit_type: unit.unit_type,
@@ -1662,6 +1651,7 @@ async fn update_hierarchy_unit(
         Ok(()) => {
             persist_governance_event(
                 state.as_ref(),
+                &ctx,
                 &GovernanceEvent::UnitUpdated {
                     unit_id: existing.id.clone(),
                     tenant_id: ctx.tenant_id.clone(),
@@ -1876,6 +1866,7 @@ async fn assign_unit_role(
             let now = chrono::Utc::now().timestamp();
             persist_governance_event(
                 state.as_ref(),
+                &ctx,
                 &GovernanceEvent::RoleAssigned {
                     user_id: user_id.clone(),
                     unit_id: unit.clone(),
@@ -2000,6 +1991,7 @@ async fn remove_unit_role(
             let now = chrono::Utc::now().timestamp();
             persist_governance_event(
                 state.as_ref(),
+                &ctx,
                 &GovernanceEvent::RoleRemoved {
                     user_id: user_id.clone(),
                     unit_id: unit.clone(),
@@ -2242,8 +2234,29 @@ async fn audit_membership_action(
         .await;
 }
 
-async fn persist_governance_event(state: &AppState, event: &GovernanceEvent) {
-    let _ = state.postgres.log_event(event).await;
+async fn persist_governance_event(
+    state: &AppState,
+    ctx: &mk_core::types::TenantContext,
+    event: &GovernanceEvent,
+) {
+    // Tenant provisioning / admin-surface events: write via the admin pool.
+    // `with_admin_context` records the admin's action in
+    // `governance_audit_log` atomically with the `governance_events` row,
+    // giving us a unified audit trail without requiring `app.tenant_id`
+    // to match (the event's tenant_id may be the *managed* tenant, not
+    // the admin's own).
+    //
+    // Clone so the boxed future owns the event and satisfies the `'static`
+    // bound required by `with_admin_context`'s HRTB.
+    let event_owned = event.clone();
+    let _ = state
+        .postgres
+        .with_admin_context(ctx, "log_governance_event", move |tx| {
+            Box::pin(async move {
+                storage::postgres::PostgresBackend::log_event(tx, &event_owned).await
+            })
+        })
+        .await;
     let _ = state
         .postgres
         .persist_event(PersistentEvent::new(event.clone()))
@@ -3150,7 +3163,7 @@ async fn create_git_provider_connection(
                 tenant_id: ctx.tenant_id.clone(),
                 timestamp: now,
             };
-            persist_governance_event(state.as_ref(), &event).await;
+            persist_governance_event(state.as_ref(), &ctx, &event).await;
             audit_tenant_action(
                 state.as_ref(),
                 &ctx,
@@ -3253,7 +3266,7 @@ async fn grant_git_provider_connection_to_tenant(
                 tenant_id: tenant_record.id.clone(),
                 timestamp: now,
             };
-            persist_governance_event(state.as_ref(), &event).await;
+            persist_governance_event(state.as_ref(), &ctx, &event).await;
             audit_tenant_action(
                 state.as_ref(),
                 &ctx,
@@ -3307,7 +3320,7 @@ async fn revoke_git_provider_connection_from_tenant(
                 tenant_id: tenant_record.id.clone(),
                 timestamp: now,
             };
-            persist_governance_event(state.as_ref(), &event).await;
+            persist_governance_event(state.as_ref(), &ctx, &event).await;
             audit_tenant_action(
                 state.as_ref(),
                 &ctx,
@@ -3623,6 +3636,7 @@ async fn provision_tenant(
             if record.created_at == record.updated_at {
                 persist_governance_event(
                     state.as_ref(),
+                    &ctx,
                     &GovernanceEvent::TenantCreated {
                         record_id: record.id.as_str().to_string(),
                         slug: record.slug.clone(),
@@ -3829,6 +3843,7 @@ async fn provision_tenant(
                         let now = chrono::Utc::now().timestamp();
                         persist_governance_event(
                             state.as_ref(),
+                            &ctx,
                             &GovernanceEvent::RepositoryBindingCreated {
                                 binding_id: binding.id.clone(),
                                 tenant_id: tenant_id.clone(),
@@ -3896,6 +3911,7 @@ async fn provision_tenant(
             }
             persist_governance_event(
                 state.as_ref(),
+                &ctx,
                 &GovernanceEvent::UnitCreated {
                     unit_id: company_unit.id.clone(),
                     unit_type: company_unit.unit_type,
@@ -3927,6 +3943,7 @@ async fn provision_tenant(
                 }
                 persist_governance_event(
                     state.as_ref(),
+                    &ctx,
                     &GovernanceEvent::UnitCreated {
                         unit_id: org_unit.id.clone(),
                         unit_type: org_unit.unit_type,
@@ -3964,6 +3981,7 @@ async fn provision_tenant(
                     } else {
                         persist_governance_event(
                             state.as_ref(),
+                            &ctx,
                             &GovernanceEvent::RoleAssigned {
                                 user_id: user_id.clone(),
                                 unit_id: org_id.clone(),
@@ -3994,6 +4012,7 @@ async fn provision_tenant(
                     }
                     persist_governance_event(
                         state.as_ref(),
+                        &ctx,
                         &GovernanceEvent::UnitCreated {
                             unit_id: team_unit.id.clone(),
                             unit_type: team_unit.unit_type,
@@ -4031,6 +4050,7 @@ async fn provision_tenant(
                         } else {
                             persist_governance_event(
                                 state.as_ref(),
+                                &ctx,
                                 &GovernanceEvent::RoleAssigned {
                                     user_id: user_id.clone(),
                                     unit_id: team_id.clone(),
@@ -4105,6 +4125,7 @@ async fn provision_tenant(
                 Ok(()) => {
                     persist_governance_event(
                         state.as_ref(),
+                        &ctx,
                         &GovernanceEvent::RoleAssigned {
                             user_id: user_id.clone(),
                             unit_id: unit_id.clone(),

--- a/storage/src/postgres.rs
+++ b/storage/src/postgres.rs
@@ -1658,8 +1658,29 @@ impl PostgresBackend {
             .collect())
     }
 
+    /// Append a governance event inside an existing transaction.
+    ///
+    /// # RLS contract
+    ///
+    /// `governance_events` has RLS enabled and is keyed on `tenant_id`.
+    /// The caller MUST ensure `app.tenant_id` is SET LOCAL to a value
+    /// matching `event`'s tenant before invoking this function. In
+    /// practice this means calling it from within either:
+    ///
+    /// - [`Self::with_tenant_context`] with a matching `TenantContext`
+    ///   (the typical tenant-scoped handler path), or
+    /// - [`Self::with_admin_context`] (tenant provisioning / admin
+    ///   cross-tenant paths — BYPASSRLS applies).
+    ///
+    /// # Shape
+    ///
+    /// ```ignore
+    /// state.postgres.with_tenant_context(&ctx, |tx| Box::pin(async move {
+    ///     PostgresBackend::log_event(tx, &event).await
+    /// })).await?;
+    /// ```
     pub async fn log_event(
-        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
         event: &mk_core::types::GovernanceEvent,
     ) -> Result<(), PostgresError> {
         let (event_type, tenant_id, _timestamp) = match event {
@@ -1830,7 +1851,7 @@ impl PostgresBackend {
         .bind(event_type)
         .bind(tenant_id.as_str())
         .bind(serde_json::to_value(event)?)
-        .execute(&self.pool)
+        .execute(&mut **tx)
         .await?;
 
         Ok(())
@@ -2078,7 +2099,18 @@ impl mk_core::traits::EventPublisher for PostgresBackend {
     type Error = PostgresError;
 
     async fn publish(&self, event: mk_core::types::GovernanceEvent) -> Result<(), Self::Error> {
-        self.log_event(&event).await
+        // `log_event` is tx-scoped and must run inside a session where
+        // `app.tenant_id` matches the event's tenant (RLS on
+        // `governance_events`). The event carries its own tenant_id;
+        // construct a minimal context and wrap in `with_tenant_context`.
+        let ctx = mk_core::types::TenantContext::new(
+            event.tenant_id().clone(),
+            mk_core::types::UserId::default(),
+        );
+        self.with_tenant_context(&ctx, move |tx| {
+            Box::pin(async move { Self::log_event(tx, &event).await })
+        })
+        .await
     }
 
     async fn subscribe(

--- a/storage/tests/postgres_test.rs
+++ b/storage/tests/postgres_test.rs
@@ -516,7 +516,12 @@ async fn test_postgres_backend_governance_events() {
         timestamp: chrono::Utc::now().timestamp(),
     };
 
-    backend.log_event(&event).await.unwrap();
+    backend
+        .with_tenant_context(&ctx, |tx| {
+            Box::pin(async move { PostgresBackend::log_event(tx, &event).await })
+        })
+        .await
+        .unwrap();
 
     let events = backend.get_governance_events(ctx, 0, 10).await.unwrap();
     assert_eq!(events.len(), 1);
@@ -584,7 +589,12 @@ async fn test_postgres_backend_governance_event_types() {
     ];
 
     for event in events {
-        backend.log_event(&event).await.unwrap();
+        backend
+            .with_tenant_context(&ctx, |tx| {
+                Box::pin(async move { PostgresBackend::log_event(tx, &event).await })
+            })
+            .await
+            .unwrap();
     }
 
     let retrieved_events = backend.get_governance_events(ctx, 0, 10).await.unwrap();
@@ -834,9 +844,14 @@ async fn test_postgres_backend_event_publisher_subscribe() {
         timestamp: chrono::Utc::now().timestamp(),
     };
 
-    backend.log_event(&event).await.unwrap();
-
     let ctx = TenantContext::new(tenant_id, UserId::default());
+    backend
+        .with_tenant_context(&ctx, |tx| {
+            Box::pin(async move { PostgresBackend::log_event(tx, &event).await })
+        })
+        .await
+        .unwrap();
+
     let events = backend.get_governance_events(ctx, 0, 10).await.unwrap();
     assert!(!events.is_empty());
 }


### PR DESCRIPTION
## A.3 Wave 1 — Cluster 3 (Event)

First of 5 cluster-based PRs for the A.3 Wave 1 / Option C1 refactor: making inherent `PostgresBackend` methods **transaction-scoped** so callers drive tx scope + RLS context explicitly.

Started here because Event has the smallest real-world blast radius (~10 direct callers, clean fire-and-forget pattern) — good pilot to lock in the pattern before bigger clusters.

### Signature change

```rust
// before
impl PostgresBackend {
    pub async fn log_event(&self, event: &GovernanceEvent) -> Result<()>
}

// after
impl PostgresBackend {
    pub async fn log_event(
        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
        event: &GovernanceEvent,
    ) -> Result<()>
}
```

### Why

`governance_events` is RLS-gated on `tenant_id`. The old signature silently used `self.pool` with no enforced `app.tenant_id` — writes happened to succeed because they ran outside any tenant-scoped tx. Making the method tx-scoped forces callers to commit under the correct RLS context, which is the A.3 Wave 1 contract.

### Caller updates

| Site | Wrapping |
|---|---|
| `cli::{team,org,project}_api::persist_event` | `with_tenant_context(&ctx, …)` |
| `cli::tenant_api::persist_governance_event` | `with_admin_context(…)` (cross-tenant admin surface) |
| `storage` `EventPublisher for PostgresBackend` | opens own tx via `event.tenant_id()`, wraps in `with_tenant_context` |
| 3 Docker-gated tests in `storage/tests/postgres_test.rs` | wrapped in `with_tenant_context` |

All ~16 handler call sites in `tenant_api.rs` had `&ctx` threaded through. 3 inline `log_event` + `publish_event` pairs were consolidated to `persist_governance_event`.

### Lifetime note

`with_tenant_context`'s `FnOnce -> BoxFuture` requires a `'static` future. Since `GovernanceEvent: Clone`, helpers clone the event into the move-closure. Cheap, explicit, no API surface change.

### Diff

```
 cli/src/server/org_api.rs      | 17 ++++++++++--
 cli/src/server/project_api.rs  | 17 ++++++++++--
 cli/src/server/team_api.rs     | 21 ++++++++++++--
 cli/src/server/tenant_api.rs   | 63 ++++++++++++++++++++++++++++--------------
 storage/src/postgres.rs        | 38 +++++++++++++++++++++++--
 storage/tests/postgres_test.rs | 23 ++++++++++++---
 6 files changed, 145 insertions(+), 34 deletions(-)
```

### Verification

- [x] `cargo check --workspace` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` on changed files — clean (pre-existing warnings in `repo_manager.rs` untouched)
- [ ] Docker-gated `postgres_test.rs` — needs CI/local Postgres

### Not in this PR

- No trait changes. `StorageBackend` trait untouched.
- No signature changes to other inherent methods — those ship in Clusters 1, 2, 4, 5.
- Combining action tx + audit tx into a single tx is a separate concern (out of scope for Wave 1).

### Follow-up clusters

1. Cluster 2 — User / Auth (`resolve_user_id_by_idp*`, `get_user_roles*`, tenant default)
2. Cluster 1 — Unit / Org / Role (`list_all_units`, `get_unit`, `create_unit`, `remove_role`, …)
3. Cluster 4 — Error / Resolution
4. Cluster 5 — Hindsight / Decomposition

See `plan-a3-wave1-c1-full.md` for the full rollout sequence.