### PR TITLE
refactor(storage): make user/auth methods transaction-scoped (A.3 Wave 1, Cluster 2)

### DIFF
--- a/cli/src/server/auth_middleware.rs
+++ b/cli/src/server/auth_middleware.rs
@@ -179,7 +179,7 @@ async fn tenant_context_from_identity(
     let (user_id_str, roles) = match &auth_state.postgres {
         Some(postgres) => {
             let resolved = postgres
-                .resolve_user_id_by_idp(&identity.idp_provider, &identity.github_login)
+                .resolve_user_id_by_idp_bootstrap(&identity.idp_provider, &identity.github_login)
                 .await
                 .ok()??;
             let roles = lookup_roles_for_idp(

--- a/cli/src/server/context.rs
+++ b/cli/src/server/context.rs
@@ -566,7 +566,7 @@ pub async fn request_context(
     // --- Step 2: users.default_tenant_id ---
     if let Ok(Some(default)) = state
         .postgres
-        .get_user_default_tenant(user_id.as_str())
+        .get_user_default_tenant_bootstrap(user_id.as_str())
         .await
     {
         // The FK ON DELETE SET NULL guarantees the tenant exists if the

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -131,11 +131,16 @@ pub(crate) async fn lookup_roles_for_idp_subject(
     idp_subject: &str,
     tenant_id: &str,
 ) -> Result<Vec<RoleIdentifier>, storage::postgres::PostgresError> {
-    let Some(user_id) = postgres.resolve_user_id_by_idp_subject(idp_subject).await? else {
+    let Some(user_id) = postgres
+        .resolve_user_id_by_idp_subject_bootstrap(idp_subject)
+        .await?
+    else {
         return Ok(Vec::new());
     };
 
-    postgres.get_user_roles_for_auth(&user_id, tenant_id).await
+    postgres
+        .get_user_roles_for_auth_bootstrap(&user_id, tenant_id)
+        .await
 }
 
 pub(crate) async fn lookup_roles_for_idp(
@@ -145,12 +150,14 @@ pub(crate) async fn lookup_roles_for_idp(
     tenant_id: &str,
 ) -> Result<Vec<RoleIdentifier>, storage::postgres::PostgresError> {
     let Some(user_id) = postgres
-        .resolve_user_id_by_idp(idp_provider, idp_subject)
+        .resolve_user_id_by_idp_bootstrap(idp_provider, idp_subject)
         .await?
     else {
         return Ok(Vec::new());
     };
-    postgres.get_user_roles_for_auth(&user_id, tenant_id).await
+    postgres
+        .get_user_roles_for_auth_bootstrap(&user_id, tenant_id)
+        .await
 }
 
 /// Extract the authenticated identity without resolving a tenant.
@@ -261,7 +268,7 @@ pub(crate) async fn resolve_identity(
         Resolution::Provider { provider, subject } => {
             let uid = state
                 .postgres
-                .resolve_user_id_by_idp(provider, &subject)
+                .resolve_user_id_by_idp_bootstrap(provider, &subject)
                 .await
                 .map_err(|err| {
                     error_json(
@@ -280,7 +287,7 @@ pub(crate) async fn resolve_identity(
 
             let root_roles = state
                 .postgres
-                .get_user_roles_for_auth(&uid, INSTANCE_SCOPE_TENANT_ID)
+                .get_user_roles_for_auth_bootstrap(&uid, INSTANCE_SCOPE_TENANT_ID)
                 .await
                 .map_err(|err| {
                     error_json(
@@ -292,7 +299,7 @@ pub(crate) async fn resolve_identity(
 
             let tenant_ids = state
                 .postgres
-                .get_user_tenant_ids(&uid)
+                .get_user_tenant_ids_bootstrap(&uid)
                 .await
                 .map_err(|err| {
                     error_json(
@@ -379,7 +386,7 @@ pub async fn authenticated_tenant_context(
     let roles = if any_provider_configured {
         state
             .postgres
-            .get_user_roles_for_auth(ctx.user_id.as_str(), tenant.id.as_str())
+            .get_user_roles_for_auth_bootstrap(ctx.user_id.as_str(), tenant.id.as_str())
             .await
             .map_err(|err| {
                 error_json(

--- a/cli/src/server/plugin_auth.rs
+++ b/cli/src/server/plugin_auth.rs
@@ -610,7 +610,7 @@ async fn admin_session_handler(
 
     let user_id = match state
         .postgres
-        .resolve_user_id_by_idp(&identity.idp_provider, &identity.github_login)
+        .resolve_user_id_by_idp_bootstrap(&identity.idp_provider, &identity.github_login)
         .await
     {
         Ok(Some(id)) => id,
@@ -637,7 +637,7 @@ async fn admin_session_handler(
 
     let roles = match state
         .postgres
-        .get_user_roles_for_auth(&user_id, &identity.tenant_id)
+        .get_user_roles_for_auth_bootstrap(&user_id, &identity.tenant_id)
         .await
     {
         Ok(r) => r,
@@ -662,7 +662,7 @@ async fn admin_session_handler(
 
     let default_tenant_id = state
         .postgres
-        .get_user_default_tenant(&user_id)
+        .get_user_default_tenant_bootstrap(&user_id)
         .await
         .ok()
         .flatten();
@@ -683,7 +683,7 @@ async fn admin_session_handler(
             Err(_) => vec![],
         }
     } else {
-        match state.postgres.get_user_tenant_ids(&user_id).await {
+        match state.postgres.get_user_tenant_ids_bootstrap(&user_id).await {
             Ok(ids) => ids
                 .into_iter()
                 .map(|id| {

--- a/cli/src/server/role_grants.rs
+++ b/cli/src/server/role_grants.rs
@@ -250,7 +250,7 @@ async fn handle_revoke_role(
 
     let existing = match state
         .postgres
-        .get_user_roles(&user_id, &ctx.tenant_id)
+        .get_user_roles_scoped(&ctx, &user_id, &ctx.tenant_id)
         .await
     {
         Ok(roles) => roles
@@ -319,7 +319,7 @@ async fn handle_list_grants(
 
         match state
             .postgres
-            .get_user_roles(&user_id, &ctx.tenant_id)
+            .get_user_roles_scoped(&ctx, &user_id, &ctx.tenant_id)
             .await
         {
             Ok(entries) => entries

--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -2047,7 +2047,7 @@ async fn list_user_memberships(
 
     match state
         .postgres
-        .get_user_roles(&user_id, &ctx.tenant_id)
+        .get_user_roles_scoped(&ctx, &user_id, &ctx.tenant_id)
         .await
     {
         Ok(entries) => {

--- a/cli/src/server/user_api.rs
+++ b/cli/src/server/user_api.rs
@@ -127,7 +127,7 @@ async fn get_default_tenant(
 
     match state
         .postgres
-        .get_user_default_tenant(ctx.user_id.as_str())
+        .get_user_default_tenant_bootstrap(ctx.user_id.as_str())
         .await
     {
         Ok(None) => (StatusCode::NO_CONTENT, Json(json!({}))).into_response(),
@@ -232,7 +232,7 @@ async fn set_default_tenant(
 
     if let Err(e) = state
         .postgres
-        .set_user_default_tenant(ctx.user_id.as_str(), record.id.as_str())
+        .set_user_default_tenant_bootstrap(ctx.user_id.as_str(), record.id.as_str())
         .await
     {
         return (
@@ -273,7 +273,7 @@ async fn clear_default_tenant(
 
     if let Err(e) = state
         .postgres
-        .clear_user_default_tenant(ctx.user_id.as_str())
+        .clear_user_default_tenant_bootstrap(ctx.user_id.as_str())
         .await
     {
         return (
@@ -939,7 +939,7 @@ async fn list_user_roles(
     };
     let roles = match state
         .postgres
-        .get_user_roles(&user_id, &ctx.tenant_id)
+        .get_user_roles_scoped(&ctx, &user_id, &ctx.tenant_id)
         .await
     {
         Ok(roles) => roles,
@@ -1031,7 +1031,7 @@ async fn revoke_user_role(
     };
     let roles = match state
         .postgres
-        .get_user_roles(&user_id, &ctx.tenant_id)
+        .get_user_roles_scoped(&ctx, &user_id, &ctx.tenant_id)
         .await
     {
         Ok(roles) => roles,

--- a/storage/src/postgres.rs
+++ b/storage/src/postgres.rs
@@ -271,6 +271,46 @@ impl PostgresBackend {
         Ok(out)
     }
 
+    /// Run `body` inside a plain transaction with NO tenant context set and
+    /// NO admin audit write.
+    ///
+    /// This is the read-only helper for the **authentication bootstrap
+    /// path** — the narrow window before a `TenantContext` exists, where the
+    /// server is still resolving which user/tenant the caller belongs to.
+    /// Concrete use cases:
+    ///
+    /// - `resolve_user_id_by_idp` / `resolve_user_id_by_idp_subject`
+    /// - `get_user_roles_for_auth` at `INSTANCE_SCOPE_TENANT_ID`
+    /// - `get_user_tenant_ids`
+    /// - `get_user_default_tenant`
+    ///
+    /// These methods read from `users` / `user_roles`, which are NOT
+    /// RLS-enabled (verified in migrations 004, 006, 008, 012, 014, 016):
+    /// there is no `app.tenant_id` to set, and no admin-audit row is
+    /// warranted on the auth hot path (one per request would flood
+    /// `governance_audit_log`).
+    ///
+    /// # When NOT to use
+    ///
+    /// - Any write path — use `with_tenant_context` or `with_admin_context`.
+    /// - Anything touching an RLS-gated table — bootstrap tx does not set
+    ///   `app.tenant_id`, so those queries would silently match zero rows.
+    /// - Anything where a `TenantContext` is already available — prefer
+    ///   `with_tenant_context` for consistency.
+    pub async fn with_bootstrap_context<'a, F, T>(&self, body: F) -> Result<T, PostgresError>
+    where
+        F: for<'c> FnOnce(
+            &'c mut sqlx::Transaction<'_, Postgres>,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<T, PostgresError>> + Send + 'c>,
+        >,
+    {
+        let mut tx = self.pool.begin().await?;
+        let out = body(&mut tx).await?;
+        tx.commit().await?;
+        Ok(out)
+    }
+
     pub async fn initialize_schema(&self) -> Result<(), PostgresError> {
         // Enable pgcrypto extension for gen_random_uuid()
         sqlx::query("CREATE EXTENSION IF NOT EXISTS pgcrypto")
@@ -1458,7 +1498,7 @@ impl PostgresBackend {
     }
 
     pub async fn get_user_roles(
-        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         user_id: &mk_core::types::UserId,
         tenant_id: &mk_core::types::TenantId,
     ) -> Result<Vec<(String, RoleIdentifier)>, PostgresError> {
@@ -1467,7 +1507,7 @@ impl PostgresBackend {
         )
         .bind(user_id.as_str())
         .bind(tenant_id.as_str())
-        .fetch_all(&self.pool)
+        .fetch_all(&mut **tx)
         .await?;
 
         let mut roles = Vec::new();
@@ -1511,13 +1551,13 @@ impl PostgresBackend {
     /// Returns `None` when no matching user exists — callers should treat this as an anonymous /
     /// unauthenticated identity with no roles.
     pub async fn resolve_user_id_by_idp_subject(
-        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         idp_subject: &str,
     ) -> Result<Option<String>, PostgresError> {
         use sqlx::Row;
         let row = sqlx::query("SELECT id::text FROM users WHERE idp_subject = $1 LIMIT 1")
             .bind(idp_subject)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut **tx)
             .await?;
         Ok(row.map(|r| r.get::<String, _>("id")))
     }
@@ -1527,7 +1567,7 @@ impl PostgresBackend {
     /// Both `idp_provider` and `idp_subject` must match.  Returns `None` when no
     /// matching user exists.
     pub async fn resolve_user_id_by_idp(
-        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         idp_provider: &str,
         idp_subject: &str,
     ) -> Result<Option<String>, PostgresError> {
@@ -1537,7 +1577,7 @@ impl PostgresBackend {
         )
         .bind(idp_provider)
         .bind(idp_subject)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut **tx)
         .await?;
         Ok(row.map(|r| r.get::<String, _>("id")))
     }
@@ -1547,7 +1587,7 @@ impl PostgresBackend {
     ///
     /// This is the authoritative role lookup for authentication context construction.
     pub async fn get_user_roles_for_auth(
-        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         user_id: &str,
         tenant_id: &str,
     ) -> Result<Vec<RoleIdentifier>, PostgresError> {
@@ -1559,7 +1599,7 @@ impl PostgresBackend {
         .bind(user_id)
         .bind(tenant_id)
         .bind(INSTANCE_SCOPE_TENANT_ID)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut **tx)
         .await?;
 
         let mut roles: Vec<RoleIdentifier> = rows
@@ -1586,14 +1626,14 @@ impl PostgresBackend {
     /// Added in OpenSpec change `refactor-platform-admin-impersonation` (#44.b)
     /// to back the `GET /api/v1/user/me/default-tenant` endpoint.
     pub async fn get_user_default_tenant(
-        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         user_id: &str,
     ) -> Result<Option<String>, PostgresError> {
         use sqlx::Row;
         let row =
             sqlx::query("SELECT default_tenant_id::text AS tid FROM users WHERE id = $1::uuid")
                 .bind(user_id)
-                .fetch_optional(&self.pool)
+                .fetch_optional(&mut **tx)
                 .await?;
         Ok(row.and_then(|r| r.try_get::<Option<String>, _>("tid").ok().flatten()))
     }
@@ -1604,7 +1644,7 @@ impl PostgresBackend {
     /// verified membership in it before calling this method. The FK
     /// constraint rejects orphan IDs at write time.
     pub async fn set_user_default_tenant(
-        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         user_id: &str,
         tenant_id: &str,
     ) -> Result<(), PostgresError> {
@@ -1613,7 +1653,7 @@ impl PostgresBackend {
         )
         .bind(user_id)
         .bind(tenant_id)
-        .execute(&self.pool)
+        .execute(&mut **tx)
         .await?;
         if res.rows_affected() == 0 {
             return Err(PostgresError::NotFound(format!("user {user_id} not found")));
@@ -1622,12 +1662,15 @@ impl PostgresBackend {
     }
 
     /// Clear the caller-configured default tenant for a user.
-    pub async fn clear_user_default_tenant(&self, user_id: &str) -> Result<(), PostgresError> {
+    pub async fn clear_user_default_tenant(
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        user_id: &str,
+    ) -> Result<(), PostgresError> {
         let res = sqlx::query(
             "UPDATE users SET default_tenant_id = NULL, updated_at = NOW() WHERE id = $1::uuid",
         )
         .bind(user_id)
-        .execute(&self.pool)
+        .execute(&mut **tx)
         .await?;
         if res.rows_affected() == 0 {
             return Err(PostgresError::NotFound(format!("user {user_id} not found")));
@@ -1641,7 +1684,10 @@ impl PostgresBackend {
     /// header, the server can auto-select the tenant when the result is exactly one.
     /// When the result is empty or more than one, the caller must require an explicit
     /// `X-Tenant-ID`.
-    pub async fn get_user_tenant_ids(&self, user_id: &str) -> Result<Vec<String>, PostgresError> {
+    pub async fn get_user_tenant_ids(
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        user_id: &str,
+    ) -> Result<Vec<String>, PostgresError> {
         use sqlx::Row;
         let rows = sqlx::query(
             "SELECT DISTINCT tenant_id FROM user_roles
@@ -1650,12 +1696,145 @@ impl PostgresBackend {
         )
         .bind(user_id)
         .bind(INSTANCE_SCOPE_TENANT_ID)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut **tx)
         .await?;
         Ok(rows
             .iter()
             .map(|r| r.get::<String, _>("tenant_id"))
             .collect())
+    }
+
+    // -- Auth / bootstrap convenience wrappers --------------------------------
+    //
+    // These thin wrappers drive the associated `resolve_user_id_by_idp*` /
+    // `get_user_roles_for_auth` / `get_user_tenant_ids` / `get_user_default_tenant`
+    // methods through [`Self::with_bootstrap_context`]. They exist because the
+    // authentication hot path runs before any `TenantContext` is known, so the
+    // normal `with_tenant_context` / `with_admin_context` wrappers do not apply
+    // (the former has no tenant, the latter would emit an admin-audit row per
+    // request).
+    //
+    // The underlying tables (`users`, `user_roles`) are not RLS-enabled; the tx
+    // is used purely for atomicity and consistency with the rest of the API.
+
+    /// Bootstrap variant of [`Self::resolve_user_id_by_idp_subject`].
+    pub async fn resolve_user_id_by_idp_subject_bootstrap(
+        &self,
+        idp_subject: &str,
+    ) -> Result<Option<String>, PostgresError> {
+        let idp_subject = idp_subject.to_string();
+        self.with_bootstrap_context(move |tx| {
+            Box::pin(async move { Self::resolve_user_id_by_idp_subject(tx, &idp_subject).await })
+        })
+        .await
+    }
+
+    /// Bootstrap variant of [`Self::resolve_user_id_by_idp`].
+    pub async fn resolve_user_id_by_idp_bootstrap(
+        &self,
+        idp_provider: &str,
+        idp_subject: &str,
+    ) -> Result<Option<String>, PostgresError> {
+        let idp_provider = idp_provider.to_string();
+        let idp_subject = idp_subject.to_string();
+        self.with_bootstrap_context(move |tx| {
+            Box::pin(
+                async move { Self::resolve_user_id_by_idp(tx, &idp_provider, &idp_subject).await },
+            )
+        })
+        .await
+    }
+
+    /// Bootstrap variant of [`Self::get_user_roles_for_auth`].
+    pub async fn get_user_roles_for_auth_bootstrap(
+        &self,
+        user_id: &str,
+        tenant_id: &str,
+    ) -> Result<Vec<RoleIdentifier>, PostgresError> {
+        let user_id = user_id.to_string();
+        let tenant_id = tenant_id.to_string();
+        self.with_bootstrap_context(move |tx| {
+            Box::pin(async move { Self::get_user_roles_for_auth(tx, &user_id, &tenant_id).await })
+        })
+        .await
+    }
+
+    /// Bootstrap variant of [`Self::get_user_tenant_ids`].
+    pub async fn get_user_tenant_ids_bootstrap(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<String>, PostgresError> {
+        let user_id = user_id.to_string();
+        self.with_bootstrap_context(move |tx| {
+            Box::pin(async move { Self::get_user_tenant_ids(tx, &user_id).await })
+        })
+        .await
+    }
+
+    /// Bootstrap variant of [`Self::get_user_default_tenant`].
+    pub async fn get_user_default_tenant_bootstrap(
+        &self,
+        user_id: &str,
+    ) -> Result<Option<String>, PostgresError> {
+        let user_id = user_id.to_string();
+        self.with_bootstrap_context(move |tx| {
+            Box::pin(async move { Self::get_user_default_tenant(tx, &user_id).await })
+        })
+        .await
+    }
+
+    /// Bootstrap-pool write variant of [`Self::set_user_default_tenant`].
+    ///
+    /// `users.default_tenant_id` is user-level state, not tenant-scoped;
+    /// there is no RLS policy on the `users` table (verified in the
+    /// migration set). The bootstrap pool gives us tx-scoped atomicity
+    /// without emitting an admin-audit row on every preference change.
+    pub async fn set_user_default_tenant_bootstrap(
+        &self,
+        user_id: &str,
+        tenant_id: &str,
+    ) -> Result<(), PostgresError> {
+        let user_id = user_id.to_string();
+        let tenant_id = tenant_id.to_string();
+        self.with_bootstrap_context(move |tx| {
+            Box::pin(async move { Self::set_user_default_tenant(tx, &user_id, &tenant_id).await })
+        })
+        .await
+    }
+
+    /// Bootstrap-pool write variant of [`Self::clear_user_default_tenant`].
+    ///
+    /// See [`Self::set_user_default_tenant_bootstrap`] for rationale.
+    pub async fn clear_user_default_tenant_bootstrap(
+        &self,
+        user_id: &str,
+    ) -> Result<(), PostgresError> {
+        let user_id = user_id.to_string();
+        self.with_bootstrap_context(move |tx| {
+            Box::pin(async move { Self::clear_user_default_tenant(tx, &user_id).await })
+        })
+        .await
+    }
+
+    /// Tenant-scoped convenience variant of [`Self::get_user_roles`].
+    ///
+    /// Wraps the associated function in [`Self::with_tenant_context`] so
+    /// handler call sites don't need to `Box::pin` an async block each time.
+    /// The scoped tx is technically redundant today (`user_roles` is not
+    /// RLS-gated), but it's the right shape for the A.3 Wave 1 contract
+    /// and future-proofs against enabling RLS on `user_roles`.
+    pub async fn get_user_roles_scoped(
+        &self,
+        ctx: &TenantContext,
+        user_id: &mk_core::types::UserId,
+        tenant_id: &mk_core::types::TenantId,
+    ) -> Result<Vec<(String, RoleIdentifier)>, PostgresError> {
+        let user_id = user_id.clone();
+        let tenant_id = tenant_id.clone();
+        self.with_tenant_context(ctx, move |tx| {
+            Box::pin(async move { Self::get_user_roles(tx, &user_id, &tenant_id).await })
+        })
+        .await
     }
 
     /// Append a governance event inside an existing transaction.

--- a/storage/tests/postgres_test.rs
+++ b/storage/tests/postgres_test.rs
@@ -297,7 +297,11 @@ async fn test_postgres_backend_role_management() {
         .await
         .unwrap();
 
-    let roles = backend.get_user_roles(&user_id, &tenant_id).await.unwrap();
+    let ctx = TenantContext::new(tenant_id.clone(), user_id.clone());
+    let roles = backend
+        .get_user_roles_scoped(&ctx, &user_id, &tenant_id)
+        .await
+        .unwrap();
     assert_eq!(roles.len(), 1);
     assert_eq!(roles[0].0, comp_id);
     assert_eq!(roles[0].1, mk_core::types::Role::Admin.into());
@@ -312,7 +316,10 @@ async fn test_postgres_backend_role_management() {
         .await
         .unwrap();
 
-    let roles_after = backend.get_user_roles(&user_id, &tenant_id).await.unwrap();
+    let roles_after = backend
+        .get_user_roles_scoped(&ctx, &user_id, &tenant_id)
+        .await
+        .unwrap();
     assert_eq!(roles_after.len(), 0);
 }
 
@@ -338,14 +345,14 @@ async fn test_resolve_user_id_by_idp_subject_returns_matching_user() {
     .unwrap();
 
     let resolved = backend
-        .resolve_user_id_by_idp_subject(&idp_subject)
+        .resolve_user_id_by_idp_subject_bootstrap(&idp_subject)
         .await
         .unwrap();
 
     assert_eq!(resolved.as_deref(), Some(user_id.as_str()));
     assert_eq!(
         backend
-            .resolve_user_id_by_idp_subject("missing-subject")
+            .resolve_user_id_by_idp_subject_bootstrap("missing-subject")
             .await
             .unwrap(),
         None
@@ -435,7 +442,7 @@ async fn test_get_user_roles_for_auth_includes_instance_scope_and_deduplicates()
     .unwrap();
 
     let roles = backend
-        .get_user_roles_for_auth(&user_id, tenant_id.as_str())
+        .get_user_roles_for_auth_bootstrap(&user_id, tenant_id.as_str())
         .await
         .unwrap();
 


### PR DESCRIPTION
## A.3 Wave 1 — Cluster 2 (User / Auth / Tenant Resolution)

Second of 5 cluster-based PRs. Follows #76 (Cluster 3, Event).

### Scope

8 inherent `PostgresBackend` methods on the user/auth/tenant-resolution path refactored to take `&mut Transaction` as their first parameter:

| Method | Callers |
|---|---|
| `resolve_user_id_by_idp` | 4 |
| `resolve_user_id_by_idp_subject` | 1 |
| `get_user_roles_for_auth` | 5 |
| `get_user_tenant_ids` | 2 |
| `get_user_default_tenant` | 3 |
| `set_user_default_tenant` | 1 |
| `clear_user_default_tenant` | 1 |
| `get_user_roles` | 5 |
| **Total** | **22 sites** |

### New: `with_bootstrap_context`

Cluster 3 used `with_tenant_context` (per-tenant) and `with_admin_context` (cross-tenant + audit). The auth path needs a **third** shape:

- No `TenantContext` exists yet — it's being built
- Must not emit `governance_audit_log` rows per request (hot path)
- Reads non-RLS tables (`users`, `user_roles`)

```rust
pub async fn with_bootstrap_context<'a, F, T>(&self, body: F) -> Result<T, PostgresError>
```

Plain app-pool transaction, no session vars set, no audit. Explicitly documented as "auth bootstrap read path only".

### RLS verification

Grepped migrations 004/006/008/012/014/016 — **none of `users`, `user_roles`, `user_default_tenant` have `ENABLE ROW LEVEL SECURITY`**. Bootstrap tx is functionally correct today; the tx contract future-proofs for when RLS lands.

### Convenience methods (to keep call sites readable)

Inherent wrappers that hide the `Box::pin` / closure ceremony:

| Wrapper | Delegates to | Helper |
|---|---|---|
| `*_bootstrap` (5) | associated fns | `with_bootstrap_context` |
| `set_user_default_tenant_bootstrap` | assoc | `with_bootstrap_context` |
| `clear_user_default_tenant_bootstrap` | assoc | `with_bootstrap_context` |
| `get_user_roles_scoped` | `get_user_roles` | `with_tenant_context` |

### Context-wrapper decision table

| Call site | Has ctx? | Wrapper | Why |
|---|---|---|---|
| `mod.rs` auth flows | No | bootstrap | Pre-tenant-context resolution |
| `plugin_auth.rs` | No | bootstrap | Plugin-based auth resolution |
| `auth_middleware.rs` | No | bootstrap | JWT-phase identity lookup |
| `context.rs` default-tenant resolution | Partial | bootstrap | Building the ctx itself |
| `user_api.rs` preferences | Yes (RequestContext) | bootstrap | `users` has no RLS; user-level op |
| `user_api.rs` role list/revoke | Yes (TenantContext) | tenant-scoped | Consistency w/ handler-tenant flow |
| `tenant_api.rs` role list | Yes | tenant-scoped | Handler in tenant ctx |
| `role_grants.rs` role ops | Yes | tenant-scoped | Handler in tenant ctx |

### Verification

- [x] `cargo check --workspace --tests` — clean
- [x] `cargo fmt --check` — clean
- [x] Full CI clippy gate: `cargo clippy --workspace --all-targets -- -D correctness -D suspicious -W style -W complexity -W perf -A pedantic -A nursery` — clean
- [ ] Docker-gated `postgres_test.rs` — needs CI / local Postgres

### Diff

```
 cli/src/server/auth_middleware.rs |   2 +-
 cli/src/server/context.rs         |   2 +-
 cli/src/server/mod.rs             |  23 +++--
 cli/src/server/plugin_auth.rs     |   8 +-
 cli/src/server/role_grants.rs     |   4 +-
 cli/src/server/tenant_api.rs      |   2 +-
 cli/src/server/user_api.rs        |  10 +-
 storage/src/postgres.rs           | 211 +++++++++++++++++++++++++++++++++++---
 storage/tests/postgres_test.rs    |  17 ++-
 9 files changed, 236 insertions(+), 43 deletions(-)
```

### Follow-up clusters

- Cluster 1 — Unit / Org / Role (largest: `list_all_units`, `get_unit`, `create_unit`, `remove_role`, ~15 methods)
- Cluster 4 — Error / Resolution
- Cluster 5 — Hindsight / Decomposition

See `plan-a3-wave1-c1-full.md` for the full rollout.