### PR TITLE
ci(cut-release): use RELEASE_BOT_PAT instead of GITHUB_TOKEN for Open PR step

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -82,9 +82,32 @@ jobs:
           git push origin "release/v${{ inputs.version }}"
 
       - name: Open PR
+        # NOTE: We deliberately use a PAT here instead of the default
+        # ${{ secrets.GITHUB_TOKEN }}. The kikokikok org policy
+        # "Allow GitHub Actions to create and approve pull requests" is
+        # disabled (see Settings → Actions → General), which causes
+        # `gh pr create` with GITHUB_TOKEN to fail with:
+        #   "GitHub Actions is not permitted to create or approve pull
+        #    requests (createPullRequest)"
+        #
+        # Required repo secret: RELEASE_BOT_PAT
+        #   - Classic PAT with `repo` scope, OR
+        #   - Fine-grained PAT scoped to this repo with:
+        #       Contents: Read & Write
+        #       Pull requests: Read & Write
+        #   - Owner must have push access (a maintainer, or a bot account).
+        #
+        # If the secret is missing, the step fails loudly with a clear
+        # message instead of the cryptic GraphQL error above.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_PAT }}
         run: |
+          if [[ -z "${GH_TOKEN}" ]]; then
+              echo "::error::Repo secret RELEASE_BOT_PAT is not set."
+              echo "::error::Create a PAT (contents:write + pull-requests:write) and add it as RELEASE_BOT_PAT."
+              echo "::error::See the comment above this step in cut-release.yml for details."
+              exit 1
+          fi
           gh pr create \
             --base master \
             --head "release/v${{ inputs.version }}" \


### PR DESCRIPTION
## Problem

The `Cut Release (version bump PR)` workflow ends by calling `gh pr create` to open the version-bump PR. That step fails on every run under this org's policy:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

This is the `kikokikok` org setting **Settings → Actions → General → “Allow GitHub Actions to create and approve pull requests”** being disabled — a reasonable org-wide default for supply-chain hygiene, but it means the default `GITHUB_TOKEN` cannot open PRs.

As a result, every cut-release run ends with a failed final step, forcing a maintainer to manually open the PR afterwards (as I had to do for #81 just now).

## Fix

Switch the `Open PR` step to use a dedicated repo secret `RELEASE_BOT_PAT` — a PAT (classic or fine-grained) carrying `contents:write` + `pull-requests:write`. The default `GITHUB_TOKEN` is **not** an allowed substitute; this only works with a user-owned token or a GitHub App installation token.

If the secret is missing, the step now fails loudly with an actionable message instead of a cryptic GraphQL error:

```
::error::Repo secret RELEASE_BOT_PAT is not set.
::error::Create a PAT (contents:write + pull-requests:write) and add it as RELEASE_BOT_PAT.
::error::See the comment above this step in cut-release.yml for details.
```

A multi-line comment block above the step explains why we can't use `GITHUB_TOKEN` and what the secret needs.

## One-time setup required after merge

A repo admin (you) must create the secret before the next cut-release run:

1. Create a PAT:
   - **Classic:** `repo` scope
   - **Fine-grained (recommended):** scoped to `kikokikok/aeterna` with `Contents: RW` + `Pull requests: RW`
2. **Settings → Secrets and variables → Actions → New repository secret:**
   - Name: `RELEASE_BOT_PAT`
   - Value: the PAT

After that, cut-release runs end-to-end — no more manual PR opening.

## Scope

- Single file: `.github/workflows/cut-release.yml`
- +24 / −1
- No code changes, no runtime impact
- Doesn't affect the currently-open release PR #81 (that one is already opened manually)

## Alternatives considered

| Option | Why not |
|---|---|
| GitHub App installation token | Cleaner long-term, but requires creating + installing a new app. PAT is the minimum viable fix today. |
| `continue-on-error: true` + print compare URL | Leaves the workflow yellow-failing on every run, hides real errors, and still requires manual PR opening. Worse UX. |
| Enable the org policy | Out of scope — org-wide security posture change that affects every repo, not ours to make here. |