### PR TITLE
test(admin-ui): add Playwright e2e regression suite for #85, #86, #87

### DIFF
--- a/.github/workflows/admin-ui-e2e.yml
+++ b/.github/workflows/admin-ui-e2e.yml
@@ -1,0 +1,57 @@
+name: admin-ui e2e
+
+on:
+  pull_request:
+    paths:
+      - 'admin-ui/**'
+      - '.github/workflows/admin-ui-e2e.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'admin-ui/**'
+      - '.github/workflows/admin-ui-e2e.yml'
+
+jobs:
+  playwright:
+    name: Playwright (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: admin-ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: admin-ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('admin-ui/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Run e2e tests
+        run: npx playwright test
+        env:
+          CI: '1'
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: admin-ui/playwright-report
+          retention-days: 14

--- a/admin-ui/.gitignore
+++ b/admin-ui/.gitignore
@@ -2,3 +2,8 @@ node_modules/
 dist/
 .env.local
 *.tsbuildinfo
+
+# Playwright
+/playwright-report/
+/test-results/
+/playwright/.cache/

--- a/admin-ui/e2e/README.md
+++ b/admin-ui/e2e/README.md
@@ -1,0 +1,49 @@
+# admin-ui end-to-end tests
+
+Hermetic Playwright regression suite for the Aeterna admin UI.
+
+## Philosophy
+
+- **No backend required.** Every test intercepts HTTP with `page.route()`
+  and returns deterministic fixtures. This keeps the suite fast (~seconds)
+  and runnable in any CI without infra dependencies.
+- **One bug → one spec.** Each file pins the behavior of a previously shipped
+  regression so it can't silently come back.
+- **Contract-level assertions.** Tests assert on the shape/URL of outbound
+  requests and the text/roles users see — not on internal component state.
+
+## Running
+
+```bash
+cd admin-ui
+npm ci
+npm run test:e2e:install   # one-time: download chromium
+npm run test:e2e           # headless
+npm run test:e2e:ui        # interactive UI mode
+npm run test:e2e -- --debug
+```
+
+The `webServer` in `playwright.config.ts` boots `npm run dev` on port 5173
+automatically. Set `CI=1` to enable retries and GitHub-Actions reporting.
+
+## Regression index
+
+| Spec                      | Issue / PR | Bug                                                                   |
+| ------------------------- | ---------- | --------------------------------------------------------------------- |
+| `tenant-detail.spec.ts`   | #85 / PR#85| TenantDetailPage fetched `/tenants/undefined/*` due to envelope leak. |
+| `org-create.spec.ts`      | #86 / PR#88| Create Org dialog sent `{ unit_type }` instead of `{ companyId }`.    |
+| `memory-search.spec.ts`   | #87 / PR#89| Memory handlers 502'd on internal errors; UI contract-pinned here.    |
+
+## Adding a new spec
+
+1. Create `<feature>.spec.ts` in this directory.
+2. `import { test, expect } from "./fixtures"`.
+3. Call `await login({ mocks: [...] })` before `page.goto()`.
+4. Prefer `getByRole` / `getByLabel` / `getByText` over brittle CSS locators.
+5. When asserting on an outbound request, prefer `handler` with
+   `route.request().postDataJSON()` over waiting for a global side-effect.
+
+## CI
+
+The GitHub Actions workflow `.github/workflows/admin-ui-e2e.yml` runs this
+suite on every PR touching `admin-ui/**`.

--- a/admin-ui/e2e/fixtures.ts
+++ b/admin-ui/e2e/fixtures.ts
@@ -1,0 +1,102 @@
+/**
+ * Playwright fixtures for admin-ui e2e tests.
+ *
+ * Provides a `login()` helper that pre-seeds localStorage with a fake
+ * JWT-ish token (so AuthContext hydrates as logged-in) and installs
+ * baseline API mocks via page.route(). Individual tests layer extra
+ * mocks on top.
+ *
+ * All tests are hermetic: no real backend is ever contacted.
+ */
+import { test as base, expect, type Page, type Route } from "@playwright/test"
+
+export interface ApiMock {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+  urlPattern: string | RegExp
+  status?: number
+  body?: unknown
+  /** Optional: fully custom handler if a static status/body isn't enough. */
+  handler?: (route: Route) => void | Promise<void>
+}
+
+export interface MockedSession {
+  userId?: string
+  userEmail?: string
+  tenants?: Array<{ id: string; slug: string; name: string; status?: string }>
+  isPlatformAdmin?: boolean
+}
+
+export function defaultSessionBody(session: MockedSession = {}) {
+  const tenants = session.tenants ?? [
+    { id: "tenant-acme-id", slug: "acme", name: "Acme Corp", status: "Active" },
+  ]
+  return {
+    user: {
+      id: session.userId ?? "user-test",
+      email: session.userEmail ?? "test@example.com",
+      displayName: "Test User",
+    },
+    tenants: tenants.map((t) => ({
+      id: t.id,
+      slug: t.slug,
+      name: t.name,
+      status: t.status ?? "Active",
+      sourceOwner: "Admin",
+      createdAt: 1_700_000_000,
+      updatedAt: 1_700_000_000,
+      deactivatedAt: null,
+    })),
+    roles: [],
+    is_platform_admin: session.isPlatformAdmin ?? true,
+  }
+}
+
+async function seedAuth(page: Page) {
+  await page.addInitScript(() => {
+    const now = Math.floor(Date.now() / 1000)
+    const tokens = {
+      access_token: "e2e-fake-access-token",
+      refresh_token: "e2e-fake-refresh-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+      stored_at: now,
+    }
+    localStorage.setItem("aeterna_tokens", JSON.stringify(tokens))
+  })
+}
+
+async function installMocks(page: Page, mocks: ApiMock[]) {
+  for (const mock of mocks) {
+    await page.route(mock.urlPattern, async (route) => {
+      if (mock.method && route.request().method() !== mock.method) {
+        await route.fallback()
+        return
+      }
+      if (mock.handler) {
+        await mock.handler(route)
+        return
+      }
+      await route.fulfill({
+        status: mock.status ?? 200,
+        contentType: "application/json",
+        body: JSON.stringify(mock.body ?? {}),
+      })
+    })
+  }
+}
+
+export const test = base.extend<{
+  login: (opts?: { session?: MockedSession; mocks?: ApiMock[] }) => Promise<void>
+}>({
+  login: async ({ page }, use) => {
+    await use(async ({ session, mocks } = {}) => {
+      await seedAuth(page)
+      await installMocks(page, [
+        { urlPattern: /\/api\/v1\/auth\/session$/, body: defaultSessionBody(session) },
+        ...(mocks ?? []),
+      ])
+    })
+  },
+})
+
+export { expect }

--- a/admin-ui/e2e/memory-search.spec.ts
+++ b/admin-ui/e2e/memory-search.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression test for #87 — memory API status codes.
+ *
+ * The bug was backend-side (handlers returning 502 for internal errors),
+ * but the UI regressions worth pinning are:
+ *
+ *   1. Browse mode issues POST /api/v1/memory/list with a valid
+ *      `{ layer, limit }` body (shape the backend actually parses).
+ *   2. Search mode issues POST /api/v1/memory/search with `{ query }`.
+ *   3. When the backend returns 500 with `{ error, message }`, the page
+ *      shows the error state + Retry button (doesn't blank out).
+ */
+import { test, expect } from "./fixtures"
+
+test("Memory browse issues a well-formed POST /memory/list", async ({ page, login }) => {
+  let capturedListBody: unknown = null
+
+  await login({
+    mocks: [
+      {
+        urlPattern: /\/api\/v1\/memory\/list$/,
+        method: "POST",
+        handler: async (route) => {
+          capturedListBody = route.request().postDataJSON()
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              items: [
+                {
+                  id: "mem-1",
+                  content: "project onboarding notes",
+                  layer: "Project",
+                  importanceScore: 0.42,
+                },
+              ],
+              total: 1,
+            }),
+          })
+        },
+      },
+    ],
+  })
+
+  await page.goto("/admin/memory")
+  await page.getByRole("button", { name: /browse/i }).click()
+
+  await expect(page.getByText("project onboarding notes")).toBeVisible({ timeout: 10_000 })
+
+  // Contract: the browse request must include a `layer` field.
+  expect(capturedListBody).toMatchObject({ layer: "Project" })
+  expect((capturedListBody as { limit?: number }).limit).toBeGreaterThan(0)
+})
+
+test("Memory search renders error state when backend returns 500", async ({ page, login }) => {
+  await login({
+    mocks: [
+      {
+        urlPattern: /\/api\/v1\/memory\/search$/,
+        method: "POST",
+        status: 500,
+        body: {
+          error: "memory_search_failed",
+          message: "vector store unreachable",
+        },
+      },
+    ],
+  })
+
+  await page.goto("/admin/memory")
+  await page.getByPlaceholder(/search memory entries/i).fill("hello world")
+  // The page has two "Search" buttons (view-mode toggle + form submit).
+  // Scope to the form to disambiguate.
+  await page.locator("form").getByRole("button", { name: /^search$/i }).click()
+
+  // The page renders a visible failure state with a retry affordance.
+  await expect(page.getByText(/search failed/i)).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByRole("button", { name: /retry/i })).toBeVisible()
+})

--- a/admin-ui/e2e/org-create.spec.ts
+++ b/admin-ui/e2e/org-create.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression test for #86 — org create schema drift.
+ *
+ * The bug: CreateOrgDialog sent `{ name, unit_type }`, but the backend
+ * expects `{ name, description?, companyId }` and validates the company.
+ * Result: three consecutive 422s on submit.
+ *
+ * These tests pin the correct wire contract:
+ *   1. When companies exist, submitting the form POSTs a body that
+ *      contains `companyId` and `name`, does NOT contain `unit_type`.
+ *   2. When no Company units exist, the Create button is disabled and
+ *      the amber hint is visible.
+ */
+import { test, expect } from "./fixtures"
+
+const COMPANY = {
+  id: "unit-company-01",
+  name: "Acme Holding",
+  unitType: "Company",
+  parentId: null,
+}
+
+test("Create Org dialog sends { name, companyId } and never unit_type", async ({
+  page,
+  login,
+}) => {
+  let capturedPost: { url: string; body: unknown } | null = null
+
+  await login({
+    mocks: [
+      {
+        urlPattern: /\/api\/v1\/org$/,
+        method: "GET",
+        body: [COMPANY],
+      },
+      {
+        urlPattern: /\/api\/v1\/org$/,
+        method: "POST",
+        handler: async (route) => {
+          capturedPost = {
+            url: route.request().url(),
+            body: route.request().postDataJSON(),
+          }
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              id: "unit-org-new",
+              name: "New Org",
+              unitType: "Organization",
+              parentId: COMPANY.id,
+            }),
+          })
+        },
+      },
+    ],
+  })
+
+  await page.goto("/admin/organizations")
+
+  // Wait for the tree to hydrate (the Company node renders its name).
+  await expect(page.getByText("Acme Holding")).toBeVisible({ timeout: 10_000 })
+
+  // Open the create dialog.
+  await page.getByRole("button", { name: /create org/i }).click()
+
+  const dialog = page.locator("role=dialog")
+    .or(page.locator("form").filter({ has: page.getByLabel("Name") }))
+
+  // The parent company select should be populated and defaulted.
+  const companySelect = page.getByLabel(/parent company/i)
+  await expect(companySelect).toBeVisible()
+  await expect(companySelect).toHaveValue(COMPANY.id)
+
+  // Fill the form and submit.
+  await page.getByLabel("Name").fill("New Org")
+  await page.getByLabel(/description/i).fill("Created by e2e test")
+  await page.getByRole("button", { name: /^create$/i }).click()
+
+  // Wait until the handler captured the POST.
+  await expect.poll(() => capturedPost, { timeout: 5_000 }).not.toBeNull()
+
+  // HARD contract assertions.
+  const body = (capturedPost as unknown as { body: Record<string, unknown> }).body
+  expect(body).toMatchObject({
+    name: "New Org",
+    companyId: COMPANY.id,
+    description: "Created by e2e test",
+  })
+  expect(body).not.toHaveProperty("unit_type")
+  expect(body).not.toHaveProperty("unitType")
+  // Ensure we did not send either bogus parent field.
+  expect(body).not.toHaveProperty("parentId")
+
+  // Dialog should close on success.
+  await expect(dialog).toBeHidden({ timeout: 5_000 })
+})
+
+test("Create Org dialog blocks submit when no Company units exist", async ({
+  page,
+  login,
+}) => {
+  await login({
+    mocks: [
+      {
+        urlPattern: /\/api\/v1\/org$/,
+        method: "GET",
+        body: [], // empty tree — no Company
+      },
+    ],
+  })
+
+  await page.goto("/admin/organizations")
+  await page.getByRole("button", { name: /create org/i }).click()
+
+  // Button is disabled.
+  const createBtn = page.getByRole("button", { name: /^create$/i })
+  await expect(createBtn).toBeDisabled()
+
+  // The amber hint text is shown.
+  await expect(page.getByText(/must be attached to a company/i)).toBeVisible()
+})

--- a/admin-ui/e2e/tenant-detail.spec.ts
+++ b/admin-ui/e2e/tenant-detail.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression test for #85 — TenantDetailPage envelope unwrap.
+ *
+ * The bug: `show_tenant` returns { success, tenant: {...} } but the page
+ * used `useQuery<TenantRecord>` directly, so `tenant.slug` was undefined
+ * and sub-tabs fetched `/api/v1/admin/tenants/undefined/*`. This test
+ * pins the correct behavior by asserting that:
+ *
+ *   1. No request is ever made to a URL containing `/tenants/undefined/`.
+ *   2. When the Config tab is opened, the request URL contains the real
+ *      slug from the envelope (`acme`).
+ */
+import { test, expect } from "./fixtures"
+
+const TENANT_ENVELOPE = {
+  success: true,
+  tenant: {
+    id: "tenant-acme-id",
+    slug: "acme",
+    name: "Acme Corp",
+    status: "Active",
+    sourceOwner: "Admin",
+    createdAt: 1_700_000_000,
+    updatedAt: 1_700_000_000,
+    deactivatedAt: null,
+  },
+}
+
+test("TenantDetailPage unwraps the envelope and never requests /tenants/undefined/*", async ({
+  page,
+  login,
+}) => {
+  // Track every request so we can assert URL hygiene at the end.
+  const requests: string[] = []
+  page.on("request", (req) => requests.push(req.url()))
+
+  await login({
+    mocks: [
+      // GET /api/v1/admin/tenants/:id → envelope
+      {
+        urlPattern: /\/api\/v1\/admin\/tenants\/[^/]+$/,
+        method: "GET",
+        body: TENANT_ENVELOPE,
+      },
+      // Config tab
+      {
+        urlPattern: /\/api\/v1\/admin\/tenants\/[^/]+\/config$/,
+        method: "GET",
+        body: { "memory.vectorStore.type": "qdrant" },
+      },
+      // Providers tab (may be prefetched by tab bar)
+      {
+        urlPattern: /\/api\/v1\/admin\/tenants\/[^/]+\/providers$/,
+        method: "GET",
+        body: [],
+      },
+      // Repository-binding tab
+      {
+        urlPattern: /\/api\/v1\/admin\/tenants\/[^/]+\/repository-binding$/,
+        method: "GET",
+        body: { binding: null },
+      },
+    ],
+  })
+
+  await page.goto("/admin/tenants/acme")
+
+  // Overview content proves the envelope was unwrapped correctly: if the
+  // unwrap had failed, tenant.name/tenant.slug would render as empty and
+  // these text nodes would not be on the page at all.
+  await expect(page.getByRole("heading", { name: "Acme Corp" })).toBeVisible({
+    timeout: 10_000,
+  })
+  // The slug appears in the overview definition list.
+  await expect(
+    page.getByRole("definition").filter({ hasText: /^acme$/ }),
+  ).toBeVisible()
+
+  // Open the Config tab, which is the one that triggered the undefined bug.
+  await page.getByRole("button", { name: /^config$/i }).click()
+
+  // Wait for the config fixture content to render (proves the tab
+  // successfully fetched AND parsed the response).
+  await expect(page.getByText("memory.vectorStore.type")).toBeVisible({
+    timeout: 10_000,
+  })
+
+  // HARD assertion: no request for the literal "undefined" path.
+  const undefinedCalls = requests.filter((u) => u.includes("/tenants/undefined/"))
+  expect(undefinedCalls, `Unexpected requests: ${undefinedCalls.join(", ")}`).toEqual([])
+
+  // Soft assertion: at least one correctly-slugged sub-tab call exists.
+  const slugCalls = requests.filter((u) => /\/tenants\/acme\/config(\?|$)/.test(u))
+  expect(slugCalls.length).toBeGreaterThan(0)
+})

--- a/admin-ui/eslint.config.js
+++ b/admin-ui/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'playwright-report', 'test-results', 'e2e']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.1.0",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
@@ -556,6 +557,21 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2829,6 +2845,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -10,7 +10,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:install": "playwright install chromium --with-deps"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.62.0",
@@ -24,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.1.0",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",

--- a/admin-ui/playwright.config.ts
+++ b/admin-ui/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from "@playwright/test"
+
+/**
+ * Playwright config for admin-ui e2e tests.
+ *
+ * Strategy: hermetic tests.
+ *   - `webServer` below boots Vite dev server on port 5173.
+ *   - Tests do NOT hit a real backend. Every network call is intercepted
+ *     with `page.route()` and answered by the test itself. This keeps the
+ *     suite fast, deterministic, and runnable in CI without any infra.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  timeout: 30_000,
+
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: {
+    command: "npm run dev -- --port 5173 --strictPort",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+})


### PR DESCRIPTION
Adds a hermetic Playwright e2e suite for the admin UI, with one spec per recently-shipped bug so none of them can silently come back.

## What

**Scaffolding**
- `admin-ui/playwright.config.ts` — chromium-only, auto-boots `vite` on `:5173` via `webServer`.
- `admin-ui/e2e/fixtures.ts` — `login()` fixture that seeds a fake non-expired token in `localStorage` (so `AuthContext` hydrates) and installs a default `/auth/session` mock. Callers layer extra mocks on top.
- `admin-ui/e2e/README.md` — philosophy, run/debug instructions, regression index, contribution guide.
- `.github/workflows/admin-ui-e2e.yml` — PR-gated workflow for `admin-ui/**`, caches `ms-playwright`, runs `tsc` + `playwright test`, uploads HTML report as an artifact.
- `package.json` scripts: `test:e2e`, `test:e2e:ui`, `test:e2e:install`.
- `eslint.config.js` / `.gitignore` housekeeping.

**No backend required.** Every HTTP call is intercepted with `page.route()` and answered with deterministic fixtures. The suite runs in ~6 s in any CI without infra dependencies.

## Regression specs

| Spec | Bug | Invariant pinned |
|------|-----|------------------|
| `tenant-detail.spec.ts` | #85 | No request ever hits `/tenants/undefined/*`; Config tab hits `/tenants/acme/config`. |
| `org-create.spec.ts` · test 1 | #86 | POST body matches `{ name, companyId, description? }`; never contains `unit_type` / `unitType` / `parentId`. |
| `org-create.spec.ts` · test 2 | #86 | When no Company units exist, Create is disabled and the amber hint is visible. |
| `memory-search.spec.ts` · test 1 | #87 | Browse POSTs a well-formed `{ layer, limit }` to `/memory/list`. |
| `memory-search.spec.ts` · test 2 | #87 | On 500 response, error state + Retry affordance render (pairs with the status-code fix in #89). |

## Local verification

```
$ cd admin-ui && npx playwright test --reporter=list
Running 5 tests using 5 workers
  ✓  5 passed (5.5s)
```

## Why hermetic

- Fast (seconds, not minutes).
- Deterministic — no flakes from timing, DB state, or cluster availability.
- Runs anywhere — CI, laptops, Codespaces — zero infra setup.
- Asserts the **contract** the frontend expects, not internal component state. Breaks loudly when either side of that contract drifts again, which is exactly what #85, #86, #87 were.

## Follow-ups (not in this PR)

- Add auth/login flow spec once the login UI stabilises.
- Add happy-path smoke for users and knowledge pages.
- Consider a separate project for cross-browser (webkit/firefox) when there's real ROI.