### PR TITLE
fix(admin-ui): derive effective companyId instead of syncing via useEffect (unblocks CI)

### DIFF
--- a/admin-ui/src/pages/organizations/OrgTreePage.tsx
+++ b/admin-ui/src/pages/organizations/OrgTreePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { Network, ChevronRight, ChevronDown, Users, Plus, Loader2, X } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -78,16 +78,17 @@ function CreateOrgDialog({
   const queryClient = useQueryClient()
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
-  const [companyId, setCompanyId] = useState<string>("")
+  // User-overridden companyId. Empty string means "let the component pick the
+  // default". The actual value used at submit time is `companyId` below, which
+  // is derived (not synced) from `selectedCompanyId` + the available companies
+  // so we don't run into the `react-hooks/set-state-in-effect` anti-pattern.
+  const [selectedCompanyId, setSelectedCompanyId] = useState<string>("")
 
-  // Default-select the first company whenever the set of available companies
-  // changes (or the dialog re-opens). The backend requires `companyId` to
-  // reference an existing Company unit in the target tenant.
-  useEffect(() => {
-    if (open && !companyId && companies.length > 0) {
-      setCompanyId(companies[0].id)
-    }
-  }, [open, companyId, companies])
+  // Effective companyId: user choice if set, otherwise first available company.
+  // The backend requires `companyId` to reference an existing Company unit in
+  // the target tenant (see cli/src/server/org_api.rs::CreateOrgRequest).
+  const companyId =
+    selectedCompanyId || (companies.length > 0 ? companies[0].id : "")
 
   // Backend contract (cli/src/server/org_api.rs::CreateOrgRequest):
   //   { name: string, description?: string, companyId: string }
@@ -146,7 +147,7 @@ function CreateOrgDialog({
               <select
                 id="org-company"
                 value={companyId}
-                onChange={(e) => setCompanyId(e.target.value)}
+                onChange={(e) => setSelectedCompanyId(e.target.value)}
                 required
                 disabled={noCompanies}
                 className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-gray-100 disabled:text-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:disabled:bg-gray-800"


### PR DESCRIPTION
## Why

CI lint gate is currently failing on **every branch against master** (including #90 and #91) on a single lint error introduced by my PR #88:

```
/admin-ui/src/pages/organizations/OrgTreePage.tsx
  88:7  error  Calling setState synchronously within an effect can trigger cascading renders
                react-hooks/set-state-in-effect
```

The synced-state pattern shipped in #88 triggers a cascading render on every dialog open. The `react-hooks/set-state-in-effect` rule (enabled in this repo) exists to prevent exactly that — when the value can be computed during render, it should be derived, not synced.

## Fix

Replace the synced state with a derived value:

```ts
// before: synced via useEffect (lint error)
const [companyId, setCompanyId] = useState('')
useEffect(() => {
  if (open && !companyId && companies.length > 0) setCompanyId(companies[0].id)
}, [open, companyId, companies])

// after: derived each render (no effect, no cascading render)
const [selectedCompanyId, setSelectedCompanyId] = useState('')
const companyId = selectedCompanyId || companies[0]?.id || ''
```

- `selectedCompanyId` holds **only** the user's explicit choice.
- `companyId` is derived each render and read by the controlled `<select>`.
- `onChange` writes `setSelectedCompanyId(...)`.
- The now-unused `useEffect` import is removed.

## Verification

Local:
```
npm run lint                 # ✓
npx tsc --noEmit             # ✓
npx playwright test          # 5/5 passed (5.0s)
```

The #86 regression test (`org-create.spec.ts`) still passes — it asserts the exact POST body, so any behavioural regression in the defaulting would have broken it.

## Blast radius

- No wire-format change.
- No-Company-units UX from #86 (disabled Create + amber hint) unchanged.
- Once merged, #90 and #91 only need a rebase to go green.