### PR TITLE
fix(secret): enforce camelCase wire shape for SecretReference variant fields

### DIFF
--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -4712,8 +4712,8 @@ mod tests {
                 "repo.token": {
                     "logicalName": "repo.token",
                     "ownership": "tenant",
-                    "secretName": "aeterna-tenant-11111111-1111-1111-1111-111111111111-secret",
-                    "secretKey": "repo.token"
+                    "kind": "postgres",
+                    "secretId": "22222222-2222-2222-2222-222222222222"
                 }
             }
         }))

--- a/mk_core/src/secret.rs
+++ b/mk_core/src/secret.rs
@@ -208,7 +208,7 @@ impl schemars::JsonSchema for SecretBytes {
 /// so future backends (external secret managers, cloud KV stores, etc.)
 /// can be added as additive variants.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum SecretReference {
     /// Encrypted blob stored in the `tenant_secrets` Postgres table. The row
     /// holds a KMS-wrapped DEK and an AES-256-GCM ciphertext.
@@ -285,5 +285,38 @@ mod tests {
         assert!(j.contains("\"kind\":\"postgres\""));
         let parsed: SecretReference = serde_json::from_str(&j).unwrap();
         assert_eq!(r, parsed);
+    }
+
+    /// Regression: the wire shape of every `SecretReference` variant field
+    /// must be camelCase, matching the outer `kind` tag and the flattening
+    /// context (`TenantSecretReference`). Without `rename_all_fields =
+    /// "camelCase"` on the enum, variant fields leak as snake_case, which
+    /// broke [`cli::server::tenant_api`] deserialization of
+    /// `UpsertTenantConfigRequest.secretReferences`.
+    #[test]
+    fn reference_variant_fields_are_camel_case_on_wire() {
+        let r = SecretReference::Postgres {
+            secret_id: Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap(),
+        };
+        let j = serde_json::to_string(&r).unwrap();
+        assert!(j.contains("\"secretId\""), "expected camelCase secretId on wire, got: {j}");
+        assert!(!j.contains("\"secret_id\""), "snake_case secret_id leaked on wire: {j}");
+
+        // Deserialize MUST accept camelCase (the canonical shape) and
+        // MUST reject snake_case so we do not have two valid wire shapes.
+        let good = serde_json::json!({
+            "kind": "postgres",
+            "secretId": "22222222-2222-2222-2222-222222222222"
+        });
+        assert!(serde_json::from_value::<SecretReference>(good).is_ok());
+
+        let bad = serde_json::json!({
+            "kind": "postgres",
+            "secret_id": "22222222-2222-2222-2222-222222222222"
+        });
+        assert!(
+            serde_json::from_value::<SecretReference>(bad).is_err(),
+            "snake_case secret_id must not be accepted (we ship only one wire shape)"
+        );
     }
 }


### PR DESCRIPTION
**Fixes the unit test broken by #94/#95** — `tenant_config_request_deserializes_with_camel_case` — and the underlying API-quality bug it exposed.

## Bug

#94 introduced `SecretReference` as a tagged enum:

```rust
#[serde(tag = "kind", rename_all = "camelCase")]
pub enum SecretReference {
    Postgres { secret_id: Uuid },
}
```

On serde, the enum-level `rename_all` only renames **variant names**, not their fields. Combined with `TenantSecretReference` which uses `#[serde(flatten)]` over `SecretReference` under `#[serde(rename_all = "camelCase")]`, the wire shape came out mixed:

```json
{
  "logicalName": "repo.token",
  "ownership": "tenant",
  "kind": "postgres",
  "secret_id": "22222222-..."   // ← leaked snake_case
}
```

Consequences:

1. `UpsertTenantConfigRequest` deserialization fails when clients send the naturally-expected `secretId`, which is why the existing test broke.
2. Two casing conventions in one JSON object is an API smell that will bite every caller that round-trips manifests.

## Fix

Add `rename_all_fields = "camelCase"` on the enum (serde 1.0.175+). The canonical wire shape is now one thing, everywhere `SecretReference` appears:

```json
{ "kind": "postgres", "secretId": "<uuid>" }
```

## Regression test

Added `mk_core::secret::reference_variant_fields_are_camel_case_on_wire`:

- asserts `secretId` is emitted on the wire,
- asserts the old `secret_id` is now **rejected** on deserialize (so we do not silently accept two shapes and drift again).

Also fixed the existing `tenant_api` test fixture to use the correct shape.

## Verification

```
cargo test -p mk_core --lib secret::                                              # 8/8 pass
cargo test -p aeterna --lib tenant_config_request_deserializes_with_camel_case    # pass
```

## Risk

Wire-format change for `SecretReference`, but B1 just shipped today and no external consumer produces the mixed shape yet — `TenantConfigProvider` callers all go through typed Rust, not raw JSON. Safe to ship now rather than in a later compat layer.