### PR TITLE
ci(release): skip .dockerbuild metadata artifacts in github-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -526,9 +526,15 @@ jobs:
     needs: [resolve-version, docker-merge, docker-scan-sbom, cli-build, helm-release, npm-release, admin-ui-release]
     runs-on: ubuntu-latest
     steps:
+      # Only pull the artifacts we actually ship. docker/build-push-action v5+
+      # auto-uploads a `<repo>~<slug>.dockerbuild` metadata artifact per build
+      # matrix cell; those aren't used by the release step and their downloads
+      # occasionally flake on Azure Blob ("Artifact download failed after 5
+      # retries"), taking down the whole release job with them.
       - uses: actions/download-artifact@v4
         with:
           path: assets
+          pattern: '!*.dockerbuild'
       - name: Flatten assets
         run: |
           mkdir -p release-files


### PR DESCRIPTION
## Problem

The `github release` job in `release.yml` failed on `v0.8.0-rc.2` — twice in a row — with:

```
Error: Unable to download and extract artifact: Artifact download failed after 5 retries.
```

**All real build work had already succeeded** (run [24643174033](https://github.com/kikokikok/aeterna/actions/runs/24643174033)):
- ✅ 4/4 CLI binaries built & signed
- ✅ Docker images (amd64 + arm64) built, merged, cosign-signed
- ✅ Helm charts published to OCI
- ✅ npm package `@aeterna-org/opencode-plugin@0.8.0-rc.2` published
- ✅ SBOM generated
- ❌ `github release` — died on `actions/download-artifact@v4`

## Root cause

`docker/build-push-action` v5+ auto-uploads a `<repo>~<slug>.dockerbuild` metadata artifact per build matrix cell. Those artifacts are **not consumed** by the `github-release` step (its `find` filter is `*.tar.gz | *.sha256 | *.tgz | sbom.spdx.json`), but `actions/download-artifact@v4` with no `pattern` pulls **everything** produced by the workflow run.

Under intermittent Azure Blob Storage pressure, those 3 files (`kikokikok~aeterna~C3Y96S.dockerbuild`, `~8OG5IQ.dockerbuild`, `~QTOKY6.dockerbuild`) hit a download failure — even though the 8 artifacts we actually care about all succeeded.

This is a pure orchestration failure — none of our code or builds were broken.

## Fix

One line. Filter `.dockerbuild` artifacts out at download time using minimatch negation:

```yaml
- uses: actions/download-artifact@v4
  with:
    path: assets
    pattern: '!*.dockerbuild'
```

Plus a 5-line comment block explaining why.

## Verification

- ✅ YAML parses
- No other step references `.dockerbuild` artifacts (grep-confirmed)
- The `Flatten assets` step's `find` filter is already a strict allow-list, so the negated download just shrinks the search space without changing output

## v0.8.0-rc.2 status

Already published manually: https://github.com/kikokikok/aeterna/releases/tag/v0.8.0-rc.2 — I downloaded the 4 CLI tarballs + SBOM from run 24643174033, regenerated `checksums.sha256` locally, and ran `gh release create` with the full release notes. Docker digest + cosign verify command + helm install command are all in the release body.

This PR prevents the same manual workaround being needed on 0.8.0-rc.3 / 0.8.0 GA.

## Scope

- Single file: `.github/workflows/release.yml`
- +6 / −0
- No runtime impact on any other pipeline