### PR TITLE
style: cargo fmt manifest_hash and mk_core::secret

### DIFF
--- a/cli/src/server/manifest_hash.rs
+++ b/cli/src/server/manifest_hash.rs
@@ -159,7 +159,10 @@ mod tests {
         // manifests (e.g. role-assignment order matters for audit)
         let a = json!({"x": [1, 2, 3]});
         let b = json!({"x": [3, 2, 1]});
-        assert_ne!(hash_manifest_value(&a).unwrap(), hash_manifest_value(&b).unwrap());
+        assert_ne!(
+            hash_manifest_value(&a).unwrap(),
+            hash_manifest_value(&b).unwrap()
+        );
     }
 
     #[test]
@@ -224,7 +227,10 @@ mod tests {
     fn hash_changes_when_non_secret_content_changes() {
         let v1 = json!({"tenant": {"slug": "a", "name": "A"}});
         let v2 = json!({"tenant": {"slug": "a", "name": "B"}});
-        assert_ne!(hash_manifest_value(&v1).unwrap(), hash_manifest_value(&v2).unwrap());
+        assert_ne!(
+            hash_manifest_value(&v1).unwrap(),
+            hash_manifest_value(&v2).unwrap()
+        );
     }
 
     #[test]
@@ -234,7 +240,10 @@ mod tests {
         // provision_tenant would short-circuit a version bump.
         let v1 = json!({"metadata": {"generation": 1}, "tenant": {"slug": "a", "name": "A"}});
         let v2 = json!({"metadata": {"generation": 2}, "tenant": {"slug": "a", "name": "A"}});
-        assert_ne!(hash_manifest_value(&v1).unwrap(), hash_manifest_value(&v2).unwrap());
+        assert_ne!(
+            hash_manifest_value(&v1).unwrap(),
+            hash_manifest_value(&v2).unwrap()
+        );
     }
 
     #[test]
@@ -261,7 +270,10 @@ mod tests {
         // "omit labels" become indistinguishable operations.
         let absent = json!({"tenant": {"slug": "x", "name": "X"}});
         let empty = json!({"tenant": {"slug": "x", "name": "X"}, "metadata": {}});
-        assert_ne!(hash_manifest_value(&absent).unwrap(), hash_manifest_value(&empty).unwrap());
+        assert_ne!(
+            hash_manifest_value(&absent).unwrap(),
+            hash_manifest_value(&empty).unwrap()
+        );
     }
 
     #[test]
@@ -278,8 +290,7 @@ mod tests {
         // Recomputed from the canonical bytes of the above object:
         //   {"apiVersion":"aeterna.io/v1","kind":"TenantManifest","tenant":{"name":"Acme","slug":"acme"}}
         assert_eq!(
-            h,
-            "sha256:c262fb0d40d2fafbef7d4f4bf277b74760ca87ead31efcbf1549650551c5a483",
+            h, "sha256:c262fb0d40d2fafbef7d4f4bf277b74760ca87ead31efcbf1549650551c5a483",
             "if this assertion fails, read the test body before changing the expected value"
         );
     }

--- a/mk_core/src/secret.rs
+++ b/mk_core/src/secret.rs
@@ -208,7 +208,11 @@ impl schemars::JsonSchema for SecretBytes {
 /// so future backends (external secret managers, cloud KV stores, etc.)
 /// can be added as additive variants.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum SecretReference {
     /// Encrypted blob stored in the `tenant_secrets` Postgres table. The row
     /// holds a KMS-wrapped DEK and an AES-256-GCM ciphertext.
@@ -299,8 +303,14 @@ mod tests {
             secret_id: Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap(),
         };
         let j = serde_json::to_string(&r).unwrap();
-        assert!(j.contains("\"secretId\""), "expected camelCase secretId on wire, got: {j}");
-        assert!(!j.contains("\"secret_id\""), "snake_case secret_id leaked on wire: {j}");
+        assert!(
+            j.contains("\"secretId\""),
+            "expected camelCase secretId on wire, got: {j}"
+        );
+        assert!(
+            !j.contains("\"secret_id\""),
+            "snake_case secret_id leaked on wire: {j}"
+        );
 
         // Deserialize MUST accept camelCase (the canonical shape) and
         // MUST reject snake_case so we do not have two valid wire shapes.


### PR DESCRIPTION
Drive-by `cargo fmt --all` on two files that slipped in before the fmt CI gate was wired.

- `cli/src/server/manifest_hash.rs` (landed in #104)
- `mk_core/src/secret.rs` (landed in #94)

No semantic changes; `cargo check -p aeterna -p mk_core` clean.