### PR TITLE
docs(codesearch): current SecretProvider + target SecretBackend, surface in Security sidebar

### DIFF
--- a/docs/codesearch-repo-management-api.md
+++ b/docs/codesearch-repo-management-api.md
@@ -4,7 +4,7 @@
 
 The Code Search Repository Management system provides governed lifecycle management for code repositories within Aeterna's multi-tenant architecture. It supports local, remote, and hybrid repositories with incremental indexing, policy-gated access, and distributed shard routing.
 
-**Key modules:** `storage::repo_manager`, `storage::shard_router`, `storage::policy_evaluator`, `storage::secret_provider`
+**Key modules:** `storage::repo_manager`, `storage::shard_router`, `storage::policy_evaluator`, `storage::secret_provider` *(today)* — migrating to `storage::secret_backend` in [#99](https://github.com/kikokikok/aeterna/issues/99)
 
 ## Architecture
 
@@ -59,6 +59,7 @@ Requested ──▶ Pending ──▶ Approved ──▶ Cloning ──▶ Index
 ```rust
 use storage::repo_manager::{RepoManager, CreateRepository, RepositoryType};
 
+// Today: legacy SecretProvider path (migration to SecretBackend tracked in #99)
 let manager = RepoManager::new(storage, base_path, secret_provider, policy_evaluator);
 
 // Request a repository (policy-gated)
@@ -117,7 +118,18 @@ router.drain_shard("shard-1");
 router.rebalance_from_shard("shard-1");
 ```
 
-### SecretProvider
+### Secret storage for git credentials & PATs
+
+Two layers are relevant here, and they are **not yet unified**:
+
+| Layer | Status | Where it is |
+|---|---|---|
+| `storage::secret_provider::SecretProvider` | **Current** — `RepoManager` path (this document). Holds git PATs and deploy keys via the `LocalSecretProvider` / `KubernetesSecretProvider` implementations. | `storage/src/secret_provider.rs`, wired into `RepoManager::new` |
+| `storage::secret_backend::SecretBackend` | **New (B1 — #94/#95/#96)** — envelope-encrypted, AWS-KMS / local-KMS wrapped, used by `TenantConfigProvider` and every tenant secret the CLI touches. | `storage/src/secret_backend.rs`; architecture doc: [Secret Backend Architecture](./architecture/secret-backend.md) |
+
+The `RepoManager` migration onto `SecretBackend` is tracked in **[#99](https://github.com/kikokikok/aeterna/issues/99)** (Phase B2 carry-over). Until it lands, this page describes the `SecretProvider` shape that the current code ships with; the `SecretBackend` section below describes the target state so forks can plan their migration.
+
+#### Current: `SecretProvider` (git credentials path)
 
 ```rust
 use storage::secret_provider::{SecretProvider, LocalSecretProvider};
@@ -129,6 +141,55 @@ let provider = LocalSecretProvider::new(HashMap::from([
 let secret = provider.get_secret("gh-token").await?;
 let available = provider.is_available().await; // true
 ```
+
+Properties **today**:
+
+- Plaintext at rest in the `LocalSecretProvider` map or the Kubernetes Secret that `KubernetesSecretProvider` reads.
+- No envelope encryption, no KMS wrapping, no per-row DEK rotation.
+- No cross-tenant isolation at the trait level — isolation is enforced one layer up by `RepoManager` using the authenticated `tenant_id`.
+
+This is acceptable today because the only consumer (`RepoManager`) already carries `tenant_id` on every operation and because the backing store is either ephemeral (Local) or managed by Kubernetes RBAC (K8s Secret). It is **not** acceptable as a long-term posture; see #99.
+
+#### Target: `SecretBackend` (post-B2)
+
+After #99, `RepoManager::new` will take `Arc<dyn storage::secret_backend::SecretBackend>` instead of `Arc<dyn SecretProvider>`, and `repository_bindings` will reference secrets by `SecretReference` rather than by bare key name:
+
+```rust
+use storage::secret_backend::build_secret_backend_from_env;
+use mk_core::{SecretBytes, SecretReference};
+
+let backend = build_secret_backend_from_env(pool.clone()).await?;
+
+// Storing a GitHub PAT becomes a put() on the envelope-encrypted backend
+let reference: SecretReference = backend
+    .put(tenant_db_id, "github-pat", SecretBytes::from_string(pat))
+    .await?;
+
+// Consuming it during a clone; plaintext is zeroized on drop
+let plaintext = backend.get(&reference).await?;
+git_clone(url, plaintext.expose())?;
+drop(plaintext);
+```
+
+Properties **after** the migration:
+
+- **Envelope encryption.** AES-256-GCM per row; DEK wrapped by a KMS CMK. CMK rotation does not touch rows.
+- **Stable references across rotation.** Re-`put`ting a PAT bumps `generation` but preserves `SecretReference`, so `repository_bindings` rows never need updating on rotation.
+- **Cross-tenant isolation at the trait level.** `PostgresSecretBackend` enforces `tenant_id` scoping on every read; a misrouted reference returns `NotFound`, never leaks bytes.
+- **No plaintext at rest.** A compromised DB dump yields only ciphertext + wrapped DEKs.
+- **Audit parity.** Identical `audit_log` rows for `secret put` / `get` / `delete` regardless of caller (`RepoManager`, `TenantConfigProvider`, CLI).
+
+#### Migration table (for downstream forks)
+
+| Before (`SecretProvider`, today) | After (`SecretBackend`, post-#99) |
+|---|---|
+| `Arc<dyn SecretProvider>` on `RepoManager::new` | `Arc<dyn SecretBackend>` on `RepoManager::new` |
+| `provider.get_secret(&name)` returning `String` | `backend.get(&reference)` returning `SecretBytes` (zeroize-on-drop) |
+| `LocalSecretProvider::new(HashMap<_, _>)` | `InMemorySecretBackend::new()` + explicit `put()` per key (tests only) |
+| Plaintext `repository_bindings.secret_id` interpreted by `SecretProvider` | `repository_bindings.secret_reference JSONB` holding a tagged `SecretReference` |
+| No encryption at rest | AES-256-GCM + KMS-wrapped DEK per row |
+
+Operator-side, `AETERNA_KMS_PROVIDER` / `AETERNA_KMS_AWS_KEY_ARN` / `AETERNA_LOCAL_KMS_KEY` are the bootstrap knobs — see the [Helm KMS guide](../website/docs/helm/kms.md). The [Secret Rotation runbook](./guides/secret-rotation.md) will apply once the migration lands.
 
 ## Incremental Indexing
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -82,6 +82,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Security',
       items: [
+        'architecture/secret-backend',
         'security/rbac-matrix',
         'security/rbac-testing-procedures',
         'security/tenant-isolation-testing',


### PR DESCRIPTION
**Scope: doc-3 from the 2026-04-20 documentation review.**

`docs/codesearch-repo-management-api.md` was the last surface still describing the pre-B1 `storage::secret_provider` module. **Important finding while writing this PR:** the `RepoManager` path has NOT yet been migrated onto `SecretBackend` — #94/#95/#96 covered `TenantConfigProvider` and the CLI but left `storage/src/secret_provider.rs` in place, still wired into `RepoManager::new`. The `RepoManager` migration is a Phase B2 carry-over task (tracked in #99).

So this doc PR does **not** pretend the migration has landed. It documents both states honestly.

## What changes

### `docs/codesearch-repo-management-api.md`

- **"Key modules" line** — `storage::secret_provider` *(today)* — migrating to `storage::secret_backend` in #99.
- **New "Current: SecretProvider"** section preserves the existing code snippet. Calls out the honest properties today: plaintext at rest, no envelope encryption, cross-tenant isolation enforced by `RepoManager` one layer up.
- **New "Target: SecretBackend (post-B2)"** section describes the shape #99 delivers: `RepoManager::new` takes `Arc<dyn SecretBackend>`, `repository_bindings` stores `SecretReference`, CMK rotation does not touch rows.
- **Migration table** for downstream forks that will need to swap trait types.
- Cross-links to the architecture doc, Helm KMS guide, and rotation runbook landed in #98.

### `website/sidebars.ts`

- Adds `architecture/secret-backend` to the Security category (previously only in Concepts). A security reviewer scanning Security can discover the envelope encryption design without jumping categories.

## Verification

```
cd website && yarn build
# [SUCCESS] Generated static files in "build". — zero broken-link warnings.
```

## Context

Third of four planned doc PRs. #97 (hygiene) → merged. #98 (B1 content) → merged. doc-4 (architecture catalogue + website README rewrite + P2 tail) is next.