### PR TITLE
fix(release): align image tag convention — `v<Chart.AppVersion>` everywhere

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,12 +315,15 @@ jobs:
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}-admin-ui
-          # Tags use NO leading `v` to match Chart.AppVersion (which is
-          # the default used by .Values.adminUi.image.tag in the chart).
+          # Tag convention: leading `v` prefix to match the main `aeterna`
+          # image (which is published as `v<version>` by the docker-merge
+          # job above). The Helm chart derives both image tags from
+          # `v<Chart.AppVersion>` — keeping the two pipelines in lockstep
+          # so `helm install --version X.Y.Z` works with zero --set flags.
           tags: |
-            type=raw,value=${{ needs.resolve-version.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.resolve-version.outputs.version }}
-            type=semver,pattern={{major}},value=${{ needs.resolve-version.outputs.version }}
+            type=raw,value=v${{ needs.resolve-version.outputs.version }}
+            type=semver,pattern=v{{major}}.{{minor}},value=v${{ needs.resolve-version.outputs.version }}
+            type=semver,pattern=v{{major}},value=v${{ needs.resolve-version.outputs.version }}
             type=raw,value=latest
             type=sha,prefix=sha-
       - name: Build & push (multi-arch)

--- a/charts/aeterna/templates/_helpers.tpl
+++ b/charts/aeterna/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Return the image reference
 {{- define "aeterna.image" -}}
 {{- $registry := .Values.global.imageRegistry | default "" -}}
 {{- $repository := .Values.aeterna.image.repository -}}
-{{- $tag := .Values.aeterna.image.tag | default .Chart.AppVersion -}}
+{{- $tag := .Values.aeterna.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
 {{- if $registry }}
 {{- printf "%s/%s:%s" $registry $repository $tag }}
 {{- else }}

--- a/charts/aeterna/templates/aeterna/deployment.yaml
+++ b/charts/aeterna/templates/aeterna/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       initContainers:
         {{- if and .Values.adminUi.enabled .Values.adminUi.image.repository }}
         - name: admin-ui-init
-          image: {{ .Values.adminUi.image.repository }}:{{ .Values.adminUi.image.tag }}
+          image: {{ .Values.adminUi.image.repository }}:{{ .Values.adminUi.image.tag | default (printf "v%s" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.adminUi.image.pullPolicy }}
           command: ["/bin/sh", "-c", "cp -r /usr/share/nginx/html/. /mnt/admin-ui/"]
           volumeMounts:

--- a/charts/aeterna/values.yaml
+++ b/charts/aeterna/values.yaml
@@ -386,7 +386,9 @@ adminUi:
   image:
     ## @param adminUi.image.repository Image repository (empty = use assets baked into main image)
     repository: ""
-    ## @param adminUi.image.tag Image tag
+    ## @param adminUi.image.tag Image tag (default: v<Chart.AppVersion>, e.g. v0.8.0-rc.2)
+    ## Leave empty to use the chart's AppVersion with a `v` prefix (matches what the
+    ## release pipeline publishes). Override only for local / pinning / preview images.
     tag: ""
     ## @param adminUi.image.pullPolicy Image pull policy
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Problem

Fresh `helm install` of the v0.8.0-rc.2 chart fails with admin-ui init container stuck in `ImagePullBackOff`:

```
Normal   Pulling    3s  kubelet  Pulling image "ghcr.io/kikokikok/aeterna-admin-ui:v0.8.0-rc.2"
Warning  Failed     3s  kubelet  Failed to pull image "...-admin-ui:v0.8.0-rc.2": not found
```

## Root cause — four inconsistencies

| # | Where | Emits | With `v`? |
|---|---|---|---|
| 1 | `release.yml` → docker-merge (main image) | `v0.8.0-rc.2` | ✅ yes |
| 2 | `release.yml` → admin-ui-release        | `0.8.0-rc.2`  | ❌ no  |
| 3 | `_helpers.tpl` → `aeterna.image` default | `0.8.0-rc.2`  | ❌ no  |
| 4 | `deployment.yaml` → admin-ui init tag    | *(empty)*     | ⚠️ none |

A user who sets `aeterna.image.tag=v0.8.0-rc.2` to make the main image pull (workaround for #3) then hits #2: admin-ui was never published as `v0.8.0-rc.2` — only `0.8.0-rc.2`.

And even with admin-ui off, #3 means out-of-the-box `helm install` would try to pull `aeterna:0.8.0-rc.2` (no `v`) which doesn't exist either.

## Fix

Standardize on `v<version>` across CI and chart defaults so `helm install --version 0.8.0-rc.3 oci://...` works with **zero** `--set` flags:

**1. CI — admin-ui publishes with `v` prefix** (`.github/workflows/release.yml`)
```diff
  images: ${{ env.REGISTRY }}/${{ github.repository }}-admin-ui
  tags: |
-   type=raw,value=${{ needs.resolve-version.outputs.version }}
+   type=raw,value=v${{ needs.resolve-version.outputs.version }}
    ...
```

**2. Chart — main image default gets `v` prefix** (`charts/aeterna/templates/_helpers.tpl`)
```diff
-{{- $tag := .Values.aeterna.image.tag | default .Chart.AppVersion -}}
+{{- $tag := .Values.aeterna.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
```

**3. Chart — admin-ui init gains a default** (`charts/aeterna/templates/aeterna/deployment.yaml`)
```diff
-image: {{ .Values.adminUi.image.repository }}:{{ .Values.adminUi.image.tag }}
+image: {{ .Values.adminUi.image.repository }}:{{ .Values.adminUi.image.tag | default (printf "v%s" .Chart.AppVersion) }}
```

**4. `values.yaml` doc comment updated** to reflect the new default.

## Verification

```
$ helm template aeterna charts/aeterna \\
    --set adminUi.enabled=true \\
    --set adminUi.image.repository=ghcr.io/kikokikok/aeterna-admin-ui \\
    --set postgresql.host=pg --set postgresql.password=x \\
    --set redis.host=r --set redis.password=x \\
    --set vectorStore.type=pgvector | grep '^\s*image:'
          image: "ghcr.io/kikokikok/aeterna:v0.8.0-rc.2"             ✅
          image: ghcr.io/kikokikok/aeterna-admin-ui:v0.8.0-rc.2      ✅
```

`helm lint charts/aeterna` → clean.

## rc.2 migration note

v0.8.0-rc.2 is already out and admin-ui for that version exists only at `:0.8.0-rc.2` (no `v`). Users on rc.2 should either:
- pin `adminUi.image.tag=0.8.0-rc.2` (no `v`) as a workaround, **or**
- bump to rc.3 after this PR merges — consistent tags, zero flags needed.

## Scope

- 4 files, +13 / −8
- No Rust code changes
- No runtime behavior change for anyone who already overrides tags explicitly