### PR TITLE
docs(b1): add SecretBackend/KMS architecture + Helm + rotation guides

### DIFF
--- a/charts/aeterna/README.md
+++ b/charts/aeterna/README.md
@@ -355,6 +355,26 @@ kubectl create secret generic postgres-credentials \
   --from-literal=postgres-password='...'
 ```
 
+### Tenant-Secret Envelope Encryption (KMS)
+
+Tenant-scoped secrets stored in the `tenant_secrets` Postgres table are **envelope-encrypted**: every row carries its own AES-256-GCM data key, and the data keys are wrapped by the CMK you select via `kms.provider`.
+
+| Mode | `kms.provider` | Use |
+|---|---|---|
+| AWS KMS | `"aws"` | Production. Required when handling real tenant data. |
+| Local | `"local"` (default) | Development, CI, DR drills. Emits a `WARN` on every boot. |
+
+```yaml
+kms:
+  provider: "aws"
+  aws:
+    keyArn: "arn:aws:kms:<region>:<account-id>:alias/aeterna-tenant-secrets"
+    auth: "irsa"                                     # or "static"
+    roleArn: "arn:aws:iam::<account-id>:role/aeterna-kms"
+```
+
+The chart fails fast when required fields are missing (`kms.provider=aws` without `keyArn`, `auth=static` without `existingSecret`, `kms.local.generate=false` without `existingSecret`). Full operator reference: the **KMS** page in the docs site — `website/docs/helm/kms.md`.
+
 ## Multi-Tenant Administration
 
 Aeterna supports hierarchical multi-tenancy. Two administrative roles operate at distinct scopes:

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -390,6 +390,64 @@ PlatformAdmins can list resources across every tenant on the instance by passing
 
 ---
 
+## Tenant Secrets & KMS
+
+Tenant-scoped secret material (OpenAI keys, GitHub tokens, embedding-provider credentials) lives in the envelope-encrypted `tenant_secrets` Postgres table. Three layers back it:
+
+| Layer | Crate | Summary |
+|---|---|---|
+| `SecretBytes` + `SecretReference` | `mk_core::secret` | Zeroize-on-drop plaintext carrier + tagged enum reference |
+| `KmsProvider` (trait) + `AwsKmsProvider` / `LocalKmsProvider` | `storage::kms` | Wraps/unwraps per-row 32-byte DEKs |
+| `SecretBackend` (trait) + `PostgresSecretBackend` | `storage::secret_backend` | put/get/delete/list; AES-256-GCM rows + KMS-wrapped DEK |
+
+### In application code
+
+```rust
+use storage::secret_backend::build_secret_backend_from_env;
+use mk_core::SecretBytes;
+
+let backend = build_secret_backend_from_env(pool.clone()).await?;
+
+// write
+let reference = backend
+    .put(tenant_db_id, "openai-api-key", SecretBytes::from_string(api_key))
+    .await?;
+
+// read (plaintext is only alive inside `SecretBytes` — drop it promptly)
+let plaintext = backend.get(&reference).await?;
+client.set_api_key(plaintext.expose());
+drop(plaintext);
+```
+
+### In tests
+
+Prefer `InMemorySecretBackend` for unit tests; it avoids KMS and Postgres entirely. Integration tests that exercise the real path gate on `testcontainers` + Docker availability (see `storage/tests/secret_backend_integration.rs`).
+
+### Runtime configuration
+
+| Env | Meaning |
+|---|---|
+| `AETERNA_KMS_PROVIDER=aws\|local` | Selects KMS backend (default: `local`) |
+| `AETERNA_KMS_AWS_KEY_ARN` | CMK ARN when `provider=aws` |
+| `AETERNA_LOCAL_KMS_KEY` | Base64-encoded 32 bytes when `provider=local` |
+
+In Kubernetes these are all produced from the Helm `kms:` values block. See `website/docs/helm/kms.md`.
+
+### Don'ts
+
+- **Do not** `format!("{plaintext:?}")` or JSON-serialize a `SecretBytes` expecting the bytes to appear — they will always render as `<redacted>`. Use `.expose()` explicitly when bytes are actually needed.
+- **Do not** cache `SecretBytes` in a long-lived struct — the zeroize guarantee is undermined if the value outlives its use.
+- **Do not** invent new secret-bearing structs. If you need to persist something sensitive, store it through `SecretBackend` and hold a `SecretReference`.
+
+### Pointers
+
+- Concept page: `docs/architecture/secret-backend.md`
+- Operator Helm guide: `website/docs/helm/kms.md`
+- Rotation runbook: `docs/guides/secret-rotation.md`
+- Design decisions: `openspec/changes/harden-tenant-provisioning/design.md` (D1–D8)
+
+---
+
 ## Key Specs
 
 Before working on a specific area, read the relevant OpenSpec specification:

--- a/docs/architecture/secret-backend.md
+++ b/docs/architecture/secret-backend.md
@@ -1,0 +1,139 @@
+# Secret Backend & KMS Architecture
+
+> Status: implemented in [PR #94](https://github.com/kikokikok/aeterna/pull/94) / [PR #95](https://github.com/kikokikok/aeterna/pull/95) / [PR #96](https://github.com/kikokikok/aeterna/pull/96) (harden-tenant-provisioning B1). Design doc: [`openspec/changes/harden-tenant-provisioning/design.md`](https://github.com/kikokikok/aeterna/blob/master/openspec/changes/harden-tenant-provisioning/design.md).
+
+Aeterna stores tenant-scoped secrets — OpenAI keys, GitHub tokens, embedding-provider credentials — in Postgres with **envelope encryption**. Every row carries its own data encryption key (DEK), and the DEK is wrapped by a KMS-held customer master key (CMK).
+
+This page is the concept reference for the three layers that make it work: `SecretBytes`, `KmsProvider`, `SecretBackend`. For operator-facing configuration see the [Helm KMS guide](../helm/kms.md); for runbooks see [Secret Rotation](../guides/secret-rotation.md).
+
+## Why envelope encryption
+
+The naive alternative — encrypting every secret directly with a KMS `Encrypt` call — couples every read and write to a round-trip to the KMS. Envelope encryption decouples that:
+
+- The DEK is a one-time 32-byte symmetric key, generated per row.
+- Plaintext is sealed with AES-256-GCM using the DEK.
+- The DEK itself is wrapped by the CMK (one `Encrypt` call at write time, one `Decrypt` call at read time).
+- Rotating the CMK rewraps only the DEKs, never the ciphertext rows. Rotating a DEK re-encrypts only its row.
+
+Operational properties that fall out:
+
+| Property | Why it matters |
+|---|---|
+| CMK rotation is O(#rows) of network calls, but zero row rewrites | KMS rotates without touching Postgres |
+| A compromised DEK leaks exactly one secret | Blast radius bounded per-row |
+| AWS KMS `decrypt()` routes from the ciphertext blob's embedded key hint | We can retire old CMK versions without orphaning rows |
+| `PostgresSecretBackend` is the only code that sees plaintext DEKs; they are zeroized on both paths | Memory hygiene |
+
+## Layer 1 — `SecretBytes` + `SecretReference` (`mk_core`)
+
+```rust
+pub struct SecretBytes(Vec<u8>);          // zeroize-on-drop, redacted Debug/Display/Serialize
+
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum SecretReference {
+    Postgres { secret_id: Uuid },
+}
+```
+
+- `SecretBytes` is the in-memory carrier for *plaintext* secret material. Its `Debug`, `Display`, and `serde::Serialize` impls emit `<redacted>` so the material cannot leak through `tracing`, `format!`, or a JSON API response.
+- `SecretReference` is a **tagged enum** so future backends (cloud secret managers, Vault, etc.) land as additive variants. B1 ships only `Postgres`.
+
+Refer to `mk_core/src/secret.rs` for the full surface (constant-time `PartialEq`, `expose()`, `into_bytes()`).
+
+## Layer 2 — `KmsProvider` (`storage::kms`)
+
+```rust
+#[async_trait]
+pub trait KmsProvider: Send + Sync {
+    fn key_id(&self) -> &str;
+    async fn wrap(&self, dek: &[u8])       -> Result<Vec<u8>, KmsError>;
+    async fn unwrap(&self, wrapped: &[u8]) -> Result<SecretBytes, KmsError>;
+}
+```
+
+Two implementations:
+
+| Impl | Backing | Use |
+|---|---|---|
+| `AwsKmsProvider` | `aws-sdk-kms` against a real CMK ARN | **Production.** Default credential chain handles static AK/SK, IRSA, and EC2 instance profile transparently. |
+| `LocalKmsProvider` | AES-256-GCM with a key from `AETERNA_LOCAL_KMS_KEY` (base64 32 bytes) | **Dev / CI / DR drill only.** Emits `WARN: LocalKmsProvider in use …` on every encrypt and decrypt. |
+
+Design note (D4 in the design doc): `AwsKmsProvider::unwrap` deliberately **omits** `key_id`. AWS KMS routes decryption from the ciphertext blob itself, so rotating the CMK does not orphan existing rows.
+
+## Layer 3 — `SecretBackend` (`storage::secret_backend`)
+
+```rust
+#[async_trait]
+pub trait SecretBackend: Send + Sync + 'static {
+    async fn put   (&self, tenant_db_id: Uuid, logical_name: &str, value: SecretBytes)
+                        -> Result<SecretReference, SecretBackendError>;
+    async fn get   (&self, reference: &SecretReference)  -> Result<SecretBytes, SecretBackendError>;
+    async fn delete(&self, reference: &SecretReference)  -> Result<(), SecretBackendError>;
+    async fn list  (&self, tenant_db_id: Uuid)           -> Result<Vec<(String, SecretReference)>, SecretBackendError>;
+}
+```
+
+Two implementations:
+
+- `PostgresSecretBackend` — envelope-encrypted storage in the `tenant_secrets` table. On `put`, it generates a fresh 32-byte DEK, seals the value with AES-256-GCM (12-byte nonce), wraps the DEK with the configured `KmsProvider`, and upserts. On upsert conflict `(tenant_id, logical_name)`, the row is re-encrypted with a fresh DEK and `generation` is bumped — the `SecretReference` stays stable.
+- `InMemorySecretBackend` — `HashMap`-backed, for unit tests only.
+
+### `tenant_secrets` table (migration 026)
+
+```
+tenant_secrets(
+  id             UUID PK,
+  tenant_id      UUID FK → tenants ON DELETE CASCADE,
+  logical_name   TEXT,
+  kms_key_id     TEXT,          -- which CMK wrapped wrapped_dek
+  wrapped_dek    BYTEA,
+  ciphertext     BYTEA,         -- AES-256-GCM sealed plaintext
+  nonce          BYTEA,         -- 12-byte per-row GCM nonce
+  generation     INTEGER,       -- bumped on envelope rotation
+  created_at     TIMESTAMPTZ,
+  updated_at     TIMESTAMPTZ    -- BEFORE UPDATE trigger
+)
+UNIQUE (tenant_id, logical_name);
+```
+
+## Bootstrap — `build_secret_backend_from_env`
+
+```rust
+let backend: Arc<dyn SecretBackend> =
+    storage::secret_backend::build_secret_backend_from_env(pool).await?;
+```
+
+Reads `AETERNA_KMS_PROVIDER` and returns a ready-to-use `PostgresSecretBackend`:
+
+| `AETERNA_KMS_PROVIDER` | Additional env | Behaviour |
+|---|---|---|
+| `aws` | `AETERNA_KMS_AWS_KEY_ARN` (required) + `AWS_*` or IRSA role | `AwsKmsProvider` against the CMK |
+| `local` (default) | `AETERNA_LOCAL_KMS_KEY` (base64 32 bytes) | `LocalKmsProvider`, emits `WARN` on every use |
+| *anything else* | — | Falls through to `local` (will tighten in B2) |
+
+In tests, inject an `InMemorySecretBackend` directly instead of calling the helper.
+
+## Where this sits in the stack
+
+```
+  aeterna-cli (bootstrap)                ─┐
+  admin_ui routes (PUT /tenants/:id/…)   ─┼──▶ TenantConfigProvider
+  knowledge / memory consumers           ─┘          │
+                                                     ▼
+                                       ┌─────────────────────────────┐
+                                       │  SecretBackend              │  (put / get / delete / list)
+                                       │   └── PostgresSecretBackend │
+                                       └──────────────┬──────────────┘
+                                                      │
+                                           ┌──────────┴──────────┐
+                                           ▼                     ▼
+                                   AES-256-GCM row       KmsProvider
+                                   in tenant_secrets    (AwsKms | LocalKms)
+```
+
+## See also
+
+- [Helm KMS configuration](../helm/kms.md) — operator values reference, IRSA walkthrough
+- [Secret Rotation runbook](../guides/secret-rotation.md) — CMK + local-key rotation, DR drill
+- `openspec/changes/harden-tenant-provisioning/design.md` — design decisions D1–D8
+- Source: [`mk_core/src/secret.rs`](https://github.com/kikokikok/aeterna/blob/master/mk_core/src/secret.rs), [`storage/src/kms/`](https://github.com/kikokikok/aeterna/tree/master/storage/src/kms), [`storage/src/secret_backend.rs`](https://github.com/kikokikok/aeterna/blob/master/storage/src/secret_backend.rs)

--- a/docs/guides/secret-rotation.md
+++ b/docs/guides/secret-rotation.md
@@ -1,0 +1,143 @@
+# Secret Rotation Runbook
+
+> Operator runbook for rotating the keys that protect tenant secrets. Uses the `SecretBackend` primitives documented in [Secret Backend Architecture](../architecture/secret-backend.md) and the Helm surface documented in [Helm KMS](../helm/kms.md).
+
+Three kinds of keys exist; they rotate independently.
+
+| Key | Where it lives | Owner | When to rotate |
+|---|---|---|---|
+| **CMK** (customer master key) | AWS KMS — ARN in `kms.aws.keyArn` | AWS account | Annually; on suspected compromise |
+| **DEK** (data encryption key) | `tenant_secrets.wrapped_dek` — one per row | Aeterna | On re-put of a specific secret (automatic) |
+| **Local KMS key** | `<release>-kms-local` K8s Secret | Helm chart (or operator) | Never rotate in place — re-seed only for new environments |
+
+Most day-to-day rotation is the middle row and happens implicitly: re-putting a tenant secret performs a full envelope rotation for that row. The runbooks below cover the explicit cases.
+
+---
+
+## Runbook 1 — Rotate an AWS CMK (same key, new version)
+
+Use when AWS KMS flags the key as due for rotation, or on annual policy.
+
+**Mechanism.** AWS KMS key rotation creates a new *key version* but preserves the ARN. The ciphertext blobs we persisted remain valid: AWS KMS routes decryption from the embedded key hint in the blob, so existing `wrapped_dek` values continue to decrypt after rotation. New writes automatically use the new version.
+
+**Prereq.** `kms.provider=aws`, `keyArn` set to an ARN pointing at the CMK being rotated.
+
+1. Trigger rotation in AWS:
+
+   ```
+   aws kms enable-key-rotation --key-id <key-id-or-alias>
+   # (Or: aws kms rotate-key-on-demand --key-id …  if automatic rotation already enabled.)
+   ```
+2. Verify:
+
+   ```
+   aws kms get-key-rotation-status --key-id <key-id>
+   aws kms list-key-rotations --key-id <key-id>
+   ```
+3. Smoke-test from the pod. Any `secret_backend.get()` call against an existing secret still returns the correct plaintext:
+
+   ```
+   kubectl exec -it deploy/aeterna -- aeterna-cli tenants secret get \
+     --tenant-id <uuid> --name openai-api-key
+   ```
+4. New writes use the rotated key material:
+
+   ```
+   kubectl exec -it deploy/aeterna -- aeterna-cli tenants secret put \
+     --tenant-id <uuid> --name canary --value $(uuidgen)
+   kubectl exec -it deploy/aeterna -- aeterna-cli tenants secret get \
+     --tenant-id <uuid> --name canary
+   ```
+
+**No chart change.** `kms.aws.keyArn` is unchanged; no redeploy needed.
+
+---
+
+## Runbook 2 — Switch to a new AWS CMK (new ARN)
+
+Use on a suspected key-material compromise, or when migrating to a new AWS account / region.
+
+**Mechanism.** Existing rows stay decryptable as long as the old CMK remains *usable* (enabled and you have `kms:Decrypt` on it). Updating `kms.aws.keyArn` only changes the key used for **new** `put()` calls. To fully migrate off the old CMK, every row must be re-put (which rewraps its DEK with the new CMK).
+
+1. Provision the new CMK + alias + IAM grants (see [Helm KMS Recipe 1](../helm/kms.md#recipe-1--production-with-irsa-recommended)).
+2. **Keep** `kms:Decrypt` on the old CMK while migrating.
+3. Flip `kms.aws.keyArn` to the new ARN and redeploy:
+
+   ```
+   helm upgrade aeterna charts/aeterna -f values-prod.yaml \
+     --set kms.aws.keyArn=arn:aws:kms:eu-west-1:…:alias/aeterna-tenant-secrets-v2
+   ```
+4. Rewrap every existing row. The [`aeterna-cli tenants secret rewrap`] command iterates `SecretBackend::list` per tenant and performs a `put` + `get` roundtrip, bumping `generation`:
+
+   ```
+   kubectl exec -it deploy/aeterna -- \
+     aeterna-cli tenants secret rewrap --all
+   ```
+
+   > **B1 scope note.** The `rewrap` subcommand is queued for the B5 bundle. Until it ships, use a short `psql` script that `SELECT id, tenant_id FROM tenant_secrets` and calls `secret put` with the current plaintext — or simply re-put every tenant secret via your provisioning pipeline.
+
+5. Verify no row still references the old CMK:
+
+   ```
+   psql -c "SELECT DISTINCT kms_key_id FROM tenant_secrets;"
+   # Expect the new ARN only.
+   ```
+6. Disable the old CMK once the row count matches.
+
+---
+
+## Runbook 3 — Rotate a single tenant secret
+
+Use when a tenant's OpenAI key / GitHub PAT / etc. is rotated by its owner.
+
+Re-`put` is a full envelope rotation (fresh DEK, fresh nonce, fresh ciphertext, `generation` bumped, same `secret_id`):
+
+```
+aeterna-cli tenants secret put \
+  --tenant-id <tenant-uuid> \
+  --name openai-api-key \
+  --value "$(pbpaste)"
+```
+
+Consumers holding the `SecretReference::Postgres { secret_id }` do not need to update; the reference is stable across rotations. Their next `get()` picks up the new value.
+
+---
+
+## Runbook 4 — Re-seed a local KMS key (fresh environment only)
+
+**Never do this on a cluster with existing tenant data.** The local key is the DEK-wrapping key for every `wrapped_dek` in `tenant_secrets`; rotating it in place orphans every row.
+
+Supported scenarios:
+
+- **Fresh dev / CI environment.** The chart auto-generates one; no action required.
+- **DR drill starting from a wiped Postgres.** Same as above.
+- **External key management for local mode.** Follow [Helm KMS Recipe 3](../helm/kms.md#recipe-3--local--ci--dr-drill) and point `kms.local.existingSecret` at a Secret you control.
+
+If you must force a new local key:
+
+1. Ensure no data in `tenant_secrets` depends on the current key (truncate, or accept loss).
+2. Delete the chart-owned Secret:
+
+   ```
+   kubectl delete secret <release>-kms-local
+   ```
+3. Rerun `helm upgrade` — the chart regenerates a fresh key.
+
+---
+
+## Observability
+
+During any rotation, watch for:
+
+| Signal | Meaning |
+|---|---|
+| `LocalKmsProvider in use` WARN line | `provider=local` is active. In production this is a rollback / misconfiguration. |
+| `kms error:` in `SecretBackendError` | CMK missing, IAM grants dropped, or SDK chain failed. First suspects: `kms.aws.roleArn`, `kms.aws.keyArn`. |
+| `aead error:` on `get` | Row tampering, wrong CMK, or a half-migrated state — stop the rotation and investigate before continuing. |
+| `tenant_secrets.generation` not advancing during Runbook 2 | The rewrap loop is not actually calling `put`; it is reading only. |
+
+## Related
+
+- [Secret Backend Architecture](../architecture/secret-backend.md)
+- [Helm KMS configuration](../helm/kms.md)
+- `openspec/changes/harden-tenant-provisioning/design.md` — decisions D2 (envelope), D4 (CMK rotation without orphan), D5 (rewrap tool)

--- a/website/docs/guides/secret-rotation.md
+++ b/website/docs/guides/secret-rotation.md
@@ -1,0 +1,1 @@
+../../../docs/guides/secret-rotation.md

--- a/website/docs/helm/kms.md
+++ b/website/docs/helm/kms.md
@@ -1,0 +1,173 @@
+# KMS & Tenant-Secret Envelope Encryption
+
+> Maps the Helm `kms:` values block onto the `SecretBackend` / `KmsProvider` architecture. For the conceptual picture, start with [Secret Backend Architecture](../architecture/secret-backend.md).
+
+Aeterna envelope-encrypts every tenant secret row (OpenAI keys, GitHub tokens, embedding credentials …). The `kms.provider` knob in `values.yaml` selects how the per-row data keys are wrapped.
+
+| Mode | `kms.provider` | Use |
+|---|---|---|
+| **AWS KMS** | `"aws"` | Production. Required in any environment handling real tenant data. |
+| **Local** | `"local"` | Development, CI, and DR drills only. The app emits `WARN: LocalKmsProvider in use …` on every boot. |
+
+---
+
+## Values reference
+
+New top-level `kms:` block in `charts/aeterna/values.yaml`:
+
+```yaml
+kms:
+  provider: "local"            # "aws" | "local"
+
+  aws:
+    keyArn: ""                 # arn:aws:kms:<region>:<account-id>:key/<uuid>
+                               # arn:aws:kms:<region>:<account-id>:alias/<alias-name>
+    auth: "irsa"               # "irsa" | "static"
+    roleArn: ""                # IAM role ARN — annotates the SA when auth=irsa
+    existingSecret: ""         # K8s Secret holding AWS AK/SK — only for auth=static
+    accessKeyIdKey: "aws-access-key-id"
+    secretAccessKeyKey: "aws-secret-access-key"
+
+  local:
+    generate: true             # chart creates a random 32B key Secret (default)
+    existingSecret: ""         # externally-managed Secret (when generate=false)
+    secretKey: "kms-local-key" # key inside that Secret
+```
+
+### Env variables produced
+
+The chart projects `kms.*` into the aeterna Deployment as:
+
+| Env var | Mode | Source |
+|---|---|---|
+| `AETERNA_KMS_PROVIDER` | always | `kms.provider` |
+| `AETERNA_KMS_AWS_KEY_ARN` | aws | `kms.aws.keyArn` |
+| `AWS_ACCESS_KEY_ID` | aws + static | `kms.aws.existingSecret` → `accessKeyIdKey` |
+| `AWS_SECRET_ACCESS_KEY` | aws + static | `kms.aws.existingSecret` → `secretAccessKeyKey` |
+| `AETERNA_LOCAL_KMS_KEY` | local | chart-generated or `kms.local.existingSecret` → `secretKey` |
+
+### Fail-closed validation
+
+`helm template` errors before rendering when:
+
+- `kms.provider=aws` and `kms.aws.keyArn` is empty → `kms.provider=aws requires kms.aws.keyArn to be set`
+- `kms.provider=aws`, `auth=static`, and `kms.aws.existingSecret` is empty → `kms.aws.existingSecret is required when kms.aws.auth=static`
+- `kms.provider=local`, `generate=false`, and `kms.local.existingSecret` is empty → `kms.local.existingSecret is required when kms.local.generate=false`
+
+---
+
+## Recipe 1 — Production with IRSA (recommended)
+
+```yaml
+# values-prod.yaml
+kms:
+  provider: "aws"
+  aws:
+    keyArn: "arn:aws:kms:eu-west-1:123456789012:alias/aeterna-tenant-secrets"
+    auth: "irsa"
+    roleArn: "arn:aws:iam::123456789012:role/aeterna-kms"
+```
+
+1. Create the CMK and grant the IAM role `kms:Encrypt`, `kms:Decrypt`, `kms:GenerateDataKey`:
+
+   ```
+   aws kms create-key --description 'aeterna tenant-secret envelope DEKs'
+   aws kms create-alias --alias-name alias/aeterna-tenant-secrets --target-key-id <key-id>
+   ```
+2. Create the IAM role with a trust policy for your EKS OIDC provider and the `kms:*` policy above. See [AWS IRSA docs](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+3. Install / upgrade:
+
+   ```
+   helm upgrade --install aeterna charts/aeterna -f values-prod.yaml
+   ```
+4. Verify the ServiceAccount picked up the annotation:
+
+   ```
+   kubectl get sa aeterna -o jsonpath='{.metadata.annotations}'
+   # {"eks.amazonaws.com/role-arn":"arn:aws:iam::123456789012:role/aeterna-kms"}
+   ```
+5. Verify the pod env:
+
+   ```
+   kubectl exec deploy/aeterna -- env | grep AETERNA_KMS
+   # AETERNA_KMS_PROVIDER=aws
+   # AETERNA_KMS_AWS_KEY_ARN=arn:aws:kms:eu-west-1:…
+   ```
+
+## Recipe 2 — Production with static AWS credentials
+
+Only use when IRSA is unavailable (e.g. non-EKS clusters). Credentials live in a K8s Secret your operator manages out-of-band.
+
+```yaml
+kms:
+  provider: "aws"
+  aws:
+    keyArn: "arn:aws:kms:eu-west-1:123456789012:key/…"
+    auth: "static"
+    existingSecret: "aeterna-aws-credentials"
+    # optionally override key names inside the Secret:
+    # accessKeyIdKey: "AWS_ACCESS_KEY_ID"
+    # secretAccessKeyKey: "AWS_SECRET_ACCESS_KEY"
+```
+
+```
+kubectl create secret generic aeterna-aws-credentials \
+  --from-literal=aws-access-key-id=AKIA… \
+  --from-literal=aws-secret-access-key=…
+```
+
+## Recipe 3 — Local / CI / DR drill
+
+The default `provider: "local"` needs no configuration — the chart auto-generates a 32-byte random key into a `<release>-kms-local` Secret on first install.
+
+The Secret is annotated `helm.sh/resource-policy: keep` and re-read via `lookup` on upgrade, so **the key survives chart upgrades and release rotations**. Rotating the Helm release will not corrupt existing ciphertext rows.
+
+If you want to manage the key yourself (for a DR runbook that pre-seeds keys, for example):
+
+```yaml
+kms:
+  provider: "local"
+  local:
+    generate: false
+    existingSecret: "my-kms-local"
+    secretKey: "key"
+```
+
+With:
+
+```
+head -c 32 /dev/urandom | base64 | \
+  kubectl create secret generic my-kms-local --from-file=key=/dev/stdin
+```
+
+**⚠️ Never use `provider: local` in production.** The app emits a `WARN` on every KMS operation precisely so this shows up in log aggregators.
+
+---
+
+## Verification: `helm template` dry-runs
+
+```
+# local mode — renders the kms-local Secret + AETERNA_LOCAL_KMS_KEY env
+helm template aeterna charts/aeterna \
+  | grep -E 'AETERNA_(KMS|LOCAL)|kms-local'
+
+# aws + IRSA — renders SA annotation + AETERNA_KMS_AWS_KEY_ARN env
+helm template aeterna charts/aeterna \
+  --set kms.provider=aws \
+  --set kms.aws.keyArn=arn:aws:kms:eu-west-1:123456789012:alias/x \
+  --set kms.aws.roleArn=arn:aws:iam::123456789012:role/y \
+  | grep -E 'eks.amazonaws|AETERNA_KMS'
+
+# fail-closed — errors without keyArn
+helm template aeterna charts/aeterna --set kms.provider=aws
+# Error: kms.provider=aws requires kms.aws.keyArn to be set
+```
+
+---
+
+## Related
+
+- [Secret Backend Architecture](../architecture/secret-backend.md) — trait shape, envelope encryption design
+- [Secret Rotation runbook](../guides/secret-rotation.md) — rotating CMKs, local keys, tenant keys
+- [External Secrets](./external-secrets.md) — for application-level Secrets (not the KMS DEK wrapping key)
+- [SOPS Secrets](./sops-secrets.md) — for GitOps-managed Secret manifests

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -23,6 +23,7 @@ const sidebars: SidebarsConfig = {
         'specs/overview',
         'specs/core-concepts',
         'architecture-overview',
+        'architecture/secret-backend',
         'sequence-diagrams',
         'comprehensive-ux-dx-guide',
       ],
@@ -100,6 +101,7 @@ const sidebars: SidebarsConfig = {
         'helm/security',
         'helm/external-secrets',
         'helm/sops-secrets',
+        'helm/kms',
         'helm/secrets-reference',
         'helm/upgrade',
         'helm/cnpg-upgrade',
@@ -115,6 +117,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'guides/ha-deployment',
         'guides/disaster-recovery-runbook',
+        'guides/secret-rotation',
         'guides/observability-runbook',
         'guides/managed-observability',
         'guides/cost-optimization',


### PR DESCRIPTION
**Scope: doc-2 from the 2026-04-20 documentation review.**

Documents the B1 SecretBackend / KMS stack (PRs #94 / #95 / #96). Based on `harden-tenant-provisioning-b1-finish` so the docs ship with the code they describe — GitHub will auto-retarget to `master` as the stack merges.

## New pages

| File | Audience | What's in it |
|---|---|---|
| `docs/architecture/secret-backend.md` | Developers | Three layers (SecretBytes / KmsProvider / SecretBackend), envelope encryption rationale, `tenant_secrets` schema, `build_secret_backend_from_env` usage |
| `website/docs/helm/kms.md` | Operators | `kms:` values reference, env-var projection matrix, fail-closed validation, three recipes (IRSA / static / local+DR) |
| `docs/guides/secret-rotation.md` | On-call | CMK version rotation, CMK ARN migration, tenant-secret rotation, local-key re-seed, observability signals |

## Extended pages

- **`docs/DEVELOPER_GUIDE.md`** — new "Tenant Secrets & KMS" section: code sample, runtime env matrix, test guidance, anti-patterns, pointers.
- **`charts/aeterna/README.md`** — new "Tenant-Secret Envelope Encryption" subsection under Secrets Management.
- **`website/sidebars.ts`** — wires all three new pages into Concepts / Kubernetes / Operations.

## Verification

```
cd website && yarn build
# [SUCCESS] Generated static files in "build".
# 0 broken-link warnings (verified on top of PR #97).
```

All new pages render at `/docs/architecture/secret-backend`, `/docs/helm/kms`, `/docs/guides/secret-rotation`; cross-links between them, plus links back to `openspec/changes/harden-tenant-provisioning/design.md`, all resolve.

## Context

Second of four planned doc PRs out of the doc review. doc-1 (hygiene) → #97. doc-3/doc-4 (architecture catalogue + adapter contract spec backfill) follow after B1 ships.