### PR TITLE
docs + ci: public/internal repo split policy + leak-guard (denylist loaded from outside the repo)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Scan the commit message itself after it's been written.
+set -euo pipefail
+REPO_ROOT=$(git rev-parse --show-toplevel)
+exec "$REPO_ROOT/scripts/leak-guard.sh" file "$1"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Pre-commit hook: runs the leak-guard against the staged diff + commit
+# message. Enable locally with:
+#
+#   git config core.hooksPath .githooks
+#
+# See docs/leak-guard.md for the denylist setup.
+set -euo pipefail
+REPO_ROOT=$(git rev-parse --show-toplevel)
+exec "$REPO_ROOT/scripts/leak-guard.sh" staged

--- a/.github/workflows/admin-ui-e2e.yml
+++ b/.github/workflows/admin-ui-e2e.yml
@@ -1,0 +1,57 @@
+name: admin-ui e2e
+
+on:
+  pull_request:
+    paths:
+      - 'admin-ui/**'
+      - '.github/workflows/admin-ui-e2e.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'admin-ui/**'
+      - '.github/workflows/admin-ui-e2e.yml'
+
+jobs:
+  playwright:
+    name: Playwright (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: admin-ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: admin-ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('admin-ui/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Run e2e tests
+        run: npx playwright test
+        env:
+          CI: '1'
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: admin-ui/playwright-report
+          retention-days: 14

--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -1,0 +1,61 @@
+name: leak-guard
+
+on:
+  pull_request:
+  push:
+    branches: [master, main]
+
+concurrency:
+  group: leak-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Determine scan range
+        id: range
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "base=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # On fork PRs, secrets.LEAK_PATTERNS is empty. We still run the
+      # generic-shape scan; the project-specific scan is skipped with
+      # a warning (fork contributors don't have access to internal
+      # names anyway).
+      - name: Leak-guard (diff + commit messages)
+        env:
+          AETERNA_GUARD_PATTERNS: ${{ secrets.LEAK_PATTERNS }}
+          # On same-repo pushes/PRs require strict mode (fail if secret
+          # is missing). On fork PRs the secret will be empty, so keep
+          # non-strict there to avoid false positives on community PRs.
+          AETERNA_GUARD_STRICT: ${{ secrets.LEAK_PATTERNS != '' && '1' || '0' }}
+        run: |
+          ./scripts/leak-guard.sh diff "${{ steps.range.outputs.base }}" "${{ steps.range.outputs.head }}"
+
+      - name: Leak-guard (PR title + body)
+        if: github.event_name == 'pull_request'
+        env:
+          AETERNA_GUARD_PATTERNS: ${{ secrets.LEAK_PATTERNS }}
+          AETERNA_GUARD_STRICT: ${{ secrets.LEAK_PATTERNS != '' && '1' || '0' }}
+          AETERNA_GUARD_SKIP_GITLEAKS: '1'
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" | ./scripts/leak-guard.sh text

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,65 @@
+# Leak-guard public ruleset.
+#
+# Only generic, shape-based detectors live in this file. The
+# project-specific denylist (environment names, internal hostnames,
+# tenant slugs, etc.) is NEVER checked in here — it is loaded at
+# scan time from a separate, private source (see docs/leak-guard.md).
+#
+# Inherit gitleaks' built-in rules (covers most cloud provider keys,
+# OAuth tokens, certificate material, connection strings, etc.).
+[extend]
+useDefault = true
+
+# ---- extra generic shape rules -----------------------------------
+
+[[rules]]
+id = "generic-pem-private-key"
+description = "PEM-encoded private key material"
+regex = '''-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY( BLOCK)?-----'''
+tags = ["key", "generic"]
+
+[[rules]]
+id = "generic-jwt"
+description = "Compact-serialised JWT"
+regex = '''\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b'''
+tags = ["token", "generic"]
+
+[[rules]]
+id = "generic-cloud-arn"
+description = "Cloud resource ARN / URN shape"
+regex = '''\barn:[a-z0-9-]+:[a-z0-9-]*:[a-z0-9-]*:\d{4,}:[^\s"']+'''
+tags = ["infra", "generic"]
+
+[[rules]]
+id = "generic-non-doc-ipv4"
+description = "IPv4 address outside RFC 5737 documentation ranges"
+# Matches any IPv4; allowlist below excludes 0.0.0.0, 127.0.0.0/8,
+# 10.0.0.0/8 localhost-ish defaults, documentation ranges, and
+# 255.255.255.255. The goal is to block leaking specific production
+# hosts; internal RFC1918 in dev config is permitted.
+regex = '''\b((?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b'''
+[rules.allowlist]
+regexTarget = "match"
+regexes = [
+  '''^0\.0\.0\.0$''',
+  '''^127(\.\d{1,3}){3}$''',
+  '''^10(\.\d{1,3}){3}$''',
+  '''^192\.168(\.\d{1,3}){2}$''',
+  '''^172\.(1[6-9]|2\d|3[0-1])(\.\d{1,3}){2}$''',
+  # RFC 5737 documentation blocks
+  '''^192\.0\.2(\.\d{1,3})?$''',
+  '''^198\.51\.100(\.\d{1,3})?$''',
+  '''^203\.0\.113(\.\d{1,3})?$''',
+  '''^255\.255\.255\.255$''',
+]
+
+# ---- global allowlist --------------------------------------------
+# Paths that are permitted to match generic rules (documentation,
+# this config itself, test fixtures).
+[allowlist]
+paths = [
+  '''^\.gitleaks\.toml$''',
+  '''^docs/leak-guard\.md$''',
+  '''^admin-ui/e2e/''',
+  '''(^|/)CHANGELOG\.md$''',
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,84 +6,87 @@ How AI agents interact with the Aeterna memory and knowledge framework.
 
 ## 🔴 HARD CONSTRAINT — Public vs Internal Repository Split
 
-**This repository (`kikokikok/aeterna`) is PUBLIC.** It is OSS code only.
+**This repository is a PUBLIC OSS codebase.** A **separate internal repository**
+owns everything related to deploying it on company infrastructure.
 
-A **separate internal repository** owns everything related to deploying Aeterna
-on Kyriba infrastructure. Agents MUST respect this split at all times — in
-code, configuration, commit messages, PR titles, PR bodies, issue bodies,
-review comments, filenames, and inline code comments.
+Agents MUST respect this split at all times — in code, configuration, commit
+messages, PR titles, PR bodies, issue bodies, review comments, filenames,
+and inline code comments and docstrings.
 
-### What MUST NEVER appear in this public repo
+### Categories that MUST NOT appear in this public repo
 
-- Internal environment / cluster identifiers (e.g. `ci-dev-NN`, `kyriba-eng`,
-  `prod-eu`, tenant-specific names)
-- Any `*.kyriba.io`, `*.kyriba.internal`, or other internal domains / hostnames
-- Internal IP ranges, VPC/subnet IDs, VPN endpoints
-- AWS account IDs, ARNs, S3 bucket names, RDS identifiers, EKS cluster names
-- Vault paths, KMS key IDs, IAM role names/ARNs
-- ArgoCD application names, Helm release names tied to specific environments
-- Namespace names, service account names, ingress hostnames for specific envs
-- Internal Jira/Confluence/Slack channel names, internal URLs
-- Customer names, tenant slugs, or any production data (even anonymised
-  without review)
-- References to internal incident IDs, ticket numbers, or runbooks
+No specific forbidden strings are enumerated here on purpose — listing them
+would itself be a leak. The **authoritative list** is maintained in the
+internal repo and enforced mechanically by the leak-guard (see below).
+Categorically, nothing from any of these classes belongs here:
+
+- Any identifier naming a specific company-operated environment, cluster,
+  namespace, tenant, customer, region, or availability zone
+- Any company-owned domain, hostname, subdomain, or private DNS zone
+- Any company-owned IP range, CIDR block, VPC/subnet identifier, or VPN
+  endpoint
+- Cloud account identifiers, resource ARNs/URNs, bucket names, database
+  identifiers, managed-cluster names
+- Secret-management paths, key-management identifiers, IAM role/policy
+  identifiers
+- GitOps/CD application names, release names, or pipeline identifiers tied
+  to specific environments
+- Internal ticket/incident identifiers, runbook names, internal URLs to
+  wikis/dashboards/observability tools
+- Production data of any kind, even if it looks anonymised
 
 ### What belongs in the INTERNAL repo instead
 
-- Helm values overlays per environment (`values-<env>.yaml`)
-- Terraform / Pulumi modules describing AWS/GCP resources
-- ArgoCD Application manifests pointing at specific clusters
-- Secret references (SealedSecrets, ExternalSecrets, SOPS)
-- Deployment runbooks, incident playbooks, on-call docs
-- Anything mentioning a specific Kyriba environment by name
+- Environment-specific Helm/Kustomize overlays
+- IaC (Terraform / Pulumi / CDK) describing real cloud resources
+- GitOps application manifests targeting real clusters
+- Secret references (SealedSecrets, ExternalSecrets, SOPS-encrypted files)
+- Runbooks, playbooks, on-call docs, incident post-mortems
+- Anything mentioning a real environment by name
 
-### What is OK in this public repo
+### What IS OK in this public repo
 
 - Generic, environment-agnostic code and configuration
-- Example/sample values files with placeholder hostnames
-  (`example.com`, `<your-host>`, `localhost`)
-- Generic terms: "the dev cluster", "a staging environment", "an internal
-  deployment" (no identifiers)
-- Fictional test fixtures (`acme`, `Acme Corp`, `test@example.com`)
+- Sample values files using placeholder hostnames drawn from IANA-reserved
+  examples (see RFC 2606 / RFC 5737)
+- Abstract wording ("a development environment", "the staging cluster",
+  "an internal deployment") — never bound to a specific real target
+- Fictional test fixtures that don't resemble anything real
 
-### Agent pre-commit checklist
+### Before any commit or PR
 
-Before running `git commit` or `gh pr create` in this repo, agents MUST
-verify that none of the material being introduced (diff + message + PR body)
-matches any of these patterns:
+Agents MUST, before `git commit` / `gh pr create`:
 
-```
-ci-dev-\d+          prod-\w+           staging-\w+
-\.kyriba\.           \.internal$
-\d+\.\d+\.\d+\.\d+   (non-documentation IPs)
-arn:aws:             AKIA[0-9A-Z]{16}   eyJ[A-Za-z0-9_-]{20,}
-```
+1. Run the leak-guard (see `docs/leak-guard.md`) against the staged diff
+   AND the commit message AND any PR/issue body drafted. This checks both
+   generic shape-based rules (committed in-repo) and a project-specific
+   denylist loaded from outside the repo.
+2. If anything matches, stop. Either scrub the draft or move the topic to
+   the internal repo. Do NOT commit first and "clean up later" — rewriting
+   public history is a partial mitigation, not a fix.
 
-If a genuine deployment topic needs to be tracked, the agent MUST:
+### Remediation if a leak does ship
 
-1. Stop the public commit/PR.
-2. Tell the user and ask whether the work should move to the internal repo.
-3. Scrub the draft before proceeding, or abandon it.
-
-### Remediation if a leak is committed
-
-- PR bodies/titles: `gh pr edit <n> --body-file <scrubbed.md>` — no history
-  rewrite needed, change is immediate.
-- Commit messages on a branch: `git rebase -i` + reword, then force-push.
+- PR bodies/titles: `gh pr edit <n> --body-file <scrubbed.md>` (immediate,
+  no history rewrite).
+- Commit messages on an unmerged branch: `git rebase -i` + reword,
+  force-push.
 - Commit messages already on `master`: `git filter-branch --msg-filter`
-  scoped to the affected commits + `git push --force-with-lease` after
-  human approval. Note: rewriting public history is loud and partially
-  ineffective (GitHub may still serve old SHAs via the events API and
-  third-party mirrors may retain them). Prevention > cure.
-- **Secrets** (tokens, keys, credentials): treat as rotated immediately —
-  rewriting history does NOT remove them from third-party caches. Rotate
-  the secret in its source system first, then clean up the repo.
+  scoped to the affected range, then `git push --force-with-lease` after
+  explicit human approval. This is loud and partial — GitHub retains
+  old SHAs via the events/timeline API, and third-party mirrors/archives
+  may have already captured the content. Prevention > cure.
+- **Credentials** (tokens, keys, passwords, session cookies): history
+  rewrites do not erase them from third-party caches. Rotate the credential
+  at its source system immediately; clean up the repo as a secondary step.
 
-### Code comments specifically
+### Code comments and docstrings
 
-Inline comments (`// ...`, `# ...`, `/* ... */`) and doc strings are part
-of the public surface of the repo and subject to all rules above. Do not
-leave "note to self" references to internal infra in source files.
+Inline comments and doc strings are part of the public surface and subject
+to every rule above. No "note to self" references to internal systems in
+source files.
+
+See `docs/leak-guard.md` for the enforcement mechanism (CI + local hook).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,89 @@ How AI agents interact with the Aeterna memory and knowledge framework.
 
 ---
 
+## 🔴 HARD CONSTRAINT — Public vs Internal Repository Split
+
+**This repository (`kikokikok/aeterna`) is PUBLIC.** It is OSS code only.
+
+A **separate internal repository** owns everything related to deploying Aeterna
+on Kyriba infrastructure. Agents MUST respect this split at all times — in
+code, configuration, commit messages, PR titles, PR bodies, issue bodies,
+review comments, filenames, and inline code comments.
+
+### What MUST NEVER appear in this public repo
+
+- Internal environment / cluster identifiers (e.g. `ci-dev-NN`, `kyriba-eng`,
+  `prod-eu`, tenant-specific names)
+- Any `*.kyriba.io`, `*.kyriba.internal`, or other internal domains / hostnames
+- Internal IP ranges, VPC/subnet IDs, VPN endpoints
+- AWS account IDs, ARNs, S3 bucket names, RDS identifiers, EKS cluster names
+- Vault paths, KMS key IDs, IAM role names/ARNs
+- ArgoCD application names, Helm release names tied to specific environments
+- Namespace names, service account names, ingress hostnames for specific envs
+- Internal Jira/Confluence/Slack channel names, internal URLs
+- Customer names, tenant slugs, or any production data (even anonymised
+  without review)
+- References to internal incident IDs, ticket numbers, or runbooks
+
+### What belongs in the INTERNAL repo instead
+
+- Helm values overlays per environment (`values-<env>.yaml`)
+- Terraform / Pulumi modules describing AWS/GCP resources
+- ArgoCD Application manifests pointing at specific clusters
+- Secret references (SealedSecrets, ExternalSecrets, SOPS)
+- Deployment runbooks, incident playbooks, on-call docs
+- Anything mentioning a specific Kyriba environment by name
+
+### What is OK in this public repo
+
+- Generic, environment-agnostic code and configuration
+- Example/sample values files with placeholder hostnames
+  (`example.com`, `<your-host>`, `localhost`)
+- Generic terms: "the dev cluster", "a staging environment", "an internal
+  deployment" (no identifiers)
+- Fictional test fixtures (`acme`, `Acme Corp`, `test@example.com`)
+
+### Agent pre-commit checklist
+
+Before running `git commit` or `gh pr create` in this repo, agents MUST
+verify that none of the material being introduced (diff + message + PR body)
+matches any of these patterns:
+
+```
+ci-dev-\d+          prod-\w+           staging-\w+
+\.kyriba\.           \.internal$
+\d+\.\d+\.\d+\.\d+   (non-documentation IPs)
+arn:aws:             AKIA[0-9A-Z]{16}   eyJ[A-Za-z0-9_-]{20,}
+```
+
+If a genuine deployment topic needs to be tracked, the agent MUST:
+
+1. Stop the public commit/PR.
+2. Tell the user and ask whether the work should move to the internal repo.
+3. Scrub the draft before proceeding, or abandon it.
+
+### Remediation if a leak is committed
+
+- PR bodies/titles: `gh pr edit <n> --body-file <scrubbed.md>` — no history
+  rewrite needed, change is immediate.
+- Commit messages on a branch: `git rebase -i` + reword, then force-push.
+- Commit messages already on `master`: `git filter-branch --msg-filter`
+  scoped to the affected commits + `git push --force-with-lease` after
+  human approval. Note: rewriting public history is loud and partially
+  ineffective (GitHub may still serve old SHAs via the events API and
+  third-party mirrors may retain them). Prevention > cure.
+- **Secrets** (tokens, keys, credentials): treat as rotated immediately —
+  rewriting history does NOT remove them from third-party caches. Rotate
+  the secret in its source system first, then clean up the repo.
+
+### Code comments specifically
+
+Inline comments (`// ...`, `# ...`, `/* ... */`) and doc strings are part
+of the public surface of the repo and subject to all rules above. Do not
+leave "note to self" references to internal infra in source files.
+
+---
+
 ## MCP Tools
 
 Aeterna exposes tools via the Model Context Protocol (MCP), defined in `tools/src/server.rs` and implemented across `tools/src/`. Tools are registered in the `ToolRegistry` and served over HTTP at `/mcp/*`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,14 @@
 # Aeterna — Claude Code Memory
 
-> **🔴 PUBLIC REPO — READ FIRST:** This repository is public OSS code only.
-> Everything related to deploying on Kyriba infrastructure lives in a
-> separate internal repository. **Never** introduce internal environment
-> names (e.g. `ci-dev-NN`), `*.kyriba.io` hostnames, AWS ARNs, cluster IDs,
-> tenant slugs, or similar identifiers into commits, PR bodies, issue
-> comments, or source-file comments here. See the full rulebook and
-> pre-commit checklist in [`AGENTS.md § Public vs Internal Repository
-> Split`](./AGENTS.md#-hard-constraint--public-vs-internal-repository-split).
+> **🔴 PUBLIC REPO — READ FIRST:** This is a public OSS codebase.
+> Everything related to deploying on real company infrastructure lives
+> in a separate internal repository. **Never** introduce identifiers
+> naming real environments, hostnames, cloud resources, tenants,
+> credentials, or any similar operational artefacts into commits,
+> PR/issue bodies, or source-file comments here. The full rulebook,
+> enforcement, and remediation recipe are in
+> [`AGENTS.md § Public vs Internal Repository Split`](./AGENTS.md#-hard-constraint--public-vs-internal-repository-split)
+> and the mechanical guard is documented in [`docs/leak-guard.md`](./docs/leak-guard.md).
 
 ## Project Purpose
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,14 @@
 # Aeterna — Claude Code Memory
 
+> **🔴 PUBLIC REPO — READ FIRST:** This repository is public OSS code only.
+> Everything related to deploying on Kyriba infrastructure lives in a
+> separate internal repository. **Never** introduce internal environment
+> names (e.g. `ci-dev-NN`), `*.kyriba.io` hostnames, AWS ARNs, cluster IDs,
+> tenant slugs, or similar identifiers into commits, PR bodies, issue
+> comments, or source-file comments here. See the full rulebook and
+> pre-commit checklist in [`AGENTS.md § Public vs Internal Repository
+> Split`](./AGENTS.md#-hard-constraint--public-vs-internal-repository-split).
+
 ## Project Purpose
 
 Universal Memory & Knowledge Framework for Enterprise AI Agent Systems. Provides hierarchical memory storage, governed organizational knowledge, and a pluggable adapter architecture for AI agents at scale (LangChain, AutoGen, CrewAI, OpenCode).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Aeterna provides hierarchical memory storage and governed organizational knowled
 > lives in a separate internal repository and must **never** be mentioned here — not in
 > code, commit messages, PR bodies, issues, or comments. See
 > [`AGENTS.md` § Public vs Internal Repository Split](./AGENTS.md#-hard-constraint--public-vs-internal-repository-split)
-> for the full rulebook and pre-commit checklist.
+> for the policy and [`docs/leak-guard.md`](./docs/leak-guard.md) for the enforcement
+> (CI + local pre-commit hook).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 Aeterna provides hierarchical memory storage and governed organizational knowledge for AI agents at scale. Built for companies deploying AI coding assistants, autonomous agents, and intelligent automation across hundreds of engineers and thousands of projects.
 
+> **Contributors & AI agents:** This repository is the **public OSS codebase**. Internal
+> deployment configuration (environment overlays, cluster manifests, secrets, runbooks)
+> lives in a separate internal repository and must **never** be mentioned here — not in
+> code, commit messages, PR bodies, issues, or comments. See
+> [`AGENTS.md` § Public vs Internal Repository Split](./AGENTS.md#-hard-constraint--public-vs-internal-repository-split)
+> for the full rulebook and pre-commit checklist.
+
 ---
 
 ## Why Aeterna?

--- a/admin-ui/.gitignore
+++ b/admin-ui/.gitignore
@@ -2,3 +2,8 @@ node_modules/
 dist/
 .env.local
 *.tsbuildinfo
+
+# Playwright
+/playwright-report/
+/test-results/
+/playwright/.cache/

--- a/admin-ui/e2e/README.md
+++ b/admin-ui/e2e/README.md
@@ -1,0 +1,49 @@
+# admin-ui end-to-end tests
+
+Hermetic Playwright regression suite for the Aeterna admin UI.
+
+## Philosophy
+
+- **No backend required.** Every test intercepts HTTP with `page.route()`
+  and returns deterministic fixtures. This keeps the suite fast (~seconds)
+  and runnable in any CI without infra dependencies.
+- **One bug → one spec.** Each file pins the behavior of a previously shipped
+  regression so it can't silently come back.
+- **Contract-level assertions.** Tests assert on the shape/URL of outbound
+  requests and the text/roles users see — not on internal component state.
+
+## Running
+
+```bash
+cd admin-ui
+npm ci
+npm run test:e2e:install   # one-time: download chromium
+npm run test:e2e           # headless
+npm run test:e2e:ui        # interactive UI mode
+npm run test:e2e -- --debug
+```
+
+The `webServer` in `playwright.config.ts` boots `npm run dev` on port 5173
+automatically. Set `CI=1` to enable retries and GitHub-Actions reporting.
+
+## Regression index
+
+| Spec                      | Issue / PR | Bug                                                                   |
+| ------------------------- | ---------- | --------------------------------------------------------------------- |
+| `tenant-detail.spec.ts`   | #85 / PR#85| TenantDetailPage fetched `/tenants/undefined/*` due to envelope leak. |
+| `org-create.spec.ts`      | #86 / PR#88| Create Org dialog sent `{ unit_type }` instead of `{ companyId }`.    |
+| `memory-search.spec.ts`   | #87 / PR#89| Memory handlers 502'd on internal errors; UI contract-pinned here.    |
+
+## Adding a new spec
+
+1. Create `<feature>.spec.ts` in this directory.
+2. `import { test, expect } from "./fixtures"`.
+3. Call `await login({ mocks: [...] })` before `page.goto()`.
+4. Prefer `getByRole` / `getByLabel` / `getByText` over brittle CSS locators.
+5. When asserting on an outbound request, prefer `handler` with
+   `route.request().postDataJSON()` over waiting for a global side-effect.
+
+## CI
+
+The GitHub Actions workflow `.github/workflows/admin-ui-e2e.yml` runs this
+suite on every PR touching `admin-ui/**`.

--- a/admin-ui/e2e/fixtures.ts
+++ b/admin-ui/e2e/fixtures.ts
@@ -1,0 +1,102 @@
+/**
+ * Playwright fixtures for admin-ui e2e tests.
+ *
+ * Provides a `login()` helper that pre-seeds localStorage with a fake
+ * JWT-ish token (so AuthContext hydrates as logged-in) and installs
+ * baseline API mocks via page.route(). Individual tests layer extra
+ * mocks on top.
+ *
+ * All tests are hermetic: no real backend is ever contacted.
+ */
+import { test as base, expect, type Page, type Route } from "@playwright/test"
+
+export interface ApiMock {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+  urlPattern: string | RegExp
+  status?: number
+  body?: unknown
+  /** Optional: fully custom handler if a static status/body isn't enough. */
+  handler?: (route: Route) => void | Promise<void>
+}
+
+export interface MockedSession {
+  userId?: string
+  userEmail?: string
+  tenants?: Array<{ id: string; slug: string; name: string; status?: string }>
+  isPlatformAdmin?: boolean
+}
+
+export function defaultSessionBody(session: MockedSession = {}) {
+  const tenants = session.tenants ?? [
+    { id: "tenant-acme-id", slug: "acme", name: "Acme Corp", status: "Active" },
+  ]
+  return {
+    user: {
+      id: session.userId ?? "user-test",
+      email: session.userEmail ?? "test@example.com",
+      displayName: "Test User",
+    },
+    tenants: tenants.map((t) => ({
+      id: t.id,
+      slug: t.slug,
+      name: t.name,
+      status: t.status ?? "Active",
+      sourceOwner: "Admin",
+      createdAt: 1_700_000_000,
+      updatedAt: 1_700_000_000,
+      deactivatedAt: null,
+    })),
+    roles: [],
+    is_platform_admin: session.isPlatformAdmin ?? true,
+  }
+}
+
+async function seedAuth(page: Page) {
+  await page.addInitScript(() => {
+    const now = Math.floor(Date.now() / 1000)
+    const tokens = {
+      access_token: "e2e-fake-access-token",
+      refresh_token: "e2e-fake-refresh-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+      stored_at: now,
+    }
+    localStorage.setItem("aeterna_tokens", JSON.stringify(tokens))
+  })
+}
+
+async function installMocks(page: Page, mocks: ApiMock[]) {
+  for (const mock of mocks) {
+    await page.route(mock.urlPattern, async (route) => {
+      if (mock.method && route.request().method() !== mock.method) {
+        await route.fallback()
+        return
+      }
+      if (mock.handler) {
+        await mock.handler(route)
+        return
+      }
+      await route.fulfill({
+        status: mock.status ?? 200,
+        contentType: "application/json",
+        body: JSON.stringify(mock.body ?? {}),
+      })
+    })
+  }
+}
+
+export const test = base.extend<{
+  login: (opts?: { session?: MockedSession; mocks?: ApiMock[] }) => Promise<void>
+}>({
+  login: async ({ page }, use) => {
+    await use(async ({ session, mocks } = {}) => {
+      await seedAuth(page)
+      await installMocks(page, [
+        { urlPattern: /\/api\/v1\/auth\/session$/, body: defaultSessionBody(session) },
+        ...(mocks ?? []),
+      ])
+    })
+  },
+})
+
+export { expect }

--- a/admin-ui/e2e/memory-search.spec.ts
+++ b/admin-ui/e2e/memory-search.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression test for #87 — memory API status codes.
+ *
+ * The bug was backend-side (handlers returning 502 for internal errors),
+ * but the UI regressions worth pinning are:
+ *
+ *   1. Browse mode issues POST /api/v1/memory/list with a valid
+ *      `{ layer, limit }` body (shape the backend actually parses).
+ *   2. Search mode issues POST /api/v1/memory/search with `{ query }`.
+ *   3. When the backend returns 500 with `{ error, message }`, the page
+ *      shows the error state + Retry button (doesn't blank out).
+ */
+import { test, expect } from "./fixtures"
+
+test("Memory browse issues a well-formed POST /memory/list", async ({ page, login }) => {
+  let capturedListBody: unknown = null
+
+  await login({
+    mocks: [
+      {
+        urlPattern: /\/api\/v1\/memory\/list$/,
+        method: "POST",
+        handler: async (route) => {
+          capturedListBody = route.request().postDataJSON()
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              items: [
+                {
+                  id: "mem-1",
+                  content: "project onboarding notes",
+                  layer: "Project",
+                  importanceScore: 0.42,
+                },
+              ],
+              total: 1,
+            }),
+          })
+        },
+      },
+    ],
+  })
+
+  await page.goto("/admin/memory")
+  await page.getByRole("button", { name: /browse/i }).click()
+
+  await expect(page.getByText("project onboarding notes")).toBeVisible({ timeout: 10_000 })
+
+  // Contract: the browse request must include a `layer` field.
+  expect(capturedListBody).toMatchObject({ layer: "Project" })
+  expect((capturedListBody as { limit?: number }).limit).toBeGreaterThan(0)
+})
+
+test("Memory search renders error state when backend returns 500", async ({ page, login }) => {
+  await login({
+    mocks: [
+      {
+        urlPattern: /\/api\/v1\/memory\/search$/,
+        method: "POST",
+        status: 500,
+        body: {
+          error: "memory_search_failed",
+          message: "vector store unreachable",
+        },
+      },
+    ],
+  })
+
+  await page.goto("/admin/memory")
+  await page.getByPlaceholder(/search memory entries/i).fill("hello world")
+  // The page has two "Search" buttons (view-mode toggle + form submit).
+  // Scope to the form to disambiguate.
+  await page.locator("form").getByRole("button", { name: /^search$/i }).click()
+
+  // The page renders a visible failure state with a retry affordance.
+  await expect(page.getByText(/search failed/i)).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByRole("button", { name: /retry/i })).toBeVisible()
+})

--- a/admin-ui/e2e/org-create.spec.ts
+++ b/admin-ui/e2e/org-create.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression test for #86 — org create schema drift.
+ *
+ * The bug: CreateOrgDialog sent `{ name, unit_type }`, but the backend
+ * expects `{ name, description?, companyId }` and validates the company.
+ * Result: three consecutive 422s on submit.
+ *
+ * These tests pin the correct wire contract:
+ *   1. When companies exist, submitting the form POSTs a body that
+ *      contains `companyId` and `name`, does NOT contain `unit_type`.
+ *   2. When no Company units exist, the Create button is disabled and
+ *      the amber hint is visible.
+ */
+import { test, expect } from "./fixtures"
+
+const COMPANY = {
+  id: "unit-company-01",
+  name: "Acme Holding",
+  unitType: "Company",
+  parentId: null,
+}
+
+test("Create Org dialog sends { name, companyId } and never unit_type", async ({
+  page,
+  login,
+}) => {
+  let capturedPost: { url: string; body: unknown } | null = null
+
+  await login({
+    mocks: [
+      {
+        urlPattern: /\/api\/v1\/org$/,
+        method: "GET",
+        body: [COMPANY],
+      },
+      {
+        urlPattern: /\/api\/v1\/org$/,
+        method: "POST",
+        handler: async (route) => {
+          capturedPost = {
+            url: route.request().url(),
+            body: route.request().postDataJSON(),
+          }
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              id: "unit-org-new",
+              name: "New Org",
+              unitType: "Organization",
+              parentId: COMPANY.id,
+            }),
+          })
+        },
+      },
+    ],
+  })
+
+  await page.goto("/admin/organizations")
+
+  // Wait for the tree to hydrate (the Company node renders its name).
+  await expect(page.getByText("Acme Holding")).toBeVisible({ timeout: 10_000 })
+
+  // Open the create dialog.
+  await page.getByRole("button", { name: /create org/i }).click()
+
+  const dialog = page.locator("role=dialog")
+    .or(page.locator("form").filter({ has: page.getByLabel("Name") }))
+
+  // The parent company select should be populated and defaulted.
+  const companySelect = page.getByLabel(/parent company/i)
+  await expect(companySelect).toBeVisible()
+  await expect(companySelect).toHaveValue(COMPANY.id)
+
+  // Fill the form and submit.
+  await page.getByLabel("Name").fill("New Org")
+  await page.getByLabel(/description/i).fill("Created by e2e test")
+  await page.getByRole("button", { name: /^create$/i }).click()
+
+  // Wait until the handler captured the POST.
+  await expect.poll(() => capturedPost, { timeout: 5_000 }).not.toBeNull()
+
+  // HARD contract assertions.
+  const body = (capturedPost as unknown as { body: Record<string, unknown> }).body
+  expect(body).toMatchObject({
+    name: "New Org",
+    companyId: COMPANY.id,
+    description: "Created by e2e test",
+  })
+  expect(body).not.toHaveProperty("unit_type")
+  expect(body).not.toHaveProperty("unitType")
+  // Ensure we did not send either bogus parent field.
+  expect(body).not.toHaveProperty("parentId")
+
+  // Dialog should close on success.
+  await expect(dialog).toBeHidden({ timeout: 5_000 })
+})
+
+test("Create Org dialog blocks submit when no Company units exist", async ({
+  page,
+  login,
+}) => {
+  await login({
+    mocks: [
+      {
+        urlPattern: /\/api\/v1\/org$/,
+        method: "GET",
+        body: [], // empty tree — no Company
+      },
+    ],
+  })
+
+  await page.goto("/admin/organizations")
+  await page.getByRole("button", { name: /create org/i }).click()
+
+  // Button is disabled.
+  const createBtn = page.getByRole("button", { name: /^create$/i })
+  await expect(createBtn).toBeDisabled()
+
+  // The amber hint text is shown.
+  await expect(page.getByText(/must be attached to a company/i)).toBeVisible()
+})

--- a/admin-ui/e2e/tenant-detail.spec.ts
+++ b/admin-ui/e2e/tenant-detail.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression test for #85 — TenantDetailPage envelope unwrap.
+ *
+ * The bug: `show_tenant` returns { success, tenant: {...} } but the page
+ * used `useQuery<TenantRecord>` directly, so `tenant.slug` was undefined
+ * and sub-tabs fetched `/api/v1/admin/tenants/undefined/*`. This test
+ * pins the correct behavior by asserting that:
+ *
+ *   1. No request is ever made to a URL containing `/tenants/undefined/`.
+ *   2. When the Config tab is opened, the request URL contains the real
+ *      slug from the envelope (`acme`).
+ */
+import { test, expect } from "./fixtures"
+
+const TENANT_ENVELOPE = {
+  success: true,
+  tenant: {
+    id: "tenant-acme-id",
+    slug: "acme",
+    name: "Acme Corp",
+    status: "Active",
+    sourceOwner: "Admin",
+    createdAt: 1_700_000_000,
+    updatedAt: 1_700_000_000,
+    deactivatedAt: null,
+  },
+}
+
+test("TenantDetailPage unwraps the envelope and never requests /tenants/undefined/*", async ({
+  page,
+  login,
+}) => {
+  // Track every request so we can assert URL hygiene at the end.
+  const requests: string[] = []
+  page.on("request", (req) => requests.push(req.url()))
+
+  await login({
+    mocks: [
+      // GET /api/v1/admin/tenants/:id → envelope
+      {
+        urlPattern: /\/api\/v1\/admin\/tenants\/[^/]+$/,
+        method: "GET",
+        body: TENANT_ENVELOPE,
+      },
+      // Config tab
+      {
+        urlPattern: /\/api\/v1\/admin\/tenants\/[^/]+\/config$/,
+        method: "GET",
+        body: { "memory.vectorStore.type": "qdrant" },
+      },
+      // Providers tab (may be prefetched by tab bar)
+      {
+        urlPattern: /\/api\/v1\/admin\/tenants\/[^/]+\/providers$/,
+        method: "GET",
+        body: [],
+      },
+      // Repository-binding tab
+      {
+        urlPattern: /\/api\/v1\/admin\/tenants\/[^/]+\/repository-binding$/,
+        method: "GET",
+        body: { binding: null },
+      },
+    ],
+  })
+
+  await page.goto("/admin/tenants/acme")
+
+  // Overview content proves the envelope was unwrapped correctly: if the
+  // unwrap had failed, tenant.name/tenant.slug would render as empty and
+  // these text nodes would not be on the page at all.
+  await expect(page.getByRole("heading", { name: "Acme Corp" })).toBeVisible({
+    timeout: 10_000,
+  })
+  // The slug appears in the overview definition list.
+  await expect(
+    page.getByRole("definition").filter({ hasText: /^acme$/ }),
+  ).toBeVisible()
+
+  // Open the Config tab, which is the one that triggered the undefined bug.
+  await page.getByRole("button", { name: /^config$/i }).click()
+
+  // Wait for the config fixture content to render (proves the tab
+  // successfully fetched AND parsed the response).
+  await expect(page.getByText("memory.vectorStore.type")).toBeVisible({
+    timeout: 10_000,
+  })
+
+  // HARD assertion: no request for the literal "undefined" path.
+  const undefinedCalls = requests.filter((u) => u.includes("/tenants/undefined/"))
+  expect(undefinedCalls, `Unexpected requests: ${undefinedCalls.join(", ")}`).toEqual([])
+
+  // Soft assertion: at least one correctly-slugged sub-tab call exists.
+  const slugCalls = requests.filter((u) => /\/tenants\/acme\/config(\?|$)/.test(u))
+  expect(slugCalls.length).toBeGreaterThan(0)
+})

--- a/admin-ui/eslint.config.js
+++ b/admin-ui/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'playwright-report', 'test-results', 'e2e']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.1.0",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
@@ -556,6 +557,21 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2829,6 +2845,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -10,7 +10,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:install": "playwright install chromium --with-deps"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.62.0",
@@ -24,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.1.0",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",

--- a/admin-ui/playwright.config.ts
+++ b/admin-ui/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from "@playwright/test"
+
+/**
+ * Playwright config for admin-ui e2e tests.
+ *
+ * Strategy: hermetic tests.
+ *   - `webServer` below boots Vite dev server on port 5173.
+ *   - Tests do NOT hit a real backend. Every network call is intercepted
+ *     with `page.route()` and answered by the test itself. This keeps the
+ *     suite fast, deterministic, and runnable in CI without any infra.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  timeout: 30_000,
+
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: {
+    command: "npm run dev -- --port 5173 --strictPort",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+})

--- a/docs/leak-guard.md
+++ b/docs/leak-guard.md
@@ -1,0 +1,122 @@
+# Leak-guard
+
+Mechanical enforcement of the public/internal repository split described
+in [`AGENTS.md` § Public vs Internal Repository Split](../AGENTS.md#-hard-constraint--public-vs-internal-repository-split).
+
+## Design
+
+Two independent checks, both against the staged diff, commit message,
+and (in CI) PR title/body:
+
+1. **Generic shape-based rules** — `.gitleaks.toml` at the repo root.
+   Covers cloud provider credentials, private keys, JWTs, cloud resource
+   ARNs, non-documentation IPv4 addresses, and everything the default
+   [gitleaks](https://github.com/gitleaks/gitleaks) ruleset catches. This
+   file is deliberately generic — it names no project-specific string.
+
+2. **Project denylist** — a list of regexes enumerating the identifiers
+   this project considers forbidden in public (environment names,
+   internal hostnames, tenant slugs, cluster identifiers, etc.). This
+   list is **never** committed to this repo. It lives in the internal
+   repository and is loaded at scan time from one of:
+
+   - `$AETERNA_GUARD_PATTERNS_FILE` — absolute path to a file on the
+     developer's machine, typically under `~/.config/aeterna/`.
+   - `$AETERNA_GUARD_PATTERNS` — inline patterns (one per line). Used
+     by the CI workflow to receive the list from a GitHub Actions
+     secret (`LEAK_PATTERNS`).
+
+   Format: one extended regular expression (ERE) per line. Lines
+   starting with `#` are comments; blank lines are ignored.
+
+When a match is found, the scanner prints the offending **line number**
+only, never the matched substring or the pattern. This keeps the failure
+message itself leak-free.
+
+## Local setup
+
+One-time:
+
+```bash
+# 1. Install gitleaks
+brew install gitleaks                # macOS
+# or: apt install gitleaks / see https://github.com/gitleaks/gitleaks
+
+# 2. Grab the project denylist from the internal repo and place it
+#    OUTSIDE this working tree (e.g. under your user config dir).
+mkdir -p ~/.config/aeterna
+# copy/download the file from the internal repo — do NOT paste its
+# contents anywhere that ends up in this repo.
+cp /path/to/internal-repo/leak-guard/patterns.txt ~/.config/aeterna/leak-patterns.txt
+chmod 600 ~/.config/aeterna/leak-patterns.txt
+
+# 3. Point the guard at it (add to your shell rc)
+echo 'export AETERNA_GUARD_PATTERNS_FILE=$HOME/.config/aeterna/leak-patterns.txt' >> ~/.zshrc
+
+# 4. Enable the hooks in this clone
+git config core.hooksPath .githooks
+```
+
+Verify:
+
+```bash
+./scripts/leak-guard.sh staged        # scans current staged diff
+```
+
+To require strict mode locally (fail instead of warn when the denylist
+isn't configured):
+
+```bash
+export AETERNA_GUARD_STRICT=1
+```
+
+## CI setup
+
+The `leak-guard` workflow runs on every push and PR. It expects a repo
+secret named `LEAK_PATTERNS` containing the denylist contents (copy the
+whole `patterns.txt` file into the secret value). Setting the secret is
+a one-time operation by a repo admin:
+
+```bash
+gh secret set LEAK_PATTERNS < /path/to/internal-repo/leak-guard/patterns.txt
+```
+
+On fork PRs the secret is unavailable by design — the generic scan still
+runs, and the project-specific scan is skipped with a warning.
+
+## Why the denylist is not here
+
+Writing the forbidden strings into a config file inside the public
+repo would defeat the purpose: the list itself would be the leak. The
+split above is load-bearing.
+
+## Authoring guidance for the denylist (internal repo)
+
+The internal `patterns.txt` should contain **regexes** — not literal
+strings — so one line catches many related identifiers. Example shape
+(the internal repo's README will show concrete entries):
+
+```
+# one regex per line, ERE
+^\s*(env-name-pattern-\d+)\s*$
+(?i)\binternal[-_]?project[-_]?name\b
+(?i)\.example-owned-domain\.tld\b
+```
+
+Keep each pattern:
+
+- Anchored or word-bounded (`\b`) to avoid false positives
+- Case-insensitive where the real identifier's case varies
+- Narrow enough that legitimate generic words (e.g. "prod", "staging",
+  "cluster") don't all trip it
+
+## Remediation on a match
+
+1. Scrub the draft and re-stage.
+2. If already committed locally, amend: `git commit --amend` after
+   fixing the content and the message.
+3. If already pushed, see [`AGENTS.md` § Remediation if a leak does
+   ship](../AGENTS.md#remediation-if-a-leak-does-ship).
+4. If a credential was matched, rotate it at its source system
+   immediately — history rewrites alone do not erase credentials from
+   third-party mirrors.

--- a/scripts/leak-guard.sh
+++ b/scripts/leak-guard.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# leak-guard.sh
+#
+# Runs two checks against a given scope (staged diff, commit range,
+# file, or PR/issue body text):
+#
+#   1. gitleaks with the in-repo .gitleaks.toml (generic shapes only).
+#   2. A project-specific denylist loaded from a private source.
+#      The denylist file is ONE regex per line (POSIX ERE), lines
+#      starting with '#' are comments, blank lines ignored. This file
+#      is NEVER stored in the public repo. Source priority:
+#
+#         a) $AETERNA_GUARD_PATTERNS_FILE (path to file outside repo)
+#         b) $AETERNA_GUARD_PATTERNS (patterns inline, one per line)
+#         c) GitHub Actions secret LEAK_PATTERNS (see CI workflow)
+#
+#      If none is configured, the project-specific scan is SKIPPED
+#      with a warning. CI is configured to fail instead of skipping;
+#      local dev defaults to warn-and-continue unless
+#      AETERNA_GUARD_STRICT=1.
+#
+# Exits non-zero on the first match. Never prints the pattern that
+# matched, only the offending path + line number. The matching line
+# itself is printed ONLY when --show-lines is passed.
+
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: leak-guard.sh <mode> [args...]
+
+Modes:
+  staged                       Scan the current git staged diff + HEAD commit message.
+  diff <base> <head>           Scan the diff between two refs.
+  file <path>                  Scan a single file's contents.
+  text                         Scan stdin as free text (use for PR/issue bodies).
+
+Environment:
+  AETERNA_GUARD_PATTERNS_FILE  Path to private denylist file (preferred).
+  AETERNA_GUARD_PATTERNS       Inline denylist (newline-separated).
+  AETERNA_GUARD_STRICT=1       Fail instead of warning when no denylist is configured.
+  AETERNA_GUARD_SKIP_GITLEAKS=1  Skip the gitleaks step (denylist only).
+USAGE
+}
+
+log()  { printf '[leak-guard] %s\n' "$*" >&2; }
+fail() { printf '[leak-guard] ❌ %s\n' "$*" >&2; exit 1; }
+warn() { printf '[leak-guard] ⚠️  %s\n' "$*" >&2; }
+
+[[ $# -ge 1 ]] || { usage >&2; exit 2; }
+MODE=$1; shift
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+# ---- prepare a temp file holding the payload to scan ------------
+PAYLOAD=$(mktemp -t leakguard.XXXXXX)
+trap 'rm -f "$PAYLOAD" "$PATTERNS_FILE_INTERNAL" 2>/dev/null || true' EXIT
+
+case "$MODE" in
+  staged)
+    git diff --cached > "$PAYLOAD"
+    # Also scan the prepared-commit-msg if the hook passes it.
+    if [[ -f "$REPO_ROOT/.git/COMMIT_EDITMSG" ]]; then
+      printf '\n--- commit message ---\n' >> "$PAYLOAD"
+      cat "$REPO_ROOT/.git/COMMIT_EDITMSG" >> "$PAYLOAD"
+    fi
+    ;;
+  diff)
+    [[ $# -eq 2 ]] || { usage >&2; exit 2; }
+    git diff "$1" "$2" > "$PAYLOAD"
+    git log --format='%B%n' "$1".. "$2" >> "$PAYLOAD" || true
+    ;;
+  file)
+    [[ $# -eq 1 ]] || { usage >&2; exit 2; }
+    cat "$1" > "$PAYLOAD"
+    ;;
+  text)
+    cat > "$PAYLOAD"
+    ;;
+  *)
+    usage >&2; exit 2
+    ;;
+esac
+
+# ---- step 1: gitleaks (generic shapes) --------------------------
+if [[ "${AETERNA_GUARD_SKIP_GITLEAKS:-0}" != "1" ]]; then
+  if command -v gitleaks >/dev/null 2>&1; then
+    if ! gitleaks detect \
+        --no-banner \
+        --redact \
+        --no-git \
+        --source="$PAYLOAD" \
+        --config="$REPO_ROOT/.gitleaks.toml" \
+        >/dev/null 2>&1; then
+      # Re-run with output visible so user sees redacted findings.
+      gitleaks detect --no-banner --redact --no-git \
+          --source="$PAYLOAD" \
+          --config="$REPO_ROOT/.gitleaks.toml" >&2 || true
+      fail "generic secret / shape match — scrub before committing"
+    fi
+  else
+    warn "gitleaks not installed; skipping generic-shape scan (install: https://github.com/gitleaks/gitleaks)"
+  fi
+fi
+
+# ---- step 2: project denylist (private, never in-repo) ----------
+PATTERNS_FILE_INTERNAL=""
+if [[ -n "${AETERNA_GUARD_PATTERNS_FILE:-}" && -r "$AETERNA_GUARD_PATTERNS_FILE" ]]; then
+  PATTERNS_FILE_INTERNAL=$AETERNA_GUARD_PATTERNS_FILE
+elif [[ -n "${AETERNA_GUARD_PATTERNS:-}" ]]; then
+  PATTERNS_FILE_INTERNAL=$(mktemp -t leakpatterns.XXXXXX)
+  printf '%s\n' "$AETERNA_GUARD_PATTERNS" > "$PATTERNS_FILE_INTERNAL"
+fi
+
+if [[ -z "$PATTERNS_FILE_INTERNAL" ]]; then
+  if [[ "${AETERNA_GUARD_STRICT:-0}" = "1" ]]; then
+    fail "no project denylist configured (set AETERNA_GUARD_PATTERNS_FILE or AETERNA_GUARD_PATTERNS); see docs/leak-guard.md"
+  fi
+  warn "no project denylist configured — generic scan ran, project-specific scan SKIPPED"
+  warn "(configure AETERNA_GUARD_PATTERNS_FILE per docs/leak-guard.md)"
+  exit 0
+fi
+
+# Strip comments / blanks and run grep with -f (patterns from file).
+# Output format: we deliberately do NOT echo the matched substring,
+# only the file-synthetic line number from the payload, so a leaking
+# commit message doesn't also echo its own leak on failure.
+CLEAN_PATTERNS=$(mktemp -t leakpatternsC.XXXXXX)
+grep -vE '^\s*(#|$)' "$PATTERNS_FILE_INTERNAL" > "$CLEAN_PATTERNS" || true
+trap 'rm -f "$PAYLOAD" "$PATTERNS_FILE_INTERNAL" "$CLEAN_PATTERNS" 2>/dev/null || true' EXIT
+
+if [[ ! -s "$CLEAN_PATTERNS" ]]; then
+  warn "denylist is empty after comment stripping; nothing to scan"
+  exit 0
+fi
+
+MATCH_COUNT=$(grep -cEHnf "$CLEAN_PATTERNS" "$PAYLOAD" 2>/dev/null | awk -F: '{n+=$2} END {print n+0}')
+# grep -c returns one count per input file; with a single file it's just that number.
+# Re-run to get the line numbers (without the matched content).
+if grep -nEf "$CLEAN_PATTERNS" "$PAYLOAD" >/dev/null 2>&1; then
+  LINES=$(grep -nEf "$CLEAN_PATTERNS" "$PAYLOAD" | awk -F: '{print $1}' | paste -sd',' -)
+  fail "project-denylist match(es) at payload line(s): $LINES — scrub before committing (the pattern itself is not printed on purpose)"
+fi
+
+log "✅ clean (generic + project denylist)"


### PR DESCRIPTION
## Context

The first revision of this PR codified the public/internal split in
`AGENTS.md` but listed the forbidden identifiers as *examples* — which
would have been a leak in the same file that forbids them. This revision
resolves that paradox end-to-end.

## What

### Policy (text)

- **`AGENTS.md`** — policy rewritten to describe forbidden material by
  **category only** (identifiers naming real environments, real hosts,
  real cloud resources, real tenants, credentials, etc.). No concrete
  internal string appears. Points readers at the mechanical guard for
  enforcement and at `docs/leak-guard.md` for the specifics.
- **`CLAUDE.md`** / **`README.md`** — banners simplified to the same
  abstract wording.

### Mechanical guard (enforcement)

Two independent checks, both against diff + commit message (and in CI,
PR title + body):

| Layer | What it catches | Config location |
|---|---|---|
| **Generic shapes** | Cloud credentials, private keys, JWTs, cloud ARNs, non-doc IPv4, default gitleaks ruleset | `.gitleaks.toml` (in-repo, public, names nothing specific) |
| **Project denylist** | Env names, internal hostnames, tenant slugs, cluster IDs, etc. — all the project-specific material | Loaded at scan time from `$AETERNA_GUARD_PATTERNS_FILE`, `$AETERNA_GUARD_PATTERNS`, or CI secret `LEAK_PATTERNS`. **Never checked in here.** |

New files:

- `.gitleaks.toml` — public config, generic only.
- `scripts/leak-guard.sh` — two-stage scanner with modes `staged`,
  `diff <base> <head>`, `file <path>`, `text` (stdin). On match prints
  only the payload line number, **not** the matched substring or the
  pattern — the failure message itself stays leak-free.
- `.githooks/pre-commit` + `.githooks/commit-msg` — thin hooks.
  Enable with `git config core.hooksPath .githooks`.
- `.github/workflows/leak-guard.yml` — runs on every push and PR. Uses
  the `LEAK_PATTERNS` Actions secret. Fork PRs (no secret access) still
  get the generic scan; project-specific scan is skipped with a warning.
- `docs/leak-guard.md` — design, local setup, CI setup, guidance for
  *authoring the denylist in the internal repo*, remediation recipe.

### Smoke test

```
$ AETERNA_GUARD_SKIP_GITLEAKS=1 \
  AETERNA_GUARD_PATTERNS=$'<regex-matching-the-bad-string>' \
  bash -c 'echo "<payload containing bad string>" | ./scripts/leak-guard.sh text'
[leak-guard] ❌ project-denylist match(es) at payload line(s): 1 — scrub before committing (the pattern itself is not printed on purpose)
exit 1
```

Clean payload exits 0.

## Follow-up for a repo admin

After merge, one-time setup:

```bash
gh secret set LEAK_PATTERNS < /path/to/internal-repo/leak-guard/patterns.txt
```

Then the CI workflow is fully armed. Local contributors follow
`docs/leak-guard.md` to wire up `core.hooksPath` and
`$AETERNA_GUARD_PATTERNS_FILE` against a file outside the working tree.
