### PR TITLE
fix(memory-api): stop returning 502 for internal errors; add tracing (closes #87)

### DIFF
--- a/cli/src/server/memory_api.rs
+++ b/cli/src/server/memory_api.rs
@@ -213,11 +213,14 @@ async fn search_handler(
             )
                 .into_response()
         }
-        Err(err) => error_response(
-            StatusCode::BAD_GATEWAY,
-            "memory_search_failed",
-            &err.to_string(),
-        ),
+        Err(err) => {
+            tracing::error!(error = %err, "memory search failed");
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "memory_search_failed",
+                &err.to_string(),
+            )
+        }
     }
 }
 
@@ -245,11 +248,14 @@ async fn add_handler(
             }),
         )
             .into_response(),
-        Err(err) => error_response(
-            StatusCode::BAD_GATEWAY,
-            "memory_add_failed",
-            &err.to_string(),
-        ),
+        Err(err) => {
+            tracing::error!(error = %err, layer = %req.layer, "memory add failed");
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "memory_add_failed",
+                &err.to_string(),
+            )
+        }
     }
 }
 
@@ -281,11 +287,14 @@ async fn list_handler(
             )
                 .into_response()
         }
-        Err(err) => error_response(
-            StatusCode::BAD_GATEWAY,
-            "memory_list_failed",
-            &err.to_string(),
-        ),
+        Err(err) => {
+            tracing::error!(error = %err, layer = %req.layer, "memory list failed");
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "memory_list_failed",
+                &err.to_string(),
+            )
+        }
     }
 }
 
@@ -332,11 +341,19 @@ async fn feedback_handler(
             }),
         )
             .into_response(),
-        Err(err) => error_response(
-            StatusCode::BAD_GATEWAY,
-            "memory_feedback_failed",
-            &err.to_string(),
-        ),
+        Err(err) => {
+            tracing::error!(
+                error = %err,
+                memory_id = %req.memory_id,
+                layer = %req.layer,
+                "memory feedback failed"
+            );
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "memory_feedback_failed",
+                &err.to_string(),
+            )
+        }
     }
 }
 
@@ -369,11 +386,19 @@ async fn delete_handler(
             }),
         )
             .into_response(),
-        Err(err) => error_response(
-            StatusCode::BAD_GATEWAY,
-            "memory_delete_failed",
-            &err.to_string(),
-        ),
+        Err(err) => {
+            tracing::error!(
+                error = %err,
+                memory_id = %memory_id,
+                layer = %req.layer,
+                "memory delete failed"
+            );
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "memory_delete_failed",
+                &err.to_string(),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Closes #87.

## The 502 was self-inflicted

All five memory handlers were literally returning `StatusCode::BAD_GATEWAY` on any error from `memory_manager.*`:

```rust
Err(err) => error_response(
    StatusCode::BAD_GATEWAY,   // ← 502 from the origin server
    "memory_search_failed",
    &err.to_string(),
),
```

Per RFC 9110 §15.6.3, 502 means *"the server, while acting as a gateway or proxy, received an invalid response from an inbound server"*. The memory service is not a gateway — it's the origin. Indistinguishable from an actual ingress 502 on the client, which is why the dev cluster looked like a cluster-level problem for days when the backend was alive and emitting 502s on purpose.

## Fix

- Return `500 Internal Server Error` for memory-manager failures (body still carries `{error, message}` — all the diagnostic info a client/SRE needs).
- Add `tracing::error!` before each error return, with the underlying error and relevant ids (`memory_id`, `layer`). Pod logs will finally show what's failing without needing client cooperation.
- No behavior change on success paths.
- No change to `parse_memory_layer` / `parse_reward_type` 400 paths.

## Verification

- `cargo check -p aeterna` → clean
- `grep BAD_GATEWAY` in `cli/tests/` and `crates/` shows no test was asserting the old 502, so nothing to update.

## Next step for the dev cluster

With this deployed, redoing the failing call will surface the real error in two places: the response body, and the aeterna pod logs (`kubectl logs ... | grep 'memory search failed\|memory list failed'`). At that point #87 can be re-triaged with actual evidence instead of hypotheses.
