### PR TITLE
docs(hygiene): fix broken links, main->master branch refs, stale values-file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ Aeterna addresses **93 production readiness gaps** identified across enterprise 
 **Prebuilt binary (recommended):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kikokikok/aeterna/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/kikokikok/aeterna/master/install.sh | sh
 ```
 
 Platforms: Linux `x86_64` / `aarch64` (gnu), macOS `x86_64` / `aarch64`. See the

--- a/docs/guides/cli-quick-reference.md
+++ b/docs/guides/cli-quick-reference.md
@@ -10,7 +10,7 @@ This is a concise cheat sheet. For detailed tenancy-management workflows, also s
 
 ```bash
 # Install latest supported release for your platform
-curl -fsSL https://raw.githubusercontent.com/kikokikok/aeterna/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/kikokikok/aeterna/master/install.sh | sh
 
 # Or build from source
 git clone https://github.com/kikokikok/aeterna.git
@@ -44,7 +44,7 @@ aeterna auth status --json
 
 | Step | Command |
 |------|---------|
-| Install CLI | `curl -fsSL https://raw.githubusercontent.com/kikokikok/aeterna/main/install.sh | sh` |
+| Install CLI | `curl -fsSL https://raw.githubusercontent.com/kikokikok/aeterna/master/install.sh | sh` |
 | Log in | `aeterna auth login --profile dev --server-url https://aeterna.example.com` |
 | Verify auth | `aeterna auth status --profile dev` |
 | Inspect config | `aeterna config show --profile dev` |

--- a/docs/guides/ha-deployment.md
+++ b/docs/guides/ha-deployment.md
@@ -1,6 +1,6 @@
 # High Availability Deployment Guide
 
-> **⚠️ Reference Only** — The primary supported production deployment path is the **Helm chart** documented in [`INSTALL.md`](../../INSTALL.md). The manifests referenced below (`infrastructure/ha/`) are supplementary reference configurations for operators who need to customize HA storage independently of the chart. The Helm chart already includes HA sizing presets (`values-production.yaml`, `values-large.yaml`) that configure replicas, PDBs, and anti-affinity for production use.
+> **⚠️ Reference Only** — The primary supported production deployment path is the **Helm chart** documented in the [Helm quickstart](../helm/quickstart-local.md) (or [`INSTALL.md`](https://github.com/kikokikok/aeterna/blob/master/INSTALL.md) on GitHub). The manifests referenced below (`infrastructure/ha/`) are supplementary reference configurations for operators who need to customize HA storage independently of the chart. The Helm chart already includes HA sizing presets (`values-large.yaml` for production, `values-medium.yaml` for staging) that configure replicas, PDBs, and anti-affinity for production use.
 
 ## Overview
 
@@ -20,7 +20,7 @@ The HA setup consists of the following components:
 - Kubernetes cluster with at least 3 nodes across multiple Availability Zones (AZs).
 - `kubectl` and `helm` installed and configured.
 - The `infrastructure/ha/` directory in the Aeterna repository contains the reference manifests.
-- **For most deployments**: Use the Helm chart with `values-production.yaml` or `values-large.yaml` instead of deploying these manifests directly.
+- **For most deployments**: Use the Helm chart with `values-large.yaml` (production sizing) or `values-medium.yaml` (staging sizing) instead of deploying these manifests directly.
 
 ## Component Configuration
 

--- a/website/docs/guides/tenant-admin-control-plane.md
+++ b/website/docs/guides/tenant-admin-control-plane.md
@@ -69,4 +69,4 @@ aeterna tenant connection grant acme --connection <id>
 
 For the repo version of this guide with the longer operator walkthrough, see:
 
-- [`docs/guides/tenant-admin-control-plane.md`](../../../docs/guides/tenant-admin-control-plane.md)
+- [`docs/guides/tenant-admin-control-plane.md`](https://github.com/kikokikok/aeterna/blob/master/docs/guides/tenant-admin-control-plane.md) on GitHub

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -42,7 +42,7 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           routeBasePath: 'docs',
           editUrl:
-            'https://github.com/kikokikok/aeterna/tree/main/website/',
+            'https://github.com/kikokikok/aeterna/tree/master/website/',
         },
         blog: false,
         theme: {


### PR DESCRIPTION
**Scope: doc-1 from the 2026-04-20 documentation review.**

Small, pure-hygiene changes. No content additions.

## What changes

| File | Change |
|---|---|
| `website/docusaurus.config.ts` | `editUrl` points to `tree/master/` instead of `tree/main/` — default branch is master, so every "Edit this page" button on the published site currently 404s |
| `README.md` + `docs/guides/cli-quick-reference.md` | install.sh curl URL `raw/main` → `raw/master` (3 occurrences) |
| `docs/guides/ha-deployment.md` | Broken `../../INSTALL.md` link replaced with a link to the published Helm quickstart plus a GitHub blob URL for the root-level `INSTALL.md` |
| `docs/guides/ha-deployment.md` | Dropped 2 references to the non-existent `values-production.yaml` (production preset is actually `values-large.yaml`) |
| `website/docs/guides/tenant-admin-control-plane.md` | Self-referential link that escaped the `docs/` tree replaced with GitHub blob URL |

## Verification

```
cd website && yarn build
# Before: [WARNING] Docusaurus found broken links! (2 links)
# After:  [SUCCESS] Generated static files in "build". (zero broken-link warnings)
```

## Context

First of four planned doc PRs stacking out of the full doc review. Next PR (`doc-2`) will add the missing SecretBackend / KMS / envelope-encryption pages needed for the B1 stack (#94/#95/#96).