### PR TITLE
fix(admin-ui): unwrap tenant response envelope (fixes /tenants/undefined/* 404s)

### DIFF
--- a/admin-ui/src/pages/tenants/TenantDetailPage.tsx
+++ b/admin-ui/src/pages/tenants/TenantDetailPage.tsx
@@ -342,11 +342,17 @@ export default function TenantDetailPage() {
   const navigate = useNavigate()
   const [activeTab, setActiveTab] = useState<Tab>("overview")
 
-  const { data: tenant, isLoading, error, refetch } = useQuery<TenantRecord>({
+  // Backend returns `{ success: true, tenant: TenantRecord }` (see
+  // cli/src/server/tenant_api.rs::show_tenant). Typing the query as
+  // `TenantRecord` directly caused `tenant.slug` to be undefined, which
+  // propagated into the Config/Providers/Repository tabs and produced
+  // requests to `/api/v1/admin/tenants/undefined/*` (404s in the console).
+  const { data, isLoading, error, refetch } = useQuery<{ tenant: TenantRecord }>({
     queryKey: ["tenant", id],
     queryFn: () => apiClient.get(`/api/v1/admin/tenants/${id}`),
     enabled: !!id,
   })
+  const tenant = data?.tenant
 
   const tabs: { key: Tab; label: string }[] = [
     { key: "overview", label: "Overview" },


### PR DESCRIPTION
## Problem

On the dev cluster (v0.8.0-rc.2) the browser console floods with 404s whenever the TenantDetailPage mounts:

```
GET /api/v1/admin/tenants/undefined/config             404 (x2)
GET /api/v1/admin/tenants/undefined/providers          404 (x2)
GET /api/v1/admin/tenants/undefined/repository-binding 404 (x10)
```

The literal string `"undefined"` in the URL = JS template-literal interpolating an `undefined` variable.

## Root cause

Backend `show_tenant` in `cli/src/server/tenant_api.rs` returns an envelope:

```json
{ "success": true, "tenant": { "id": "...", "slug": "...", ... } }
```

`TenantDetailPage.tsx` typed the query as the bare record and used the raw response directly:

```tsx
const { data: tenant } = useQuery<TenantRecord>({ ... })   // wrong shape
...
<ConfigTab     tenantSlug={tenant.slug} />   // tenant.slug === undefined
<ProvidersTab  tenantSlug={tenant.slug} />
<RepositoryTab tenantSlug={tenant.slug} />
```

TypeScript couldn't catch it because the envelope has no `.slug`, and `undefined.slug` is just… `undefined`, which interpolates silently.

## Fix

Match the pattern `TenantListPage.tsx` already uses for the list endpoint:

```diff
-  const { data: tenant, ... } = useQuery<TenantRecord>({
+  const { data, ... } = useQuery<{ tenant: TenantRecord }>({
       queryKey: ["tenant", id],
       queryFn: () => apiClient.get(`/api/v1/admin/tenants/${id}`),
       enabled: !!id,
     })
+  const tenant = data?.tenant
```

A comment next to the query documents the envelope shape so this doesn't regress.

## Verification

- `cd admin-ui && npx tsc --noEmit` → clean
- After this PR, tabs fetch `/api/v1/admin/tenants/<real-slug>/{config,providers,repository-binding}` and the 404 storm disappears

## Scope

- 1 file, +7 / −1
- No behavior change for the overview tab (`tenant.name`, `tenant.status`, etc.)

## Not fixed here

Same console dump surfaced two separate bugs that need their own tracking:

- **`POST /api/v1/org` 422** — admin-ui sends `{ name, unit_type }`; backend `CreateOrgRequest` requires `{ name, description, companyId }`. `CreateOrgDialog` needs a Company parent picker.
- **`POST /api/v1/memory/{search,list}` 502** — only the memory endpoints 502 while everything else on the host responds. Needs pod logs; hypotheses are (a) vector store unreachable from pod, (b) panic in handler, (c) handler timeout > ingress timeout.
