### PR TITLE
release: 0.8.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "adapters"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aeterna"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "adapters",
  "aeterna-backup",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "agent-a2a"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "a2a-types",
  "anyhow",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "anyhow",
  "errors",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "context"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "backoff",
  "chrono",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "cross-tests"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "chrono",
  "memory",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "errors"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "idp-sync"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4805,7 +4805,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memory"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "aisdk",
  "anyhow",
@@ -4969,7 +4969,7 @@ dependencies = [
 
 [[package]]
 name = "mk_core"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5404,7 +5404,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opal-fetcher"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7994,7 +7994,7 @@ dependencies = [
 
 [[package]]
 name = "storage"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "adapters",
  "aes-gcm",
@@ -8165,7 +8165,7 @@ dependencies = [
 
 [[package]]
 name = "sync"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8344,7 +8344,7 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8748,7 +8748,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "adapters",
  "anyhow",
@@ -9245,7 +9245,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 # - `.github/workflows/version-consistency.yml` enforces that all those
 #   surfaces agree on every PR and on every tag push.
 [workspace.package]
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 
 [workspace.lints.rust]
 unused_imports = "warn"

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin-ui",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-ui",
-      "version": "0.8.0-rc.1",
+      "version": "0.8.0-rc.2",
       "dependencies": {
         "@tanstack/react-query": "^5.62.0",
         "class-variance-authority": "^0.7.1",

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-ui",
   "private": true,
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0-rc.2",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/charts/aeterna-prereqs/Chart.yaml
+++ b/charts/aeterna-prereqs/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   Redis-compatible cache (Dragonfly or Valkey), and vector store (Qdrant)
   for development and testing environments.
 type: application
-version: 0.8.0-rc.1
-appVersion: "0.8.0-rc.1"
+version: 0.8.0-rc.2
+appVersion: "0.8.0-rc.2"
 
 home: https://github.com/kikokikok/aeterna
 sources:

--- a/charts/aeterna/Chart.yaml
+++ b/charts/aeterna/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   stack, and supporting jobs. Requires external PostgreSQL, Redis-compatible
   cache, and vector store. Use the aeterna-prereqs chart for dev/test backends.
 type: application
-version: 0.8.0-rc.1
-appVersion: "0.8.0-rc.1"
+version: 0.8.0-rc.2
+appVersion: "0.8.0-rc.2"
 
 home: https://github.com/kikokikok/aeterna
 icon: https://raw.githubusercontent.com/kikokikok/aeterna/main/docs/logo.png

--- a/deploy/helm/aeterna-opal/Chart.yaml
+++ b/deploy/helm/aeterna-opal/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aeterna-opal
 description: OPAL Authorization Stack for Aeterna Memory-Knowledge System
 type: application
-version: 0.8.0-rc.1
-appVersion: "0.8.0-rc.1"
+version: 0.8.0-rc.2
+appVersion: "0.8.0-rc.2"
 keywords:
   - opal
   - cedar

--- a/packages/opencode-plugin/package-lock.json
+++ b/packages/opencode-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aeterna-org/opencode-plugin",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aeterna-org/opencode-plugin",
-      "version": "0.8.0-rc.1",
+      "version": "0.8.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencode-ai/plugin": "1.3.6",

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeterna-org/opencode-plugin",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0-rc.2",
   "description": "OpenCode plugin for Aeterna memory and knowledge integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "website",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "website",
-      "version": "0.8.0-rc.1",
+      "version": "0.8.0-rc.2",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0-rc.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
Automated version bump produced by `.github/workflows/cut-release.yml` (PR-create step blocked by org policy — opened manually).

Bumps workspace version + 3 Helm charts + 3 package.jsons from `0.8.0-rc.1` → `0.8.0-rc.2`.

## Checklist before merging
- [ ] `Version Consistency` check is green
- [ ] `PR Fast Gate` is green (unit tests, clippy, fmt, helm lint)
- [ ] `PR Integration Gate` is green (multi-arch docker build + shipped-smoke)

## After merge
```
git checkout master && git pull
git tag v0.8.0-rc.2
git push origin v0.8.0-rc.2
```
That tag push triggers `release.yml` which builds, signs (cosign), packages helm charts, builds CLI binaries for 4 targets, and opens the GitHub Release with all assets attached.