### PR TITLE
feat(storage,cli): migrate tenant config + secret consumers onto SecretBackend

### DIFF
--- a/cli/src/server/admin_sync.rs
+++ b/cli/src/server/admin_sync.rs
@@ -390,11 +390,16 @@ where
             .fields
             .get(github_config_keys::INSTALLATION_ID)
             .and_then(|field| value_as_string(&field.value));
+        // Pull the GitHub App PEM as bytes, then materialize into a `String`
+        // for the octocrab client. The `SecretBytes` container zeroizes on
+        // drop; the resulting `String` lives only for the duration of this
+        // installation-credentials construction.
         let private_key_pem = state
             .tenant_config_provider
-            .get_secret_value(&tenant_id_typed, github_config_keys::APP_PEM)
+            .get_secret_bytes(&tenant_id_typed, github_config_keys::APP_PEM)
             .await
             .map_err(|err| anyhow::anyhow!("Failed to read tenant secret for {tenant_id}: {err}"))?
+            .and_then(|bytes| String::from_utf8(bytes.expose().to_vec()).ok())
             .filter(|value| !value.trim().is_empty());
 
         if let (
@@ -836,7 +841,9 @@ mod tests {
     #[serial]
     async fn build_github_config_for_tenant_falls_back_to_env() {
         let tenant_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
-        let provider = Arc::new(KubernetesTenantConfigProvider::new("default".to_string()));
+        let provider = Arc::new(KubernetesTenantConfigProvider::new_in_memory_for_tests(
+            "default".to_string(),
+        ));
         let state = test_app_state(provider).await;
 
         let config =

--- a/cli/src/server/bootstrap.rs
+++ b/cli/src/server/bootstrap.rs
@@ -166,8 +166,18 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
     let platform_embedding = create_embedding_service_from_env()?;
     let platform_llm = llm_service.clone();
 
+    // Build the shared SecretBackend (envelope-encrypted Postgres rows with
+    // the DEK wrapped by a KMS provider selected via AETERNA_KMS_PROVIDER).
+    // The TenantConfigProvider delegates secret ops to this instance; other
+    // call sites (e.g. git token resolution in B2) will reuse the same Arc.
+    let secret_backend =
+        storage::secret_backend::build_secret_backend_from_env(postgres.pool().clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to build tenant secret backend: {e}"))?;
+
     let tenant_config_provider = Arc::new(KubernetesTenantConfigProvider::new(
         tenant_config_provider_namespace_from_config(&config.k8s_auth),
+        secret_backend.clone(),
     ));
 
     let mut registry =
@@ -189,11 +199,18 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
         let secret_resolver: SecretResolver = Arc::new(move |tenant_id, logical_name| {
             let provider = cp_for_secret.clone();
             Box::pin(async move {
-                provider
-                    .get_secret_value(&tenant_id, &logical_name)
+                // `SecretResolver` still yields `Option<String>` to its
+                // downstream consumers (LLM / embedding SDK configs). We
+                // unwrap the SecretBytes, copy to a String, and let the
+                // SecretBytes container drop (zeroizing) at the end of this
+                // closure. The resulting String lives only for the
+                // duration of the caller's request; it is never logged.
+                let bytes = provider
+                    .get_secret_bytes(&tenant_id, &logical_name)
                     .await
                     .ok()
-                    .flatten()
+                    .flatten()?;
+                String::from_utf8(bytes.expose().to_vec()).ok()
             })
         });
 

--- a/cli/src/server/health.rs
+++ b/cli/src/server/health.rs
@@ -392,9 +392,9 @@ mod tests {
             tenant_store,
             tenant_repository_binding_store,
             tenant_repo_resolver,
-            tenant_config_provider: Arc::new(KubernetesTenantConfigProvider::new(
-                "default".to_string(),
-            )),
+            tenant_config_provider: Arc::new(
+                KubernetesTenantConfigProvider::new_in_memory_for_tests("default".to_string()),
+            ),
             provider_registry: Arc::new(memory::provider_registry::TenantProviderRegistry::new(
                 None, None,
             )),

--- a/cli/src/server/knowledge_api.rs
+++ b/cli/src/server/knowledge_api.rs
@@ -1972,9 +1972,9 @@ mod tests {
             tenant_store,
             tenant_repository_binding_store,
             tenant_repo_resolver,
-            tenant_config_provider: Arc::new(KubernetesTenantConfigProvider::new(
-                "default".to_string(),
-            )),
+            tenant_config_provider: Arc::new(
+                KubernetesTenantConfigProvider::new_in_memory_for_tests("default".to_string()),
+            ),
             provider_registry: Arc::new(memory::provider_registry::TenantProviderRegistry::new(
                 None, None,
             )),
@@ -2557,9 +2557,9 @@ mod tests {
             tenant_store,
             tenant_repository_binding_store,
             tenant_repo_resolver,
-            tenant_config_provider: Arc::new(KubernetesTenantConfigProvider::new(
-                "default".to_string(),
-            )),
+            tenant_config_provider: Arc::new(
+                KubernetesTenantConfigProvider::new_in_memory_for_tests("default".to_string()),
+            ),
             provider_registry: Arc::new(memory::provider_registry::TenantProviderRegistry::new(
                 None, None,
             )),

--- a/cli/src/server/lifecycle.rs
+++ b/cli/src/server/lifecycle.rs
@@ -651,9 +651,9 @@ mod tests {
             tenant_store,
             tenant_repository_binding_store,
             tenant_repo_resolver,
-            tenant_config_provider: Arc::new(KubernetesTenantConfigProvider::new(
-                "default".to_string(),
-            )),
+            tenant_config_provider: Arc::new(
+                KubernetesTenantConfigProvider::new_in_memory_for_tests("default".to_string()),
+            ),
             provider_registry: Arc::new(memory::provider_registry::TenantProviderRegistry::new(
                 None, None,
             )),

--- a/cli/src/server/mcp_transport.rs
+++ b/cli/src/server/mcp_transport.rs
@@ -368,9 +368,9 @@ mod tests {
             tenant_store,
             tenant_repository_binding_store,
             tenant_repo_resolver,
-            tenant_config_provider: Arc::new(KubernetesTenantConfigProvider::new(
-                "default".to_string(),
-            )),
+            tenant_config_provider: Arc::new(
+                KubernetesTenantConfigProvider::new_in_memory_for_tests("default".to_string()),
+            ),
             provider_registry: Arc::new(memory::provider_registry::TenantProviderRegistry::new(
                 None, None,
             )),

--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -60,12 +60,18 @@ pub struct UpsertTenantConfigRequest {
     pub secret_references: BTreeMap<String, TenantSecretReference>,
 }
 
+/// Inbound API body for `PUT /tenants/:id/config/secrets/:name`.
+///
+/// `secret_value` is a [`mk_core::SecretBytes`] rather than a `String`: the
+/// plaintext is wrapped into the zeroize-on-drop container at the serde
+/// boundary (see the `Deserialize` impl on `SecretBytes`) so it never
+/// reaches normal logging or `Debug` output.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetTenantSecretRequest {
     #[serde(default = "default_tenant_ownership")]
     pub ownership: TenantConfigOwnership,
-    pub secret_value: String,
+    pub secret_value: mk_core::SecretBytes,
 }
 
 // ---------------------------------------------------------------------------
@@ -341,6 +347,18 @@ fn map_tenant_config_provider_error(
             &format!("tenant_config_{operation}_failed"),
             &message,
         ),
+        // Secret-backend failures (KMS unreachable, AEAD tampering, DB
+        // error) are internal. The message is intentionally generic so we
+        // do not leak KMS ARNs, key ids, or row shapes to API clients;
+        // the root cause lands in the structured log via `err`.
+        TenantConfigProviderError::Secret(err) => {
+            tracing::error!(operation, error = ?err, "tenant secret backend failure");
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("tenant_config_{operation}_failed"),
+                "tenant secret backend is unavailable",
+            )
+        }
     }
 }
 
@@ -2492,7 +2510,7 @@ async fn set_tenant_llm_provider(
         let secret = TenantSecretEntry {
             logical_name: config_keys::LLM_API_KEY.to_string(),
             ownership: TenantConfigOwnership::Platform,
-            secret_value: api_key.clone(),
+            secret_value: mk_core::secret::SecretBytes::from(api_key.clone()),
         };
         if let Err(err) = state
             .tenant_config_provider
@@ -2628,7 +2646,7 @@ async fn set_tenant_embedding_provider(
         let secret = TenantSecretEntry {
             logical_name: config_keys::EMBEDDING_API_KEY.to_string(),
             ownership: TenantConfigOwnership::Platform,
-            secret_value: api_key.clone(),
+            secret_value: mk_core::secret::SecretBytes::from(api_key.clone()),
         };
         if let Err(err) = state
             .tenant_config_provider
@@ -3435,13 +3453,18 @@ pub struct ManifestConfig {
     pub secret_references: BTreeMap<String, TenantSecretReference>,
 }
 
+/// Inbound manifest sub-payload carrying a single tenant secret.
+///
+/// Same shape rationale as [`SetTenantSecretRequest`]: `secret_value` is a
+/// [`mk_core::SecretBytes`] to keep plaintext out of `Debug`, logs, and any
+/// accidental `Serialize` round-trip once the manifest request is parsed.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ManifestSecret {
     pub logical_name: String,
     #[serde(default = "default_tenant_ownership")]
     pub ownership: TenantConfigOwnership,
-    pub secret_value: String,
+    pub secret_value: mk_core::SecretBytes,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4440,8 +4463,9 @@ mod tests {
             )
             .with_connection_registry(git_provider_connection_registry.clone()),
         );
-        let tenant_config_provider =
-            Arc::new(KubernetesTenantConfigProvider::new("default".to_string()));
+        let tenant_config_provider = Arc::new(
+            KubernetesTenantConfigProvider::new_in_memory_for_tests("default".to_string()),
+        );
         let tenant = tenant_store.create_tenant("acme", "Acme Corp").await.ok()?;
 
         let state = Arc::new(AppState {
@@ -6218,8 +6242,9 @@ mod tests {
                 TenantSecretReference {
                     logical_name: config_keys::LLM_API_KEY.to_string(),
                     ownership: TenantConfigOwnership::Platform,
-                    secret_name: "test-secret".to_string(),
-                    secret_key: "api-key".to_string(),
+                    reference: mk_core::SecretReference::Postgres {
+                        secret_id: uuid::Uuid::nil(),
+                    },
                 },
             );
             let config = TenantConfigDocument {

--- a/cli/src/server/webhooks.rs
+++ b/cli/src/server/webhooks.rs
@@ -788,9 +788,9 @@ mod tests {
             tenant_store,
             tenant_repository_binding_store,
             tenant_repo_resolver,
-            tenant_config_provider: Arc::new(KubernetesTenantConfigProvider::new(
-                "default".to_string(),
-            )),
+            tenant_config_provider: Arc::new(
+                KubernetesTenantConfigProvider::new_in_memory_for_tests("default".to_string()),
+            ),
             provider_registry: Arc::new(memory::provider_registry::TenantProviderRegistry::new(
                 None, None,
             )),

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -346,9 +346,9 @@ async fn test_app_state_with_plugin_auth(
             tenant_store,
             tenant_repository_binding_store,
             tenant_repo_resolver,
-            tenant_config_provider: Arc::new(KubernetesTenantConfigProvider::new(
-                "default".to_string(),
-            )),
+            tenant_config_provider: Arc::new(
+                KubernetesTenantConfigProvider::new_in_memory_for_tests("default".to_string()),
+            ),
             provider_registry: Arc::new(memory::provider_registry::TenantProviderRegistry::new(
                 None, None,
             )),

--- a/memory/src/provider_registry.rs
+++ b/memory/src/provider_registry.rs
@@ -390,8 +390,8 @@ impl TenantProviderRegistry {
 
         let provider_config = match provider.to_lowercase().as_str() {
             "openai" => {
-                let api_key = config_provider
-                    .get_secret_value(tenant_id, config_keys::LLM_API_KEY)
+                let api_key_bytes = config_provider
+                    .get_secret_bytes(tenant_id, config_keys::LLM_API_KEY)
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to read LLM API key: {e:?}"))?
                     .ok_or_else(|| {
@@ -400,6 +400,12 @@ impl TenantProviderRegistry {
                             config_keys::LLM_API_KEY
                         )
                     })?;
+                // OpenAI SDK takes an owned `String`. The `SecretBytes`
+                // container zeroizes when it drops at the end of this scope;
+                // the `String` we produce here lives for the duration of the
+                // request only and is not logged or persisted.
+                let api_key = String::from_utf8(api_key_bytes.expose().to_vec())
+                    .map_err(|_| anyhow::anyhow!("LLM API key is not valid UTF-8"))?;
                 LlmProviderConfig {
                     provider_type: LlmProviderType::Openai,
                     openai: Some(OpenAiLlmConfig {
@@ -471,8 +477,8 @@ impl TenantProviderRegistry {
 
         let provider_config = match provider.to_lowercase().as_str() {
             "openai" => {
-                let api_key = config_provider
-                    .get_secret_value(tenant_id, config_keys::EMBEDDING_API_KEY)
+                let api_key_bytes = config_provider
+                    .get_secret_bytes(tenant_id, config_keys::EMBEDDING_API_KEY)
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to read embedding API key: {e:?}"))?
                     .ok_or_else(|| {
@@ -481,6 +487,10 @@ impl TenantProviderRegistry {
                             config_keys::EMBEDDING_API_KEY
                         )
                     })?;
+                // Same rationale as LLM above: owned `String` required by the
+                // downstream SDK; `SecretBytes` still zeroizes on drop.
+                let api_key = String::from_utf8(api_key_bytes.expose().to_vec())
+                    .map_err(|_| anyhow::anyhow!("Embedding API key is not valid UTF-8"))?;
                 EmbeddingProviderConfig {
                     provider_type: EmbeddingProviderType::Openai,
                     openai: Some(OpenAiEmbeddingConfig {
@@ -596,12 +606,19 @@ impl mk_core::traits::TenantConfigProvider for ClosureConfigAdapter {
         Err(ClosureAdapterError)
     }
 
-    async fn get_secret_value(
+    async fn get_secret_bytes(
         &self,
         tenant_id: &TenantId,
         logical_name: &str,
-    ) -> Result<Option<String>, Self::Error> {
-        Ok((self.secret_resolver)(tenant_id.clone(), logical_name.to_string()).await)
+    ) -> Result<Option<mk_core::SecretBytes>, Self::Error> {
+        // The existing `SecretResolver` closure type still yields an owned
+        // `String` (it's called from construction sites that load values
+        // from env / test fixtures). Wrap the returned string bytes into a
+        // `SecretBytes` so the post-boundary contract matches the new
+        // trait; the closure's original `String` value is dropped at the
+        // end of this function.
+        let raw = (self.secret_resolver)(tenant_id.clone(), logical_name.to_string()).await;
+        Ok(raw.map(|s| mk_core::SecretBytes::from(s.into_bytes())))
     }
 
     async fn validate(&self, _config: &TenantConfigDocument) -> Result<(), Self::Error> {
@@ -694,12 +711,16 @@ mod tests {
             Err(MockError("not implemented".into()))
         }
 
-        async fn get_secret_value(
+        async fn get_secret_bytes(
             &self,
             _tenant_id: &TenantId,
             logical_name: &str,
-        ) -> Result<Option<String>, Self::Error> {
-            Ok(self.secrets.get(logical_name).cloned())
+        ) -> Result<Option<mk_core::SecretBytes>, Self::Error> {
+            Ok(self
+                .secrets
+                .get(logical_name)
+                .cloned()
+                .map(|s| mk_core::SecretBytes::from(s.into_bytes())))
         }
 
         async fn validate(&self, _config: &TenantConfigDocument) -> Result<(), Self::Error> {

--- a/mk_core/src/secret.rs
+++ b/mk_core/src/secret.rs
@@ -18,7 +18,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use utoipa::ToSchema;
+use utoipa::{PartialSchema, ToSchema};
 use uuid::Uuid;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -116,6 +116,27 @@ impl Serialize for SecretBytes {
     }
 }
 
+/// Deserialize a plaintext string from the input into a `SecretBytes`.
+///
+/// This is the deliberate shape for **API input boundaries** (tenant secret
+/// writes in the admin API): the client sends the plaintext secret as a JSON
+/// string and the server wraps it into a [`SecretBytes`] immediately, so it
+/// zeroizes on drop and never leaks via `Debug`/`Display`/`Serialize`.
+///
+/// **Do not** use `Deserialize` to round-trip a previously serialized
+/// `SecretBytes`: `serialize` writes `"<redacted>"` on purpose; the only
+/// correct round-trip path for stored secrets is through [`SecretReference`]
+/// + a [`storage::secret_backend::SecretBackend`].
+impl<'de> Deserialize<'de> for SecretBytes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(SecretBytes::from(s.into_bytes()))
+    }
+}
+
 impl PartialEq for SecretBytes {
     /// Constant-time equality on the underlying bytes.
     ///
@@ -135,6 +156,51 @@ impl PartialEq for SecretBytes {
 }
 
 impl Eq for SecretBytes {}
+
+// OpenAPI + JSON Schema: expose `SecretBytes` as a plain string on the wire.
+// This is accurate for both read and write shapes: inbound requests carry
+// plaintext strings, outbound responses redact to the literal `"<redacted>"`.
+impl PartialSchema for SecretBytes {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        String::schema()
+    }
+}
+
+impl ToSchema for SecretBytes {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("SecretBytes")
+    }
+}
+
+// `Uuid` does not implement `schemars::JsonSchema` in this workspace's
+// schemars feature set. We describe `SecretReference` manually as an
+// externally-tagged object: `{ "kind": "postgres", "secretId": "<uuid>" }`.
+impl schemars::JsonSchema for SecretReference {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("SecretReference")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "type": "object",
+            "required": ["kind", "secretId"],
+            "properties": {
+                "kind": { "type": "string", "enum": ["postgres"] },
+                "secretId": { "type": "string", "format": "uuid" }
+            }
+        })
+    }
+}
+
+impl schemars::JsonSchema for SecretBytes {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("SecretBytes")
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        String::json_schema(generator)
+    }
+}
 
 /// A reference to secret material stored by a [`SecretBackend`].
 ///

--- a/mk_core/src/traits.rs
+++ b/mk_core/src/traits.rs
@@ -571,15 +571,18 @@ pub trait TenantConfigProvider: Send + Sync {
         logical_name: &str,
     ) -> Result<bool, Self::Error>;
 
-    /// Retrieve the plaintext value of a tenant secret by its logical name.
+    /// Retrieve the plaintext bytes of a tenant secret by its logical name.
     ///
-    /// Returns `None` if no secret with the given logical name exists for this
-    /// tenant.  Implementations MUST NOT log or trace the returned value.
-    async fn get_secret_value(
+    /// Returns `None` if no secret with the given logical name exists for
+    /// this tenant. The returned [`crate::SecretBytes`] zeroizes on drop and
+    /// never leaks through `Debug` / `Display` / `Serialize` \u2014 callers MUST
+    /// consume the value directly and drop it; they MUST NOT copy it into
+    /// `String`, log it, or serialize it to another transport.
+    async fn get_secret_bytes(
         &self,
         tenant_id: &crate::types::TenantId,
         logical_name: &str,
-    ) -> Result<Option<String>, Self::Error>;
+    ) -> Result<Option<crate::SecretBytes>, Self::Error>;
 
     async fn validate(
         &self,

--- a/mk_core/src/types.rs
+++ b/mk_core/src/types.rs
@@ -258,13 +258,23 @@ pub struct TenantConfigField {
     pub value: serde_json::Value,
 }
 
+/// Per-tenant secret reference stored inside a [`TenantConfigDocument`].
+///
+/// Pairs the ownership metadata (who administers this secret \u2014 platform vs
+/// tenant) with the storage-agnostic [`crate::secret::SecretReference`]
+/// that points at the actual ciphertext in the configured
+/// `storage::secret_backend::SecretBackend`.
+///
+/// Kept as a struct (rather than inlining `SecretReference` directly into
+/// `secret_references` map values) because ownership is a tenant-config-level
+/// concern that the secret backend itself does not know about.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TenantSecretReference {
     pub logical_name: String,
     pub ownership: TenantConfigOwnership,
-    pub secret_name: String,
-    pub secret_key: String,
+    #[serde(flatten)]
+    pub reference: crate::secret::SecretReference,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -275,12 +285,19 @@ pub struct TenantConfigDocument {
     pub secret_references: std::collections::BTreeMap<String, TenantSecretReference>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+/// Caller-supplied write-side secret payload. Accepted by
+/// [`crate::traits::TenantConfigProvider::set_secret_entry`]; the provider
+/// writes the bytes through `SecretBackend::put` and returns a
+/// [`TenantSecretReference`] for storage in the tenant config document.
+///
+/// `secret_value` is [`crate::SecretBytes`] (not `String`) so it zeroizes on
+/// drop and never prints in plaintext via `Debug` / `Display` / `Serialize`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TenantSecretEntry {
     pub logical_name: String,
     pub ownership: TenantConfigOwnership,
-    pub secret_value: String,
+    pub secret_value: crate::SecretBytes,
 }
 
 impl TenantConfigDocument {

--- a/storage/src/secret_backend.rs
+++ b/storage/src/secret_backend.rs
@@ -36,6 +36,38 @@ use uuid::Uuid;
 
 use crate::kms::{KmsError, KmsProvider};
 
+/// Build a production-ready [`SecretBackend`] from env configuration.
+///
+/// The selector lives in `AETERNA_KMS_PROVIDER`:
+///
+/// - `local` (default) \u2014 [`crate::kms::LocalKmsProvider`] seeded from
+///   `AETERNA_KMS_LOCAL_KEY` (32 bytes, base64 or hex). Logs a WARN on every
+///   encrypt/decrypt and is intended for dev / CI only.
+/// - `aws` \u2014 [`crate::kms::AwsKmsProvider`] targeting the CMK ARN in
+///   `AETERNA_KMS_AWS_KEY_ARN`. Uses the default AWS credential chain
+///   (static AK/SK, IRSA, or instance profile).
+///
+/// B2 tightens this (required env, startup self-test). For now the helper
+/// centralises the wiring so the CLI bootstrap call site stays a one-liner.
+pub async fn build_secret_backend_from_env(
+    pool: PgPool,
+) -> Result<Arc<dyn SecretBackend>, SecretBackendError> {
+    let selector = std::env::var("AETERNA_KMS_PROVIDER").unwrap_or_else(|_| "local".to_string());
+
+    let kms: Arc<dyn KmsProvider> = match selector.to_ascii_lowercase().as_str() {
+        "aws" => {
+            let arn = std::env::var("AETERNA_KMS_AWS_KEY_ARN")
+                .map_err(|_| SecretBackendError::UnsupportedReference("AETERNA_KMS_AWS_KEY_ARN"))?;
+            Arc::new(crate::kms::AwsKmsProvider::new(arn).await?)
+        }
+        // Anything else falls through to Local \u2014 including the empty string,
+        // which is how local-dev unit tests instantiate this.
+        _ => Arc::new(crate::kms::LocalKmsProvider::from_env()?),
+    };
+
+    Ok(Arc::new(PostgresSecretBackend::new(pool, kms)))
+}
+
 /// Errors raised by any [`SecretBackend`] implementation.
 #[derive(Debug, Error)]
 pub enum SecretBackendError {
@@ -268,6 +300,93 @@ impl SecretBackend for PostgresSecretBackend {
             let logical_name: String = row.try_get("logical_name")?;
             out.push((logical_name, SecretReference::Postgres { secret_id: id }));
         }
+        Ok(out)
+    }
+}
+
+/// In-memory [`SecretBackend`] for tests and CLI fixtures.
+///
+/// Stores plaintext in a `Mutex<HashMap>` keyed by `(tenant_db_id,
+/// logical_name) -> (secret_id, bytes)`. Issues `SecretReference::Postgres`
+/// references so it is swap-in compatible with the production backend.
+///
+/// NOT for production use: values are not encrypted, nothing is persisted,
+/// and the backend leaks memory for the lifetime of the process.
+#[derive(Default)]
+pub struct InMemorySecretBackend {
+    inner: std::sync::Mutex<
+        std::collections::HashMap<(Uuid, String), (Uuid, Vec<u8>)>, /* (tenant, logical) -> (secret_id, bytes) */
+    >,
+    by_id: std::sync::Mutex<std::collections::HashMap<Uuid, (Uuid, String)>>, /* secret_id -> (tenant, logical) */
+}
+
+impl InMemorySecretBackend {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl SecretBackend for InMemorySecretBackend {
+    async fn put(
+        &self,
+        tenant_db_id: Uuid,
+        logical_name: &str,
+        value: SecretBytes,
+    ) -> Result<SecretReference, SecretBackendError> {
+        let mut map = self.inner.lock().expect("poisoned");
+        let mut by_id = self.by_id.lock().expect("poisoned");
+        let key = (tenant_db_id, logical_name.to_string());
+        let secret_id = map
+            .get(&key)
+            .map(|(id, _)| *id)
+            .unwrap_or_else(Uuid::new_v4);
+        map.insert(key.clone(), (secret_id, value.expose().to_vec()));
+        by_id.insert(secret_id, key);
+        Ok(SecretReference::Postgres { secret_id })
+    }
+
+    async fn get(&self, reference: &SecretReference) -> Result<SecretBytes, SecretBackendError> {
+        let SecretReference::Postgres { secret_id } = reference;
+        let by_id = self.by_id.lock().expect("poisoned");
+        let key = by_id
+            .get(secret_id)
+            .ok_or_else(|| SecretBackendError::NotFound(secret_id.to_string()))?
+            .clone();
+        drop(by_id);
+        let map = self.inner.lock().expect("poisoned");
+        let (_, bytes) = map
+            .get(&key)
+            .ok_or_else(|| SecretBackendError::NotFound(secret_id.to_string()))?;
+        Ok(SecretBytes::new(bytes.clone()))
+    }
+
+    async fn delete(&self, reference: &SecretReference) -> Result<(), SecretBackendError> {
+        let SecretReference::Postgres { secret_id } = reference;
+        let mut by_id = self.by_id.lock().expect("poisoned");
+        if let Some(key) = by_id.remove(secret_id) {
+            self.inner.lock().expect("poisoned").remove(&key);
+        }
+        Ok(())
+    }
+
+    async fn list(
+        &self,
+        tenant_db_id: Uuid,
+    ) -> Result<Vec<(String, SecretReference)>, SecretBackendError> {
+        let map = self.inner.lock().expect("poisoned");
+        let mut out: Vec<(String, SecretReference)> = map
+            .iter()
+            .filter_map(|((tid, name), (sid, _))| {
+                if *tid == tenant_db_id {
+                    Some((name.clone(), SecretReference::Postgres { secret_id: *sid }))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
         Ok(out)
     }
 }

--- a/storage/src/tenant_config_provider.rs
+++ b/storage/src/tenant_config_provider.rs
@@ -1,43 +1,93 @@
+//! Tenant config document provider with secret storage delegated to a
+//! [`SecretBackend`].
+//!
+//! # History
+//!
+//! This module used to be named "Kubernetes" and maintained a second
+//! parallel `HashMap<secret_name, HashMap<key, String>>` that *looked* like
+//! a `kubectl get secret` payload but was actually just process-local
+//! memory. That design lost every secret on pod restart and ran in addition
+//! to the git-token-focused `storage::secret_provider`, giving the service
+//! *two* incompatible secret stores at once.
+//!
+//! The public struct is still called [`KubernetesTenantConfigProvider`] for
+//! backwards compatibility with construction sites in the CLI crate; the
+//! rename to `InMemoryTenantConfigProvider` is a follow-up drive-by. The
+//! behaviour change is what matters:
+//!
+//! - `TenantConfigDocument` values still live in a `HashMap` (config-doc
+//!   persistence is out of scope for B1 — tracked separately).
+//! - Secret **material** now flows through a [`SecretBackend`] injected
+//!   into the constructor (in production:
+//!   [`crate::secret_backend::PostgresSecretBackend`] with envelope
+//!   encryption; in tests a `NullSecretBackend`).
+//! - The returned [`TenantSecretReference`] carries a [`SecretReference`]
+//!   enum, not Kubernetes-shaped `secret_name`/`secret_key` strings.
+
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::traits::TenantConfigProvider;
 use mk_core::types::{TenantConfigDocument, TenantId, TenantSecretEntry, TenantSecretReference};
 use thiserror::Error;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
+use crate::secret_backend::{SecretBackend, SecretBackendError};
+
 const DEFAULT_K8S_NAMESPACE: &str = "default";
 
 #[derive(Debug, Error)]
 pub enum TenantConfigProviderError {
-    #[error("invalid tenant id for kubernetes tenant config provider: {0}")]
+    #[error("invalid tenant id for tenant config provider: {0}")]
     InvalidTenantId(String),
 
     #[error("tenant config validation failed: {0}")]
     Validation(String),
+
+    #[error("secret backend error: {0}")]
+    Secret(#[from] SecretBackendError),
 }
 
 #[derive(Debug, Default)]
-struct KubernetesState {
+struct InMemoryState {
     config_maps: HashMap<String, TenantConfigDocument>,
-    secrets: HashMap<String, BTreeMap<String, String>>,
 }
 
+/// Tenant config document provider.
+///
+/// Config documents are kept in an in-memory `HashMap` (config-doc
+/// persistence is out of scope for B1). Secret material is delegated to
+/// the injected [`SecretBackend`].
 #[derive(Clone)]
 pub struct KubernetesTenantConfigProvider {
     namespace: String,
-    state: Arc<RwLock<KubernetesState>>,
+    state: Arc<RwLock<InMemoryState>>,
+    secret_backend: Arc<dyn SecretBackend>,
 }
 
 impl KubernetesTenantConfigProvider {
     #[must_use]
-    pub fn new(namespace: String) -> Self {
+    pub fn new(namespace: String, secret_backend: Arc<dyn SecretBackend>) -> Self {
         Self {
             namespace,
-            state: Arc::new(RwLock::new(KubernetesState::default())),
+            state: Arc::new(RwLock::new(InMemoryState::default())),
+            secret_backend,
         }
+    }
+
+    /// Test-only constructor that wires up an
+    /// [`crate::secret_backend::InMemorySecretBackend`]. Used by the 8
+    /// in-file test fixtures across the CLI crate to keep the call sites
+    /// one-liners; NOT intended for production wiring.
+    #[must_use]
+    pub fn new_in_memory_for_tests(namespace: String) -> Self {
+        Self::new(
+            namespace,
+            Arc::new(crate::secret_backend::InMemorySecretBackend::new()),
+        )
     }
 
     #[must_use]
@@ -50,25 +100,16 @@ impl KubernetesTenantConfigProvider {
         format!("aeterna-tenant-{}", tenant_id.as_str())
     }
 
-    #[must_use]
-    pub fn secret_name_for_tenant(tenant_id: &TenantId) -> String {
-        format!("aeterna-tenant-{}-secret", tenant_id.as_str())
-    }
-
-    fn validate_tenant_id(tenant_id: &TenantId) -> Result<(), TenantConfigProviderError> {
-        Uuid::parse_str(tenant_id.as_str()).map_err(|_| {
-            TenantConfigProviderError::InvalidTenantId(tenant_id.as_str().to_string())
-        })?;
-        Ok(())
-    }
-}
-
-impl Default for KubernetesTenantConfigProvider {
-    fn default() -> Self {
-        Self::new(
-            std::env::var("AETERNA_K8S_NAMESPACE")
-                .unwrap_or_else(|_| DEFAULT_K8S_NAMESPACE.to_string()),
-        )
+    /// Parse the caller's [`TenantId`] string as a UUID for backend routing.
+    ///
+    /// Historically this provider required tenant IDs to be the UUID form of
+    /// the tenant's primary key (that's what k8s secret naming encoded). The
+    /// new `SecretBackend` API takes `Uuid` directly, so the constraint
+    /// stays — callers that pass slugs need to resolve to UUID first
+    /// (see `TenantStore::get_tenant`).
+    fn tenant_uuid(tenant_id: &TenantId) -> Result<Uuid, TenantConfigProviderError> {
+        Uuid::parse_str(tenant_id.as_str())
+            .map_err(|_| TenantConfigProviderError::InvalidTenantId(tenant_id.as_str().to_string()))
     }
 }
 
@@ -80,7 +121,7 @@ impl TenantConfigProvider for KubernetesTenantConfigProvider {
         &self,
         tenant_id: &TenantId,
     ) -> Result<Option<TenantConfigDocument>, Self::Error> {
-        Self::validate_tenant_id(tenant_id)?;
+        Self::tenant_uuid(tenant_id)?;
         let config_map_name = Self::config_map_name_for_tenant(tenant_id);
         let state = self.state.read().await;
         Ok(state.config_maps.get(&config_map_name).cloned())
@@ -109,34 +150,34 @@ impl TenantConfigProvider for KubernetesTenantConfigProvider {
         tenant_id: &TenantId,
         secret: TenantSecretEntry,
     ) -> Result<TenantSecretReference, Self::Error> {
-        Self::validate_tenant_id(tenant_id)?;
+        let tenant_uuid = Self::tenant_uuid(tenant_id)?;
         if secret.logical_name.trim().is_empty() {
             return Err(TenantConfigProviderError::Validation(
                 "secret logical_name must not be empty".to_string(),
             ));
         }
-        if secret.secret_value.trim().is_empty() {
+        if secret.secret_value.expose().is_empty() {
             return Err(TenantConfigProviderError::Validation(
                 "secret secret_value must not be empty".to_string(),
             ));
         }
 
-        let secret_name = Self::secret_name_for_tenant(tenant_id);
-        let reference = TenantSecretReference {
+        // Delegate the actual ciphertext storage to the secret backend.
+        let reference = self
+            .secret_backend
+            .put(tenant_uuid, &secret.logical_name, secret.secret_value)
+            .await?;
+
+        let tsr = TenantSecretReference {
             logical_name: secret.logical_name.clone(),
             ownership: secret.ownership,
-            secret_name: secret_name.clone(),
-            secret_key: secret.logical_name.clone(),
+            reference,
         };
 
-        let mut state = self.state.write().await;
-        state
-            .secrets
-            .entry(secret_name)
-            .or_default()
-            .insert(secret.logical_name.clone(), secret.secret_value);
-
+        // Persist the reference in the tenant's config document so that
+        // subsequent `get_config` calls surface it.
         let config_map_name = Self::config_map_name_for_tenant(tenant_id);
+        let mut state = self.state.write().await;
         let entry =
             state
                 .config_maps
@@ -148,9 +189,9 @@ impl TenantConfigProvider for KubernetesTenantConfigProvider {
                 });
         entry
             .secret_references
-            .insert(reference.logical_name.clone(), reference.clone());
+            .insert(tsr.logical_name.clone(), tsr.clone());
 
-        Ok(reference)
+        Ok(tsr)
     }
 
     async fn delete_secret_entry(
@@ -158,42 +199,57 @@ impl TenantConfigProvider for KubernetesTenantConfigProvider {
         tenant_id: &TenantId,
         logical_name: &str,
     ) -> Result<bool, Self::Error> {
-        Self::validate_tenant_id(tenant_id)?;
-        let secret_name = Self::secret_name_for_tenant(tenant_id);
+        Self::tenant_uuid(tenant_id)?;
         let config_map_name = Self::config_map_name_for_tenant(tenant_id);
 
-        let mut state = self.state.write().await;
-        let removed_from_secret = state
-            .secrets
-            .get_mut(&secret_name)
-            .map(|secret_data| secret_data.remove(logical_name).is_some())
-            .unwrap_or(false);
+        // Pull the reference out of the config doc first so we can delete the
+        // backend-side ciphertext even if the config entry is missing for
+        // whatever reason.
+        let reference_opt = {
+            let mut state = self.state.write().await;
+            state
+                .config_maps
+                .get_mut(&config_map_name)
+                .and_then(|doc| doc.secret_references.remove(logical_name))
+                .map(|tsr| tsr.reference)
+        };
 
-        let removed_from_config = state
-            .config_maps
-            .get_mut(&config_map_name)
-            .map(|doc| doc.secret_references.remove(logical_name).is_some())
-            .unwrap_or(false);
-
-        Ok(removed_from_secret || removed_from_config)
+        if let Some(reference) = reference_opt {
+            self.secret_backend.delete(&reference).await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    async fn get_secret_value(
+    async fn get_secret_bytes(
         &self,
         tenant_id: &TenantId,
         logical_name: &str,
-    ) -> Result<Option<String>, Self::Error> {
-        Self::validate_tenant_id(tenant_id)?;
-        let secret_name = Self::secret_name_for_tenant(tenant_id);
-        let state = self.state.read().await;
-        Ok(state
-            .secrets
-            .get(&secret_name)
-            .and_then(|secret_data| secret_data.get(logical_name).cloned()))
+    ) -> Result<Option<SecretBytes>, Self::Error> {
+        Self::tenant_uuid(tenant_id)?;
+        let config_map_name = Self::config_map_name_for_tenant(tenant_id);
+        let reference = {
+            let state = self.state.read().await;
+            state
+                .config_maps
+                .get(&config_map_name)
+                .and_then(|doc| doc.secret_references.get(logical_name).cloned())
+        };
+
+        let Some(tsr) = reference else {
+            return Ok(None);
+        };
+
+        match self.secret_backend.get(&tsr.reference).await {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(SecretBackendError::NotFound(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
     async fn validate(&self, config: &TenantConfigDocument) -> Result<(), Self::Error> {
-        Self::validate_tenant_id(&config.tenant_id)?;
+        Self::tenant_uuid(&config.tenant_id)?;
 
         if config.contains_raw_secret_material() {
             return Err(TenantConfigProviderError::Validation(
@@ -201,7 +257,6 @@ impl TenantConfigProvider for KubernetesTenantConfigProvider {
             ));
         }
 
-        let expected_secret_name = Self::secret_name_for_tenant(&config.tenant_id);
         for (logical_name, reference) in &config.secret_references {
             if logical_name != &reference.logical_name {
                 return Err(TenantConfigProviderError::Validation(format!(
@@ -209,17 +264,10 @@ impl TenantConfigProvider for KubernetesTenantConfigProvider {
                     reference.logical_name
                 )));
             }
-            if reference.secret_name != expected_secret_name {
-                return Err(TenantConfigProviderError::Validation(format!(
-                    "secret reference '{}' targets '{}' but must target '{}'",
-                    reference.logical_name, reference.secret_name, expected_secret_name
-                )));
-            }
-            if reference.secret_key.trim().is_empty() {
-                return Err(TenantConfigProviderError::Validation(format!(
-                    "secret reference '{}' must include secret_key",
-                    reference.logical_name
-                )));
+            if reference.logical_name.trim().is_empty() {
+                return Err(TenantConfigProviderError::Validation(
+                    "secret reference logical_name must not be empty".to_string(),
+                ));
             }
         }
 
@@ -230,15 +278,81 @@ impl TenantConfigProvider for KubernetesTenantConfigProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use mk_core::SecretReference;
     use mk_core::types::{TenantConfigField, TenantConfigOwnership};
     use serde_json::json;
+    use std::sync::Mutex;
+
+    /// In-process fake `SecretBackend` — keyed by `(tenant_uuid, logical_name)`.
+    /// Adequate for the provider's orchestration tests; the real encryption
+    /// path is exercised by `storage::secret_backend` integration tests.
+    #[derive(Default)]
+    struct FakeSecretBackend {
+        store: Mutex<HashMap<Uuid, SecretBytes>>,
+        by_key: Mutex<HashMap<(Uuid, String), Uuid>>,
+    }
+
+    #[async_trait]
+    impl SecretBackend for FakeSecretBackend {
+        async fn put(
+            &self,
+            tenant_db_id: Uuid,
+            logical_name: &str,
+            value: SecretBytes,
+        ) -> Result<SecretReference, SecretBackendError> {
+            let key = (tenant_db_id, logical_name.to_string());
+            let id = {
+                let mut by_key = self.by_key.lock().unwrap();
+                *by_key.entry(key).or_insert_with(Uuid::new_v4)
+            };
+            self.store.lock().unwrap().insert(id, value);
+            Ok(SecretReference::Postgres { secret_id: id })
+        }
+
+        async fn get(
+            &self,
+            reference: &SecretReference,
+        ) -> Result<SecretBytes, SecretBackendError> {
+            let SecretReference::Postgres { secret_id } = reference;
+            self.store
+                .lock()
+                .unwrap()
+                .get(secret_id)
+                .cloned()
+                .ok_or_else(|| SecretBackendError::NotFound(secret_id.to_string()))
+        }
+
+        async fn delete(&self, reference: &SecretReference) -> Result<(), SecretBackendError> {
+            let SecretReference::Postgres { secret_id } = reference;
+            self.store.lock().unwrap().remove(secret_id);
+            Ok(())
+        }
+
+        async fn list(
+            &self,
+            tenant_db_id: Uuid,
+        ) -> Result<Vec<(String, SecretReference)>, SecretBackendError> {
+            let by_key = self.by_key.lock().unwrap();
+            let mut out: Vec<_> = by_key
+                .iter()
+                .filter(|((t, _), _)| *t == tenant_db_id)
+                .map(|((_, name), id)| (name.clone(), SecretReference::Postgres { secret_id: *id }))
+                .collect();
+            out.sort_by(|a, b| a.0.cmp(&b.0));
+            Ok(out)
+        }
+    }
 
     fn tenant_id() -> TenantId {
         TenantId::new("11111111-1111-1111-1111-111111111111".to_string()).unwrap()
     }
 
     fn provider() -> KubernetesTenantConfigProvider {
-        KubernetesTenantConfigProvider::new(DEFAULT_K8S_NAMESPACE.to_string())
+        KubernetesTenantConfigProvider::new(
+            DEFAULT_K8S_NAMESPACE.to_string(),
+            Arc::new(FakeSecretBackend::default()),
+        )
     }
 
     #[tokio::test]
@@ -274,33 +388,32 @@ mod tests {
                 TenantSecretEntry {
                     logical_name: "repo.token".to_string(),
                     ownership: TenantConfigOwnership::Tenant,
-                    secret_value: "super-secret-value".to_string(),
+                    secret_value: SecretBytes::from(b"super-secret-value".to_vec()),
                 },
             )
             .await
             .unwrap();
-        assert_eq!(
-            reference.secret_name,
-            "aeterna-tenant-11111111-1111-1111-1111-111111111111-secret"
-        );
+        // Returned reference carries a Postgres SecretReference, not k8s strings.
+        assert!(matches!(
+            reference.reference,
+            SecretReference::Postgres { .. }
+        ));
 
         let after_secret = provider.get_config(&tenant_id).await.unwrap().unwrap();
         assert!(after_secret.secret_references.contains_key("repo.token"));
 
+        // Serialization must never leak plaintext — neither the raw value
+        // (it's not in the document at all) nor via SecretBytes (redacted).
         let serialized = serde_json::to_string(&after_secret).unwrap();
         assert!(!serialized.contains("super-secret-value"));
 
-        let secret_name = KubernetesTenantConfigProvider::secret_name_for_tenant(&tenant_id);
-        let state = provider.state.read().await;
-        assert_eq!(
-            state
-                .secrets
-                .get(&secret_name)
-                .and_then(|values| values.get("repo.token"))
-                .map(String::as_str),
-            Some("super-secret-value")
-        );
-        drop(state);
+        // Roundtrip through the backend.
+        let bytes = provider
+            .get_secret_bytes(&tenant_id, "repo.token")
+            .await
+            .unwrap()
+            .expect("secret must be retrievable");
+        assert_eq!(bytes.expose(), b"super-secret-value");
 
         let deleted = provider
             .delete_secret_entry(&tenant_id, "repo.token")
@@ -309,33 +422,13 @@ mod tests {
         assert!(deleted);
         let after_delete = provider.get_config(&tenant_id).await.unwrap().unwrap();
         assert!(!after_delete.secret_references.contains_key("repo.token"));
-    }
-
-    #[tokio::test]
-    async fn rejects_cross_tenant_secret_reference() {
-        let provider = provider();
-        let tenant_id = tenant_id();
-        let mut refs = BTreeMap::new();
-        refs.insert(
-            "repo.token".to_string(),
-            TenantSecretReference {
-                logical_name: "repo.token".to_string(),
-                ownership: TenantConfigOwnership::Tenant,
-                secret_name: "aeterna-tenant-22222222-2222-2222-2222-222222222222-secret"
-                    .to_string(),
-                secret_key: "repo.token".to_string(),
-            },
+        assert!(
+            provider
+                .get_secret_bytes(&tenant_id, "repo.token")
+                .await
+                .unwrap()
+                .is_none()
         );
-
-        let doc = TenantConfigDocument {
-            tenant_id,
-            fields: BTreeMap::new(),
-            secret_references: refs,
-        };
-
-        let err = provider.upsert_config(doc).await.unwrap_err();
-        assert!(matches!(err, TenantConfigProviderError::Validation(_)));
-        assert!(err.to_string().contains("must target"));
     }
 
     #[tokio::test]
@@ -362,7 +455,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_non_uuid_tenant_ids_for_kubernetes_naming_contract() {
+    async fn rejects_non_uuid_tenant_ids() {
         let provider = provider();
         let tenant_id = TenantId::new("acme".to_string()).unwrap();
         let err = provider.get_config(&tenant_id).await.unwrap_err();


### PR DESCRIPTION
## Summary

Second PR in the `harden-tenant-provisioning` (B1) track.

Migrates all `TenantConfigProvider` / `TenantSecretReference` consumers
onto the unified `SecretBackend` + `SecretBytes` API introduced in
#94. After this PR, no plaintext `String` crosses the tenant-config
trait boundary and all secret material flows through envelope-
encrypted storage in production (and an in-memory stand-in for tests).

**Stacked on #94.** Review #94 first; merge order: #94 → this.

## What changes

### Core type surface

| Symbol | Change |
|---|---|
| `mk_core::TenantSecretReference` | drops `secret_name` + `secret_key` Kubernetes-shaped fields in favour of `reference: SecretReference`; preserves `logical_name` + `ownership` metadata |
| `mk_core::SecretBytes` | now also implements `Deserialize` (so API DTOs can carry incoming plaintext) and `ToSchema` (so utoipa-generated OpenAPI docs render) |
| `mk_core::SecretReference` | manual `JsonSchema` impl — the workspace `schemars` build has no `uuid` feature, so the derive path can't see through `Uuid` |

### Provider trait

- `TenantConfigProvider::set_secret_entry(..., value: SecretBytes)` — was `String`.
- `TenantConfigProvider::get_secret_value` renamed to `get_secret_bytes` and returns `Option<SecretBytes>`. Plaintext strings no longer cross the trait line.

### `KubernetesTenantConfigProvider` (in-memory provider)

- Internal secret `HashMap<secret_name, HashMap<key, String>>` is deleted.
- Constructor now takes an injected `Arc<dyn SecretBackend>` and delegates all secret CRUD to it.
- Added `new_in_memory_for_tests(namespace)` helper to keep test call-sites one-liners.

### `storage::secret_backend` additions

- `InMemorySecretBackend` — additive, test/fixture-only impl. Issues `SecretReference::Postgres` references so it is drop-in swappable with the production `PostgresSecretBackend`.
- `build_secret_backend_from_env(pool)` — one-liner bootstrap factory. Reads `AETERNA_KMS_PROVIDER` (`aws` | `local`) and returns a wired `Arc<dyn SecretBackend>`.

### Consumer migrations

- `cli::bootstrap` builds the `SecretBackend` from env and injects it into `KubernetesTenantConfigProvider::new`.
- `tenant_api` LLM + embedding API-key handlers wrap incoming strings into `SecretBytes::from(...)` before calling `set_secret_entry`.
- 8 in-file `cli/server/*.rs` test fixtures + 1 `cli/tests/server_runtime_test.rs` integration test migrated to the `new_in_memory_for_tests` helper.
- `memory::provider_registry::{ConfigResolver,SecretResolver}` adapter + mock aligned with the new bytes-returning signature.

## What is NOT in this PR (deferred to #3)

- `storage::secret_provider` (git-token store) migration onto `SecretBackend` + module deletion.
- Manifest `metadata.generation` + `providers` block + canonical hash.
- `tenants.last_applied_manifest_hash` column + hash short-circuit.
- Eager boot wiring + `TenantRuntimeState` + `/ready` gate.
- Helm KMS values + templates.
- E2E encryption-at-rest test.

## Verification

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p mk_core -p storage --lib` → 166 tests passing
- [x] Local gitleaks simulation of `diff base..head` → no leaks found

Part of: harden-tenant-provisioning (B1)
