### PR TITLE
feat(helm): wire KMS selector + IRSA/static/local credentials for SecretBackend

### DIFF
--- a/charts/aeterna/templates/aeterna/deployment.yaml
+++ b/charts/aeterna/templates/aeterna/deployment.yaml
@@ -234,6 +234,34 @@ spec:
                   key: github-app-pem
                   optional: true
             {{- end }}
+            ## KMS / tenant-secret envelope encryption
+            - name: AETERNA_KMS_PROVIDER
+              value: {{ .Values.kms.provider | quote }}
+            {{- if eq .Values.kms.provider "aws" }}
+            {{- if not .Values.kms.aws.keyArn }}
+              {{- fail "kms.provider=aws requires kms.aws.keyArn to be set" }}
+            {{- end }}
+            - name: AETERNA_KMS_AWS_KEY_ARN
+              value: {{ .Values.kms.aws.keyArn | quote }}
+            {{- if eq .Values.kms.aws.auth "static" }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "kms.aws.existingSecret is required when kms.aws.auth=static" .Values.kms.aws.existingSecret }}
+                  key: {{ .Values.kms.aws.accessKeyIdKey | default "aws-access-key-id" }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.kms.aws.existingSecret }}
+                  key: {{ .Values.kms.aws.secretAccessKeyKey | default "aws-secret-access-key" }}
+            {{- end }}
+            {{- else if eq .Values.kms.provider "local" }}
+            - name: AETERNA_LOCAL_KMS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.kms.local.generate }}{{ include "aeterna.fullname" . }}-kms-local{{ else }}{{ required "kms.local.existingSecret is required when kms.local.generate=false" .Values.kms.local.existingSecret }}{{ end }}
+                  key: {{ .Values.kms.local.secretKey | default "kms-local-key" }}
+            {{- end }}
             - name: RUST_LOG
               value: {{ .Values.observability.logging.level | default "info" | quote }}
             - name: LOG_FORMAT

--- a/charts/aeterna/templates/aeterna/kms-local-secret.yaml
+++ b/charts/aeterna/templates/aeterna/kms-local-secret.yaml
@@ -1,0 +1,30 @@
+{{- if and (eq .Values.kms.provider "local") .Values.kms.local.generate -}}
+{{- /*
+Chart-owned, auto-generated local KMS key. Created once on first install
+and reused across upgrades (lookup keeps the original value so rotating
+the chart release does not corrupt existing ciphertext rows).
+
+For production, set kms.provider=aws. Local mode exists for development,
+CI, and disaster-recovery drills only.
+*/}}
+{{- $name := printf "%s-kms-local" (include "aeterna.fullname" .) -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $name -}}
+{{- $key := .Values.kms.local.secretKey | default "kms-local-key" -}}
+{{- $value := "" -}}
+{{- if and $existing (index $existing.data $key) -}}
+  {{- $value = index $existing.data $key -}}
+{{- else -}}
+  {{- $value = randAlphaNum 32 | b64enc -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "aeterna.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
+type: Opaque
+data:
+  {{ $key }}: {{ $value | quote }}
+{{- end }}

--- a/charts/aeterna/templates/aeterna/serviceaccount.yaml
+++ b/charts/aeterna/templates/aeterna/serviceaccount.yaml
@@ -5,9 +5,13 @@ metadata:
   name: {{ include "aeterna.serviceAccountName" . }}
   labels:
     {{- include "aeterna.labels" . | nindent 4 }}
-  {{- with .Values.aeterna.serviceAccount.annotations }}
+  {{- $saAnns := default dict .Values.aeterna.serviceAccount.annotations }}
+  {{- if and (eq .Values.kms.provider "aws") (eq .Values.kms.aws.auth "irsa") .Values.kms.aws.roleArn }}
+  {{- $saAnns = merge (dict "eks.amazonaws.com/role-arn" .Values.kms.aws.roleArn) $saAnns }}
+  {{- end }}
+  {{- if $saAnns }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $saAnns | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.aeterna.serviceAccount.automount }}
 {{- end }}

--- a/charts/aeterna/values.yaml
+++ b/charts/aeterna/values.yaml
@@ -361,6 +361,57 @@ tenantConfigProvider:
   enabled: true
   seedTenants: []
 
+## ==========================================================================
+## KMS (tenant-secret envelope encryption)
+## ==========================================================================
+## Drives storage::secret_backend::build_secret_backend_from_env. Every
+## `tenant_secrets` row is envelope-encrypted with a per-row DEK that is
+## wrapped by the configured CMK (aws) or a single in-process key (local).
+##
+## Maps to env vars:
+##   AETERNA_KMS_PROVIDER     (aws|local)
+##   AETERNA_KMS_AWS_KEY_ARN  (when provider=aws)
+##   AETERNA_LOCAL_KMS_KEY    (when provider=local; base64-encoded 32 bytes)
+##
+## Local provider emits a WARN on startup and is intended for
+## development, CI, and disaster-recovery only. Production deployments
+## MUST set kms.provider=aws.
+kms:
+  ## @param kms.provider KMS provider selector. One of: "aws" | "local".
+  provider: "local"
+
+  aws:
+    ## @param kms.aws.keyArn CMK ARN used to wrap tenant-secret DEKs.
+    ## Example: arn:aws:kms:<region>:<account-id>:key/<key-uuid>
+    ## Example: arn:aws:kms:<region>:<account-id>:alias/<alias-name>
+    keyArn: ""
+    ## @param kms.aws.auth Auth mode: "irsa" (default, uses pod SA
+    ## annotation) or "static" (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+    ## from existingSecret).
+    auth: "irsa"
+    ## IRSA: set on the aeterna ServiceAccount as
+    ## eks.amazonaws.com/role-arn. Required when auth=irsa.
+    ## @param kms.aws.roleArn IAM role ARN for IRSA (auth=irsa)
+    roleArn: ""
+    ## Static credentials path (auth=static). Never inline secrets here.
+    ## @param kms.aws.existingSecret Secret holding AWS credentials for auth=static
+    existingSecret: ""
+    ## @param kms.aws.accessKeyIdKey Key in existingSecret for the access key id
+    accessKeyIdKey: "aws-access-key-id"
+    ## @param kms.aws.secretAccessKeyKey Key in existingSecret for the secret access key
+    secretAccessKeyKey: "aws-secret-access-key"
+
+  local:
+    ## Local provider reads its key from an env var. Either let the chart
+    ## generate & stash a fresh key in a Secret (generate=true) or point at
+    ## an existing Secret that your operator manages out-of-band.
+    ## @param kms.local.generate Generate a random 32-byte key into a new chart-owned Secret
+    generate: true
+    ## @param kms.local.existingSecret Existing Secret name (used when generate=false)
+    existingSecret: ""
+    ## @param kms.local.secretKey Key inside the Secret holding the base64 key
+    secretKey: "kms-local-key"
+
 ## Plugin auth configuration
 ## Configures the OpenCode plugin authentication boundary (GitHub OAuth)
 pluginAuth:

--- a/storage/src/secret_backend.rs
+++ b/storage/src/secret_backend.rs
@@ -41,7 +41,7 @@ use crate::kms::{KmsError, KmsProvider};
 /// The selector lives in `AETERNA_KMS_PROVIDER`:
 ///
 /// - `local` (default) \u2014 [`crate::kms::LocalKmsProvider`] seeded from
-///   `AETERNA_KMS_LOCAL_KEY` (32 bytes, base64 or hex). Logs a WARN on every
+///   `AETERNA_LOCAL_KMS_KEY` (base64-encoded 32 bytes). Logs a WARN on every
 ///   encrypt/decrypt and is intended for dev / CI only.
 /// - `aws` \u2014 [`crate::kms::AwsKmsProvider`] targeting the CMK ARN in
 ///   `AETERNA_KMS_AWS_KEY_ARN`. Uses the default AWS credential chain


### PR DESCRIPTION
## Summary

Third PR in the `harden-tenant-provisioning` (B1) track. Ships the Helm
plumbing so operators can actually wire the `SecretBackend` (introduced
in #94) + consumer migration (in #95) against real AWS KMS.

**Stacked on #95 → #94.** Merge order: #94 → #95 → this.

Single knob: `kms.provider`. Everything downstream (SA annotation, env
vars, Secret creation, required-field validation) follows from that.

## Values surface

New top-level `kms:` block in `charts/aeterna/values.yaml`:

- `kms.provider` — `"aws"` | `"local"` (default: `"local"`)
- `kms.aws.keyArn` — CMK ARN, required when `provider=aws`
- `kms.aws.auth` — `"irsa"` (default) | `"static"`
- `kms.aws.roleArn` — IAM role ARN, annotates the ServiceAccount for IRSA
- `kms.aws.existingSecret` + `accessKeyIdKey` + `secretAccessKeyKey` — static mode
- `kms.local.generate` — auto-create a random 32-byte key Secret (default: `true`)
- `kms.local.existingSecret` + `secretKey` — externally-managed mode

## Deployment wiring

`templates/aeterna/deployment.yaml` now sets:

- `AETERNA_KMS_PROVIDER` (always)
- `AETERNA_KMS_AWS_KEY_ARN` + optional `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (aws + static)
- `AETERNA_LOCAL_KMS_KEY` from a `secretKeyRef` (local)

**Fail-closed:** `helm template` errors with a clear message if
`kms.provider=aws` without `keyArn`, or `kms.local.generate=false`
without `existingSecret`.

## ServiceAccount IRSA

`templates/aeterna/serviceaccount.yaml` merges the
`eks.amazonaws.com/role-arn: <kms.aws.roleArn>` annotation into any
user-supplied annotations when `provider=aws` + `auth=irsa`.

## Chart-owned local key Secret

New `templates/aeterna/kms-local-secret.yaml`:

- Renders only when `kms.provider=local` + `kms.local.generate=true`.
- Uses `lookup` + `helm.sh/resource-policy: keep` so the key survives
  chart upgrades — rotating the release will **not** corrupt existing
  ciphertext rows.
- Local mode stays dev/CI/DR only: the app itself already emits a WARN
  on every boot when `LocalKmsProvider` is in use.

## Drive-by

- Fixes stale doc-comment in `storage/src/secret_backend.rs` that named
  `AETERNA_KMS_LOCAL_KEY`. `LocalKmsProvider::from_env()` actually reads
  `AETERNA_LOCAL_KMS_KEY`; aligned both the doc and the Helm wiring on
  the real name.

## Verification

```
$ helm lint charts/aeterna
1 chart(s) linted, 0 chart(s) failed

$ helm template aeterna charts/aeterna --set kms.provider=local ...
  → renders kms-local-secret.yaml + AETERNA_LOCAL_KMS_KEY env

$ helm template aeterna charts/aeterna --set kms.provider=aws \
    --set kms.aws.keyArn=arn:... --set kms.aws.roleArn=arn:...
  → renders SA with eks.amazonaws.com/role-arn annotation
     + AETERNA_KMS_AWS_KEY_ARN env

$ helm template ... --set kms.provider=aws --set kms.aws.auth=static \
    --set kms.aws.existingSecret=my-aws
  → renders AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY envs

$ helm template ... --set kms.provider=aws  # no keyArn
  → Error: kms.provider=aws requires kms.aws.keyArn to be set

$ cargo check -p storage  → clean
```

## Still outstanding in B1 (future PRs)

- `storage::secret_provider` (legacy git-token store) migration onto
  `SecretBackend` + module deletion.
- Manifest `metadata.generation` + `providers` block + canonical hash.
- `tenants.last_applied_manifest_hash` column + hash short-circuit.
- Eager boot wiring + `TenantRuntimeState` + `/ready` gate.
- E2E encryption-at-rest test (Postgres + local KMS, then same flow
  against a real LocalStack KMS).

Part of: harden-tenant-provisioning (B1)
