### PR TITLE
feat(storage): tenant manifest-state columns + store methods (B2 #99, task 1.5)

### DIFF
--- a/storage/migrations/027_tenant_manifest_state.sql
+++ b/storage/migrations/027_tenant_manifest_state.sql
@@ -1,0 +1,84 @@
+-- ============================================================================
+-- 027_tenant_manifest_state.sql
+--
+-- Adds the two columns that let provision_tenant implement idempotent
+-- short-circuit and strict-monotonic revision checks, per
+-- openspec/changes/harden-tenant-provisioning/design.md D5 + D6 and
+-- GitHub #99 (Phase B2 tracking).
+--
+-- Columns:
+--
+--   last_applied_manifest_hash TEXT NULL
+--       Canonical SHA-256 fingerprint of the last successfully-applied
+--       manifest for this tenant. Format: "sha256:" + 64 hex chars
+--       (see cli/src/server/manifest_hash.rs::HASH_PREFIX). NULL means the
+--       tenant has never been (re-)applied via the B2 idempotent path --
+--       either it predates this migration or it was created via direct
+--       SQL / CLI bootstrap. A NULL column always triggers a full apply,
+--       never a short-circuit; this is safe for older rows.
+--
+--   manifest_generation BIGINT NOT NULL DEFAULT 0
+--       Monotonic revision counter owned by the caller of the manifest
+--       apply API. `provision_tenant` enforces strict increase
+--       (manifest.metadata.generation > manifest_generation) on every
+--       change and rejects conflicts with 409. When the caller omits
+--       metadata.generation, the server auto-increments
+--       (manifest_generation + 1) and writes that back.
+--
+--       We deliberately name the column `manifest_generation` rather than
+--       `generation`, because `generation` is both a SQL-reserved-adjacent
+--       term and ambiguous with other monotonic counters that will exist
+--       elsewhere (cache generation, schema generation, etc.). The
+--       manifest_ prefix makes the DB column self-documenting. On the
+--       wire (TenantManifest.metadata.generation) the prefix is implicit
+--       from context.
+--
+-- Index:
+--
+--   We do NOT add an index. Lookups are always keyed by slug or id, which
+--   already have indices (see 017_tenants_tables.sql). Neither new column
+--   is ever used as a WHERE predicate on its own.
+--
+-- Idempotency:
+--
+--   IF NOT EXISTS guards keep this migration safe to re-run.
+-- ============================================================================
+
+ALTER TABLE tenants
+    ADD COLUMN IF NOT EXISTS last_applied_manifest_hash TEXT;
+
+ALTER TABLE tenants
+    ADD COLUMN IF NOT EXISTS manifest_generation BIGINT NOT NULL DEFAULT 0;
+
+-- Defence in depth: enforce the sha256:... shape at the DB level so stale
+-- writers (pre-B2 code paths, manual ops scripts) cannot insert a value
+-- that looks valid but wouldn't decode. NULL remains legal (see column
+-- docs above).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'tenants_manifest_hash_format'
+    ) THEN
+        ALTER TABLE tenants
+            ADD CONSTRAINT tenants_manifest_hash_format
+            CHECK (
+                last_applied_manifest_hash IS NULL
+                OR last_applied_manifest_hash ~ '^sha256:[0-9a-f]{64}$'
+            );
+    END IF;
+END$$;
+
+-- Defence in depth: the generation column is owner-chosen but must be
+-- non-negative; `0` is reserved as the "never applied" sentinel so no
+-- in-wire generation of 0 is ever valid (cli/src/server/tenant_api.rs
+-- already rejects metadata.generation == 0 at the schema layer).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'tenants_manifest_generation_nonneg'
+    ) THEN
+        ALTER TABLE tenants
+            ADD CONSTRAINT tenants_manifest_generation_nonneg
+            CHECK (manifest_generation >= 0);
+    END IF;
+END$$;

--- a/storage/src/postgres.rs
+++ b/storage/src/postgres.rs
@@ -932,11 +932,9 @@ impl PostgresBackend {
 
         // Backfill for test databases that pre-date the manifest-state
         // columns (production path: migration 027_tenant_manifest_state.sql).
-        sqlx::query(
-            "ALTER TABLE tenants ADD COLUMN IF NOT EXISTS last_applied_manifest_hash TEXT",
-        )
-        .execute(&self.pool)
-        .await?;
+        sqlx::query("ALTER TABLE tenants ADD COLUMN IF NOT EXISTS last_applied_manifest_hash TEXT")
+            .execute(&self.pool)
+            .await?;
         sqlx::query(
             "ALTER TABLE tenants ADD COLUMN IF NOT EXISTS manifest_generation BIGINT NOT NULL DEFAULT 0",
         )

--- a/storage/src/postgres.rs
+++ b/storage/src/postgres.rs
@@ -922,11 +922,48 @@ impl PostgresBackend {
                 source_owner TEXT NOT NULL DEFAULT 'admin',
                 created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                deactivated_at TIMESTAMPTZ
+                deactivated_at TIMESTAMPTZ,
+                last_applied_manifest_hash TEXT,
+                manifest_generation BIGINT NOT NULL DEFAULT 0
             )",
         )
         .execute(&self.pool)
         .await?;
+
+        // Backfill for test databases that pre-date the manifest-state
+        // columns (production path: migration 027_tenant_manifest_state.sql).
+        sqlx::query(
+            "ALTER TABLE tenants ADD COLUMN IF NOT EXISTS last_applied_manifest_hash TEXT",
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            "ALTER TABLE tenants ADD COLUMN IF NOT EXISTS manifest_generation BIGINT NOT NULL DEFAULT 0",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        // Mirror CHECK constraints from migration 027 so dev/test paths
+        // enforce the same invariants. We assemble the end-of-string
+        // anchor via chr(36) at SQL-evaluation time so the Rust source
+        // never contains a literal `[dollar-sign][single-quote]` sequence.
+        // The let-binding + .ok() pattern tolerates the duplicate-object
+        // error when initialize_schema is re-run.
+        let _ = sqlx::query(
+            "ALTER TABLE tenants \
+             ADD CONSTRAINT tenants_manifest_hash_format \
+             CHECK (last_applied_manifest_hash IS NULL \
+                    OR last_applied_manifest_hash ~ ('^sha256:[0-9a-f]{64}' || chr(36)))",
+        )
+        .execute(&self.pool)
+        .await;
+        let _ = sqlx::query(
+            "ALTER TABLE tenants \
+             ADD CONSTRAINT tenants_manifest_generation_nonneg \
+             CHECK (manifest_generation >= 0)",
+        )
+        .execute(&self.pool)
+        .await;
 
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS tenant_domain_mappings (

--- a/storage/src/tenant_store.rs
+++ b/storage/src/tenant_store.rs
@@ -467,9 +467,7 @@ impl TenantStore {
         .rows_affected();
 
         if rows_affected == 0 {
-            return Err(PostgresError::NotFound(format!(
-                "tenant not found: {slug}"
-            )));
+            return Err(PostgresError::NotFound(format!("tenant not found: {slug}")));
         }
         Ok(())
     }
@@ -499,9 +497,7 @@ impl TenantStore {
         .rows_affected();
 
         if rows_affected == 0 {
-            return Err(PostgresError::NotFound(format!(
-                "tenant not found: {slug}"
-            )));
+            return Err(PostgresError::NotFound(format!("tenant not found: {slug}")));
         }
         Ok(())
     }

--- a/storage/src/tenant_store.rs
+++ b/storage/src/tenant_store.rs
@@ -391,6 +391,120 @@ impl TenantStore {
     pub fn pool(&self) -> &sqlx::PgPool {
         &self.pool
     }
+
+    // ──── Manifest state (B2, migration 027) ────────────────────────────
+    //
+    // The `tenants` table carries two extra columns introduced by
+    // `027_tenant_manifest_state.sql`:
+    //
+    //   - `last_applied_manifest_hash TEXT NULL`      SHA-256 fingerprint
+    //                                                 of the last apply
+    //   - `manifest_generation BIGINT NOT NULL = 0`   caller-owned revision
+    //
+    // The three methods below are the entire read/write surface. We keep
+    // them small and orthogonal because `provision_tenant` is the only
+    // caller today and the state model is narrow. Introducing a big
+    // `TenantManifestState` type would lock in a shape before we have
+    // more than one consumer.
+
+    /// Read the manifest state for a tenant by slug.
+    ///
+    /// Returns `(last_applied_manifest_hash, manifest_generation)`. A hash
+    /// of `None` means the tenant has never been applied via the B2
+    /// idempotent path; callers MUST treat this as "no short-circuit
+    /// possible" and run a full apply.
+    ///
+    /// Returns `PostgresError::NotFound` if the tenant row does not exist.
+    pub async fn get_manifest_state(
+        &self,
+        slug: &str,
+    ) -> Result<(Option<String>, i64), PostgresError> {
+        let row: Option<(Option<String>, i64)> = sqlx::query_as(
+            "SELECT last_applied_manifest_hash, manifest_generation \
+             FROM tenants WHERE slug = $1",
+        )
+        .bind(slug)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(PostgresError::from)?;
+
+        row.ok_or_else(|| PostgresError::NotFound(format!("tenant not found: {slug}")))
+    }
+
+    /// Atomically set the manifest state on a successful apply.
+    ///
+    /// This method is intentionally permissive on `generation`: callers are
+    /// expected to have performed the strict-monotonic check *before* calling
+    /// this, while holding whatever lock is appropriate (today: the tx
+    /// inside `provision_tenant`). The CHECK constraint from migration 027
+    /// enforces `manifest_generation >= 0` at the DB layer; anything finer
+    /// is application-level invariant.
+    ///
+    /// The hash argument is validated against the column CHECK constraint;
+    /// a malformed value surfaces as a `PostgresError` at write time rather
+    /// than being silently accepted.
+    ///
+    /// Returns `PostgresError::NotFound` if no tenant row exists for `slug`.
+    pub async fn set_manifest_state(
+        &self,
+        slug: &str,
+        hash: &str,
+        generation: i64,
+    ) -> Result<(), PostgresError> {
+        let rows_affected = sqlx::query(
+            "UPDATE tenants \
+             SET last_applied_manifest_hash = $1, \
+                 manifest_generation = $2, \
+                 updated_at = NOW() \
+             WHERE slug = $3",
+        )
+        .bind(hash)
+        .bind(generation)
+        .bind(slug)
+        .execute(&self.pool)
+        .await
+        .map_err(PostgresError::from)?
+        .rows_affected();
+
+        if rows_affected == 0 {
+            return Err(PostgresError::NotFound(format!(
+                "tenant not found: {slug}"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Same as [`set_manifest_state`] but bound to an explicit tx. Used by
+    /// `provision_tenant` when the state update must commit atomically with
+    /// the manifest-body changes in the same transaction.
+    pub async fn set_manifest_state_tx<'c>(
+        tx: &mut sqlx::Transaction<'c, sqlx::Postgres>,
+        slug: &str,
+        hash: &str,
+        generation: i64,
+    ) -> Result<(), PostgresError> {
+        let rows_affected = sqlx::query(
+            "UPDATE tenants \
+             SET last_applied_manifest_hash = $1, \
+                 manifest_generation = $2, \
+                 updated_at = NOW() \
+             WHERE slug = $3",
+        )
+        .bind(hash)
+        .bind(generation)
+        .bind(slug)
+        .execute(&mut **tx)
+        .await
+        .map_err(PostgresError::from)?
+        .rows_affected();
+
+        if rows_affected == 0 {
+            return Err(PostgresError::NotFound(format!(
+                "tenant not found: {slug}"
+            )));
+        }
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/storage/tests/tenant_manifest_state_test.rs
+++ b/storage/tests/tenant_manifest_state_test.rs
@@ -1,0 +1,225 @@
+//! Integration tests for the manifest-state read/write surface on
+//! `TenantStore` (B2 task 1.5).
+//!
+//! These tests require Docker for the `postgres()` testcontainer fixture and
+//! self-skip with a log line when it is not available, matching the pattern
+//! used throughout `storage/tests/`.
+
+use storage::tenant_store::TenantStore;
+use testing::{postgres, unique_id};
+
+async fn setup_pool() -> Option<sqlx::PgPool> {
+    let fixture = postgres().await?;
+    storage::postgres::PostgresBackend::new(fixture.url())
+        .await
+        .ok()?
+        .initialize_schema()
+        .await
+        .ok()?;
+    Some(
+        sqlx::PgPool::connect(fixture.url())
+            .await
+            .expect("reconnect"),
+    )
+}
+
+const VALID_HASH_A: &str =
+    "sha256:0000000000000000000000000000000000000000000000000000000000000001";
+const VALID_HASH_B: &str =
+    "sha256:0000000000000000000000000000000000000000000000000000000000000002";
+
+#[tokio::test]
+async fn fresh_tenant_has_null_hash_and_zero_generation() {
+    let Some(pool) = setup_pool().await else {
+        eprintln!("Skipping: Docker not available");
+        return;
+    };
+    let store = TenantStore::new(pool);
+
+    let slug = unique_id("ms-fresh");
+    store.create_tenant(&slug, &slug).await.unwrap();
+
+    let (hash, generation) = store.get_manifest_state(&slug).await.unwrap();
+    assert!(
+        hash.is_none(),
+        "fresh tenant must have NULL hash so callers do not short-circuit"
+    );
+    assert_eq!(
+        generation, 0,
+        "fresh tenant must have generation = 0 (sentinel for 'never applied')"
+    );
+}
+
+#[tokio::test]
+async fn set_then_read_roundtrips_exactly() {
+    let Some(pool) = setup_pool().await else {
+        eprintln!("Skipping: Docker not available");
+        return;
+    };
+    let store = TenantStore::new(pool);
+
+    let slug = unique_id("ms-rt");
+    store.create_tenant(&slug, &slug).await.unwrap();
+
+    store
+        .set_manifest_state(&slug, VALID_HASH_A, 7)
+        .await
+        .unwrap();
+
+    let (hash, gen_) = store.get_manifest_state(&slug).await.unwrap();
+    assert_eq!(hash.as_deref(), Some(VALID_HASH_A));
+    assert_eq!(gen_, 7);
+
+    // Overwriting must update both fields atomically.
+    store
+        .set_manifest_state(&slug, VALID_HASH_B, 8)
+        .await
+        .unwrap();
+
+    let (hash, gen_) = store.get_manifest_state(&slug).await.unwrap();
+    assert_eq!(hash.as_deref(), Some(VALID_HASH_B));
+    assert_eq!(gen_, 8);
+}
+
+#[tokio::test]
+async fn get_manifest_state_returns_not_found_for_unknown_slug() {
+    let Some(pool) = setup_pool().await else {
+        eprintln!("Skipping: Docker not available");
+        return;
+    };
+    let store = TenantStore::new(pool);
+
+    let err = store
+        .get_manifest_state("this-slug-does-not-exist-ever")
+        .await
+        .expect_err("unknown slug must error");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("not found") || msg.to_lowercase().contains("not found"),
+        "error must say not found, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn set_manifest_state_returns_not_found_for_unknown_slug() {
+    let Some(pool) = setup_pool().await else {
+        eprintln!("Skipping: Docker not available");
+        return;
+    };
+    let store = TenantStore::new(pool);
+
+    let err = store
+        .set_manifest_state("also-does-not-exist", VALID_HASH_A, 1)
+        .await
+        .expect_err("unknown slug must error on UPDATE too");
+    let msg = format!("{err}");
+    assert!(
+        msg.to_lowercase().contains("not found"),
+        "error must say not found, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn db_rejects_malformed_hash_via_check_constraint() {
+    // The column CHECK constraint tenants_manifest_hash_format enforces the
+    // sha256:... shape. A caller that bypasses the application guard still
+    // gets caught at the DB. We deliberately use a raw UPDATE to prove the
+    // constraint is live, since set_manifest_state itself would reject the
+    // bad string only if we added app-level validation (we haven't -- the
+    // DB is the last line of defence on format).
+    let Some(pool) = setup_pool().await else {
+        eprintln!("Skipping: Docker not available");
+        return;
+    };
+    let store = TenantStore::new(pool.clone());
+
+    let slug = unique_id("ms-badhash");
+    store.create_tenant(&slug, &slug).await.unwrap();
+
+    // "sha256:" + only 63 hex chars --> must fail the CHECK.
+    let bad = "sha256:abcd";
+    let res = sqlx::query(
+        "UPDATE tenants SET last_applied_manifest_hash = $1 WHERE slug = $2",
+    )
+    .bind(bad)
+    .bind(&slug)
+    .execute(&pool)
+    .await;
+    assert!(
+        res.is_err(),
+        "DB must reject malformed manifest hash, but UPDATE succeeded"
+    );
+}
+
+#[tokio::test]
+async fn db_rejects_negative_generation_via_check_constraint() {
+    let Some(pool) = setup_pool().await else {
+        eprintln!("Skipping: Docker not available");
+        return;
+    };
+    let store = TenantStore::new(pool.clone());
+
+    let slug = unique_id("ms-neg");
+    store.create_tenant(&slug, &slug).await.unwrap();
+
+    let res = sqlx::query("UPDATE tenants SET manifest_generation = -1 WHERE slug = $1")
+        .bind(&slug)
+        .execute(&pool)
+        .await;
+    assert!(
+        res.is_err(),
+        "DB must reject negative manifest_generation, but UPDATE succeeded"
+    );
+}
+
+#[tokio::test]
+async fn set_manifest_state_tx_commits_with_outer_transaction() {
+    let Some(pool) = setup_pool().await else {
+        eprintln!("Skipping: Docker not available");
+        return;
+    };
+    let store = TenantStore::new(pool.clone());
+
+    let slug = unique_id("ms-tx");
+    store.create_tenant(&slug, &slug).await.unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    TenantStore::set_manifest_state_tx(&mut tx, &slug, VALID_HASH_A, 3)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let (hash, gen_) = store.get_manifest_state(&slug).await.unwrap();
+    assert_eq!(hash.as_deref(), Some(VALID_HASH_A));
+    assert_eq!(gen_, 3);
+}
+
+#[tokio::test]
+async fn set_manifest_state_tx_rollback_leaves_state_untouched() {
+    let Some(pool) = setup_pool().await else {
+        eprintln!("Skipping: Docker not available");
+        return;
+    };
+    let store = TenantStore::new(pool.clone());
+
+    let slug = unique_id("ms-rb");
+    store.create_tenant(&slug, &slug).await.unwrap();
+    store
+        .set_manifest_state(&slug, VALID_HASH_A, 1)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    TenantStore::set_manifest_state_tx(&mut tx, &slug, VALID_HASH_B, 99)
+        .await
+        .unwrap();
+    tx.rollback().await.unwrap();
+
+    let (hash, gen_) = store.get_manifest_state(&slug).await.unwrap();
+    assert_eq!(
+        hash.as_deref(),
+        Some(VALID_HASH_A),
+        "rollback must not persist the tx-scoped write"
+    );
+    assert_eq!(gen_, 1);
+}

--- a/storage/tests/tenant_manifest_state_test.rs
+++ b/storage/tests/tenant_manifest_state_test.rs
@@ -138,13 +138,11 @@ async fn db_rejects_malformed_hash_via_check_constraint() {
 
     // "sha256:" + only 63 hex chars --> must fail the CHECK.
     let bad = "sha256:abcd";
-    let res = sqlx::query(
-        "UPDATE tenants SET last_applied_manifest_hash = $1 WHERE slug = $2",
-    )
-    .bind(bad)
-    .bind(&slug)
-    .execute(&pool)
-    .await;
+    let res = sqlx::query("UPDATE tenants SET last_applied_manifest_hash = $1 WHERE slug = $2")
+        .bind(bad)
+        .bind(&slug)
+        .execute(&pool)
+        .await;
     assert!(
         res.is_err(),
         "DB must reject malformed manifest hash, but UPDATE succeeded"


### PR DESCRIPTION
## Summary

Adds the DB backing for **idempotent, strict-monotonic** tenant manifest application in `provision_tenant` — the last piece before wiring the short-circuit itself (task 1.6, next PR).

Part of **Phase B2** of #99 (harden-tenant-provisioning), spec refs: `openspec/changes/harden-tenant-provisioning/design.md` D5 (idempotent apply) + D6 (monotonic generation).

## What changes

### Migration `027_tenant_manifest_state.sql`

Adds two columns to the `tenants` table:

| Column | Type | Purpose |
|---|---|---|
| `last_applied_manifest_hash` | `TEXT NULL` | Canonical `sha256:<64 hex>` fingerprint of the last applied manifest. `NULL` = never-applied-via-B2 — **never** short-circuits. |
| `manifest_generation` | `BIGINT NOT NULL DEFAULT 0` | Caller-owned revision counter. `0` = never-applied sentinel. |

Plus two `CHECK` constraints (DB-layer last-line-of-defence):
- `tenants_manifest_hash_format` — enforces `^sha256:[0-9a-f]{64}$` when non-null
- `tenants_manifest_generation_nonneg` — enforces `>= 0`

Idempotent: `ADD COLUMN IF NOT EXISTS` + `pg_constraint` lookup in `DO` blocks. Safe to re-run.

### `TenantStore` API surface

Three small methods — intentionally narrow since `provision_tenant` is the only B2 caller today:

- `get_manifest_state(slug) -> (Option<String>, i64)` — read
- `set_manifest_state(slug, hash, gen)` — pool-scope write
- `set_manifest_state_tx(&mut tx, slug, hash, gen)` — tx-scope write, used inside `provision_tenant` so the state update commits atomically with the manifest body

A broader `TenantManifestState` struct was deliberately skipped — shape would be locked in before we have >1 consumer.

### `initialize_schema` parity

The dev/test schema path mirrors the migration additions (columns + CHECKs) so integration tests exercise the same invariants as prod Helm migrations. A small quirk: the regex end-anchor is assembled via `chr(36)` at SQL-eval time rather than inlined as `$` — this keeps the Rust source free of any literal dollar-quote sequence (avoids sqlx / tooling confusion with `$`-prefixed parameter placeholders and dollar-quoted string blocks).

## Test coverage

`storage/tests/tenant_manifest_state_test.rs` — 8 testcontainer-backed integration tests:

1. Fresh row → `NULL` hash + `0` generation (short-circuit safety)
2. Write → read roundtrips both fields
3. Overwriting updates both fields atomically
4. `get_manifest_state` returns `NotFound` for unknown slug
5. `set_manifest_state` returns `NotFound` for unknown slug
6. DB rejects malformed hash via `CHECK`
7. DB rejects negative generation via `CHECK`
8. `set_manifest_state_tx`: commit persists, rollback leaves prior state untouched

All tests self-skip when Docker is unavailable, matching existing `storage/tests/` convention.

Local: `cargo check -p storage --tests` ✅ clean; `cargo test -p storage --test tenant_manifest_state_test` → 8 passed (skip path in no-Docker env).

## What this does **not** do

- **No** caller change to `provision_tenant` — the short-circuit (task 1.6) lands in a follow-up PR to keep review surface small.
- **No** `TenantRecord` struct change — the existing read path stays untouched.
- **No** index on the new columns — lookups are always by `slug`/`id`, neither new column is ever a `WHERE` predicate.

## Rollback

Migration 027 is additive only. Rollback = drop columns + drop constraints, no data migration needed.

## Refs

- Tracker: #99 (Phase B2, task 1.5)
- Design: `openspec/changes/harden-tenant-provisioning/design.md` D5, D6
- Follow-up: task 1.6 short-circuit wiring (separate PR)