### PR TITLE
[DO NOT MERGE] integration: full B2 tenant-wiring stack (CI canary vs master)

### DIFF
--- a/cli/src/commands/serve.rs
+++ b/cli/src/commands/serve.rs
@@ -55,6 +55,12 @@ pub async fn run(args: ServeArgs) -> anyhow::Result<()> {
     let lifecycle_mgr = lifecycle::LifecycleManager::new();
     lifecycle_mgr.start(state.clone());
 
+    // Eager tenant wiring (B2 task 5.2 — design §D5 boot loop). Spawned
+    // detached; the HTTP server binds immediately and `/ready` (task 5.3)
+    // reports the progress. See
+    // `cli/src/server/tenant_eager_wire.rs` for failure policy.
+    crate::server::tenant_eager_wire::spawn_eager_wire(state.clone());
+
     let app_listener = TcpListener::bind(app_addr).await?;
     let metrics_listener = TcpListener::bind(metrics_addr).await?;
 

--- a/cli/src/commands/serve.rs
+++ b/cli/src/commands/serve.rs
@@ -61,6 +61,12 @@ pub async fn run(args: ServeArgs) -> anyhow::Result<()> {
     // `cli/src/server/tenant_eager_wire.rs` for failure policy.
     crate::server::tenant_eager_wire::spawn_eager_wire(state.clone());
 
+    // Cross-pod tenant invalidation subscriber (task 5.2b). No-op when
+    // Redis is unavailable; in single-pod mode local invalidation is
+    // handled directly by the mutating handler. See
+    // `cli/src/server/tenant_pubsub.rs`.
+    crate::server::tenant_pubsub::spawn_subscriber(state.clone());
+
     let app_listener = TcpListener::bind(app_addr).await?;
     let metrics_listener = TcpListener::bind(metrics_addr).await?;
 

--- a/cli/src/server/admin_sync.rs
+++ b/cli/src/server/admin_sync.rs
@@ -808,6 +808,7 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            redis_url: None,
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),

--- a/cli/src/server/admin_sync.rs
+++ b/cli/src/server/admin_sync.rs
@@ -808,6 +808,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })
     }
 

--- a/cli/src/server/bootstrap.rs
+++ b/cli/src/server/bootstrap.rs
@@ -301,25 +301,25 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
     a2a_auth_state.validate()?;
     // Build a Redis connection manager for shared state stores.
     // If Redis is available, use Redis-backed stores for HA; otherwise fall back to in-memory.
-    let redis_conn: Option<Arc<redis::aio::ConnectionManager>> = {
+    let (redis_conn, redis_url): (Option<Arc<redis::aio::ConnectionManager>>, Option<String>) = {
         let rc = &config.providers.redis;
         let url = format!("redis://{}:{}/{}", rc.host, rc.port, rc.db);
         match redis::Client::open(url.as_str()) {
             Ok(client) => match client.get_connection_manager().await {
                 Ok(cm) => {
                     tracing::info!("Redis connection manager established for shared state stores");
-                    Some(Arc::new(cm))
+                    (Some(Arc::new(cm)), Some(url))
                 }
                 Err(e) => {
                     tracing::warn!(
                         "Failed to connect to Redis ({url}): {e}. Falling back to in-memory stores."
                     );
-                    None
+                    (None, None)
                 }
             },
             Err(e) => {
                 tracing::warn!("Invalid Redis URL ({url}): {e}. Falling back to in-memory stores.");
-                None
+                (None, None)
             }
         }
     };
@@ -405,6 +405,7 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
         provider_registry,
         git_provider_connection_registry,
         redis_conn,
+        redis_url,
         tenant_runtime_state: Arc::new(
             crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
         ),

--- a/cli/src/server/bootstrap.rs
+++ b/cli/src/server/bootstrap.rs
@@ -405,6 +405,9 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
         provider_registry,
         git_provider_connection_registry,
         redis_conn,
+        tenant_runtime_state: Arc::new(
+            crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+        ),
     }))
 }
 

--- a/cli/src/server/context.rs
+++ b/cli/src/server/context.rs
@@ -97,6 +97,86 @@ impl RequestContext {
         }
     }
 
+    /// Like [`require_target_tenant`], but additionally gates on the
+    /// pod-local tenant runtime state (B2 task 5.4).
+    ///
+    /// Handlers that invoke tenant-scoped provider calls (LLM, embedding,
+    /// memory reads/writes) should use this instead of
+    /// [`require_target_tenant`] so callers observe a clean
+    /// `503 tenant_unavailable` rather than an opaque 500 when the
+    /// provider resolve would fail.
+    ///
+    /// # Behaviour
+    ///
+    /// 1. `self.tenant` must be set \u2014 otherwise `400 select_tenant`
+    ///    (same as [`require_target_tenant`]).
+    /// 2. [`tenant_lazy_wire::ensure_wired`] is invoked against the
+    ///    resolved slug. This is cheap when already `Available` and
+    ///    primes the pod on first touch (closes the boot/pub-sub race).
+    /// 3. Result mapping:
+    ///    * `Available`     \u2192 `Ok(&ResolvedTenant)` (happy path)
+    ///    * `Loading`       \u2192 `Err(503 tenant_unavailable)` with
+    ///                        `Retry-After: 1` \u2014 another task is already
+    ///                        wiring, a quick retry will succeed
+    ///    * `LoadingFailed` (reason = \"tenant not found\") \u2192 `404`.
+    ///    * `LoadingFailed` (any other reason) \u2192 `503 tenant_unavailable`
+    ///                        with a cooldown-aligned `Retry-After`
+    ///                        header (30s by default)
+    ///
+    /// # Security
+    ///
+    /// The response body carries `error`, `state`, and `retryAfterSeconds`
+    /// but **never the internal failure reason**. Reasons can contain
+    /// upstream error text not fit for the caller's trust boundary; they
+    /// are reachable only through the admin status endpoint (task 5.5).
+    pub async fn require_available_tenant<'a>(
+        &'a self,
+        state: &crate::server::AppState,
+        headers: &HeaderMap,
+    ) -> Result<&'a ResolvedTenant, Response> {
+        let tenant = self.require_target_tenant(headers)?;
+
+        use crate::server::tenant_lazy_wire;
+        use crate::server::tenant_runtime_state::TenantRuntimeState;
+
+        let rt = tenant_lazy_wire::ensure_wired(state, &tenant.slug).await;
+
+        match rt {
+            TenantRuntimeState::Available { .. } => Ok(tenant),
+            TenantRuntimeState::Loading { .. } => Err(tenant_unavailable_response(
+                &tenant.slug,
+                "loading",
+                // A Loading state means another task holds the wiring;
+                // it should complete within the resolver budget. 1s is
+                // a sensible client retry.
+                1,
+            )),
+            TenantRuntimeState::LoadingFailed { reason, .. } => {
+                // Stable marker from tenant_lazy_wire: the slug was
+                // unknown to the tenant store. Surface as 404 so the
+                // caller doesn't retry what will never succeed.
+                if reason == "tenant not found" {
+                    Err(error_response(
+                        StatusCode::NOT_FOUND,
+                        "tenant_not_found",
+                        &format!("No tenant matches slug '{}'", tenant.slug),
+                        None,
+                    ))
+                } else {
+                    Err(tenant_unavailable_response(
+                        &tenant.slug,
+                        "loadingFailed",
+                        // Must be >= the lazy-wire cooldown or the client
+                        // will retry inside the cooldown and get the
+                        // cached failure again. 30s matches the default
+                        // `AETERNA_LAZY_RETRY_COOLDOWN_SECS`.
+                        30,
+                    ))
+                }
+            }
+        }
+    }
+
     /// Convenience: build a `TenantContext` for call sites that still require
     /// the legacy shape. Emits `select_tenant` if no tenant is resolved.
     pub fn require_tenant_context(&self, headers: &HeaderMap) -> Result<TenantContext, Response> {
@@ -681,6 +761,34 @@ fn error_response(
     (status, Json(body)).into_response()
 }
 
+/// Canonical `503 tenant_unavailable` response used by the B2 task 5.4
+/// shield. Centralised so callers (the shield helper and future hand-
+/// crafted short-circuits) emit identical wire shape \u2014 the SRE
+/// dashboard keys on `retryAfterSeconds`.
+///
+/// `Retry-After` is set in seconds (HTTP/1.1 §7.1.3 delta-seconds form);
+/// clients that respect it (K8s Service mesh sidecars, most SDK
+/// retry layers) back off correctly without us coding the budget twice.
+fn tenant_unavailable_response(slug: &str, wiring_state: &str, retry_after_secs: u64) -> Response {
+    use axum::http::HeaderValue;
+    let extra = json!({
+        "tenant": slug,
+        "state": wiring_state,
+        "retryAfterSeconds": retry_after_secs,
+    });
+    let mut resp = error_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "tenant_unavailable",
+        &format!("Tenant '{slug}' is not ready to serve traffic on this pod"),
+        Some(extra),
+    );
+    if let Ok(v) = HeaderValue::from_str(&retry_after_secs.to_string()) {
+        resp.headers_mut()
+            .insert(axum::http::header::RETRY_AFTER, v);
+    }
+    resp
+}
+
 // Re-export for external use in tests.
 pub const INSTANCE_SCOPE: &str = INSTANCE_SCOPE_TENANT_ID;
 
@@ -841,5 +949,82 @@ mod tests {
             ScopeIntent::All { is_alias: true } => {}
             other => panic!("case-insensitive alias failed: {other:?}"),
         }
+    }
+
+    // ── B2 task 5.4 shield helpers ──────────────────────────────────────
+    //
+    // The end-to-end behaviour of `require_available_tenant` is exercised
+    // in `cli/tests/tenant_shield_integration_test.rs` because it needs a
+    // live `AppState` with a populated tenant store. The unit tests below
+    // cover the response-shape contract that integration tests would
+    // otherwise duplicate verbosely.
+
+    async fn body_json(resp: Response) -> serde_json::Value {
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    #[tokio::test]
+    async fn tenant_unavailable_response_loading_shape() {
+        let resp = tenant_unavailable_response("acme", "loading", 1);
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok()),
+            Some("1"),
+            "Retry-After header MUST be set in seconds (delta-seconds form)"
+        );
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], "tenant_unavailable");
+        assert_eq!(body["tenant"], "acme");
+        assert_eq!(body["state"], "loading");
+        assert_eq!(body["retryAfterSeconds"], 1);
+    }
+
+    #[tokio::test]
+    async fn tenant_unavailable_response_failed_uses_cooldown_aligned_retry() {
+        // 30s matches the default lazy-wire cooldown. Clients retrying
+        // earlier would hit the cached failure and get nothing new.
+        let resp = tenant_unavailable_response("acme", "loadingFailed", 30);
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok()),
+            Some("30"),
+        );
+        let body = body_json(resp).await;
+        assert_eq!(body["state"], "loadingFailed");
+        assert_eq!(body["retryAfterSeconds"], 30);
+    }
+
+    #[tokio::test]
+    async fn tenant_unavailable_response_never_leaks_failure_reason() {
+        // The 503 shield body is designed so no call site CAN serialize
+        // the upstream failure reason \u2014 the function signature doesn't
+        // accept one. This test locks that in against a future signature
+        // change that might add a `reason: &str` parameter.
+        let resp = tenant_unavailable_response("acme", "loadingFailed", 30);
+        let body = body_json(resp).await;
+        let serialized = body.to_string();
+        assert!(
+            !serialized.to_lowercase().contains("reason"),
+            "body unexpectedly carries a 'reason' field: {serialized}"
+        );
+    }
+
+    #[tokio::test]
+    async fn tenant_unavailable_response_tolerates_large_retry_after() {
+        // HeaderValue::from_str can fail on NUL bytes; u64::MAX as a
+        // decimal string is 20 ASCII digits and must round-trip cleanly.
+        let resp = tenant_unavailable_response("acme", "loadingFailed", u64::MAX);
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            resp.headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .is_some()
+        );
     }
 }

--- a/cli/src/server/health.rs
+++ b/cli/src/server/health.rs
@@ -7,6 +7,8 @@ use serde::Serialize;
 use std::sync::Arc;
 
 use super::AppState;
+use super::tenant_eager_wire::is_strict_mode;
+use super::tenant_runtime_state::TenantRuntimeState;
 
 #[derive(Serialize)]
 struct HealthResponse {
@@ -24,6 +26,11 @@ pub(crate) struct ReadinessResponse {
 pub(crate) struct ReadinessChecks {
     postgres: CheckResult,
     vector_store: CheckResult,
+    /// Summary of per-tenant wiring state. See [`TenantCheck`].
+    ///
+    /// Added in B2 task 5.3. The field name is stable and monitored by
+    /// the SRE dashboard; renaming breaks external alerting rules.
+    tenants: TenantCheck,
 }
 
 #[derive(Serialize)]
@@ -31,6 +38,105 @@ pub(crate) struct CheckResult {
     status: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     message: Option<String>,
+}
+
+/// Observable summary of the pod-local tenant runtime registry.
+///
+/// # Semantics
+///
+/// * `status == "ok"`      \u2014 every known tenant is `Available` *or* there are
+///   no tenants at all (fresh cluster).
+/// * `status == "pending"` \u2014 at least one tenant is `Loading`, none failed.
+///   This happens during the eager-boot window and during pub/sub rewires;
+///   it does **not** flip the HTTP gate (see §Gate below).
+/// * `status == "degraded"`\u2014 at least one tenant is `LoadingFailed`. Flips
+///   the HTTP gate iff strict mode is on.
+///
+/// # Gate
+///
+/// `/ready` returns 503 when `failed > 0 && strictMode`. All other
+/// combinations return 200. In particular:
+///
+/// * A tenant in `Loading` does **not** cause 503 \u2014 rewires triggered by
+///   `tenant:changed` pub/sub would otherwise flap traffic off the pod.
+/// * Permissive mode (the default) never 503s on tenant state so
+///   single-tenant misconfiguration cannot take an entire cluster out
+///   of rotation. Operators opt in to strict mode per-environment via
+///   `AETERNA_EAGER_WIRE_STRICT=1`.
+///
+/// # Field stability
+///
+/// `total`, `available`, `loading`, `failed`, and `strictMode` are the
+/// wire contract monitored by alerts and the ops dashboard. Adding new
+/// fields is fine; renaming is not.
+///
+/// `failedSlugs` is populated only when `failed > 0` and contains the
+/// tenant slugs (never the failure reason strings, which may include
+/// upstream error details the caller isn't authorised to see \u2014 reasons
+/// are surfaced by the admin-only status endpoint in task 5.5).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TenantCheck {
+    status: &'static str,
+    total: usize,
+    available: usize,
+    loading: usize,
+    failed: usize,
+    /// Reflects the value of `AETERNA_EAGER_WIRE_STRICT` at *this request*.
+    /// Read each call so an operator toggling the env var doesn't need a
+    /// pod restart for the gate behaviour to change.
+    strict_mode: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    failed_slugs: Vec<String>,
+}
+
+impl TenantCheck {
+    /// Compute the check body from a snapshot of the registry.
+    ///
+    /// Sorts `failed_slugs` for deterministic output \u2014 avoids churning
+    /// monitoring diffs on every scrape when the set is stable.
+    fn from_snapshot(snapshot: Vec<(String, TenantRuntimeState)>, strict_mode: bool) -> Self {
+        let total = snapshot.len();
+        let mut available = 0usize;
+        let mut loading = 0usize;
+        let mut failed = 0usize;
+        let mut failed_slugs: Vec<String> = Vec::new();
+        for (slug, state) in snapshot {
+            match state {
+                TenantRuntimeState::Available { .. } => available += 1,
+                TenantRuntimeState::Loading { .. } => loading += 1,
+                TenantRuntimeState::LoadingFailed { .. } => {
+                    failed += 1;
+                    failed_slugs.push(slug);
+                }
+            }
+        }
+        failed_slugs.sort();
+        let status = if failed > 0 {
+            "degraded"
+        } else if loading > 0 {
+            "pending"
+        } else {
+            "ok"
+        };
+        Self {
+            status,
+            total,
+            available,
+            loading,
+            failed,
+            strict_mode,
+            failed_slugs,
+        }
+    }
+
+    /// True iff this check should gate the `/ready` response to 503.
+    ///
+    /// Intentionally narrow: only `failed > 0 && strict_mode`. See the
+    /// type-level docs for the rationale.
+    fn blocks_readiness(&self) -> bool {
+        self.failed > 0 && self.strict_mode
+    }
 }
 
 pub fn router(state: Arc<AppState>) -> Router {
@@ -58,15 +164,20 @@ async fn liveness_handler() -> StatusCode {
 async fn readiness_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let pg_check = check_postgres(&state).await;
     let vector_check = check_vector_store(&state).await;
+    let tenant_check = check_tenants(&state).await;
 
-    readiness_response(pg_check, vector_check)
+    readiness_response(pg_check, vector_check, tenant_check)
 }
 
 pub(crate) fn readiness_response(
     pg_check: CheckResult,
     vector_check: CheckResult,
+    tenant_check: TenantCheck,
 ) -> (StatusCode, Json<ReadinessResponse>) {
-    let all_healthy = pg_check.status == "ok" && vector_check.status == "ok";
+    // Backend checks gate unconditionally; tenant state gates only in
+    // strict mode with actual failures. See `TenantCheck::blocks_readiness`.
+    let backends_ok = pg_check.status == "ok" && vector_check.status == "ok";
+    let all_healthy = backends_ok && !tenant_check.blocks_readiness();
     let status_code = if all_healthy {
         StatusCode::OK
     } else {
@@ -78,10 +189,26 @@ pub(crate) fn readiness_response(
         checks: ReadinessChecks {
             postgres: pg_check,
             vector_store: vector_check,
+            tenants: tenant_check,
         },
     };
 
     (status_code, Json(response))
+}
+
+/// Build the `tenants` check body by snapshotting the runtime registry.
+///
+/// This is a read under the registry's `RwLock::read`; concurrent
+/// `mark_*` calls during a scrape yield a point-in-time snapshot, not a
+/// torn view. Duration is bounded by the number of tenants, which is
+/// single-digit thousands in practice \u2014 well within a probe's budget.
+#[tracing::instrument(skip_all)]
+async fn check_tenants(state: &AppState) -> TenantCheck {
+    let snapshot = state.tenant_runtime_state.snapshot().await;
+    // `is_strict_mode` is read every request so operators can flip
+    // `AETERNA_EAGER_WIRE_STRICT` without a pod restart when they need
+    // to bring a cluster back into rotation fast.
+    TenantCheck::from_snapshot(snapshot, is_strict_mode())
 }
 
 #[tracing::instrument(skip_all)]
@@ -488,36 +615,36 @@ mod tests {
         assert!(json.get("version").is_some());
     }
 
+    /// Shorthand helpers so the assertions stay readable.
+    fn ok_check() -> CheckResult {
+        CheckResult {
+            status: "ok",
+            message: None,
+        }
+    }
+    fn err_check(msg: &str) -> CheckResult {
+        CheckResult {
+            status: "error",
+            message: Some(msg.to_string()),
+        }
+    }
+    fn empty_tenants() -> TenantCheck {
+        TenantCheck::from_snapshot(Vec::new(), false)
+    }
+
     #[test]
     fn readiness_response_is_ready_when_all_checks_ok() {
-        let (status, Json(body)) = readiness_response(
-            CheckResult {
-                status: "ok",
-                message: None,
-            },
-            CheckResult {
-                status: "ok",
-                message: None,
-            },
-        );
-
+        let (status, Json(body)) = readiness_response(ok_check(), ok_check(), empty_tenants());
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body.status, "ready");
+        assert_eq!(body.checks.tenants.status, "ok");
+        assert_eq!(body.checks.tenants.total, 0);
     }
 
     #[test]
     fn readiness_response_is_not_ready_when_one_backend_fails() {
-        let (status, Json(body)) = readiness_response(
-            CheckResult {
-                status: "error",
-                message: Some("db down".to_string()),
-            },
-            CheckResult {
-                status: "ok",
-                message: None,
-            },
-        );
-
+        let (status, Json(body)) =
+            readiness_response(err_check("db down"), ok_check(), empty_tenants());
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(body.status, "not_ready");
         assert_eq!(body.checks.postgres.message.as_deref(), Some("db down"));
@@ -526,21 +653,148 @@ mod tests {
     #[test]
     fn readiness_response_is_not_ready_when_all_backends_fail() {
         let (status, Json(body)) = readiness_response(
-            CheckResult {
-                status: "error",
-                message: Some("db down".to_string()),
-            },
-            CheckResult {
-                status: "error",
-                message: Some("vector down".to_string()),
-            },
+            err_check("db down"),
+            err_check("vector down"),
+            empty_tenants(),
         );
-
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(body.status, "not_ready");
         assert_eq!(
             body.checks.vector_store.message.as_deref(),
             Some("vector down")
         );
+    }
+
+    // ── Tenant gate tests (B2 task 5.3) ─────────────────────────────────
+
+    /// Build a snapshot from `(slug, state)` tuples. Using the concrete
+    /// enum keeps the test expressive vs. constructing a full registry.
+    fn snap(entries: Vec<(&str, TenantRuntimeState)>) -> Vec<(String, TenantRuntimeState)> {
+        entries
+            .into_iter()
+            .map(|(s, st)| (s.to_string(), st))
+            .collect()
+    }
+
+    #[test]
+    fn tenant_check_all_available_is_ok() {
+        let snapshot = snap(vec![
+            ("alpha", TenantRuntimeState::available_now(3)),
+            ("beta", TenantRuntimeState::available_now(1)),
+        ]);
+        let c = TenantCheck::from_snapshot(snapshot, true);
+        assert_eq!(c.status, "ok");
+        assert_eq!((c.total, c.available, c.loading, c.failed), (2, 2, 0, 0));
+        assert!(c.failed_slugs.is_empty());
+        assert!(!c.blocks_readiness());
+    }
+
+    #[test]
+    fn tenant_check_loading_is_pending_and_not_blocking() {
+        // Critical for production: a rewire puts the tenant briefly in
+        // Loading; /ready MUST NOT flap to 503 during this window, even
+        // in strict mode, otherwise every pub/sub invalidation would
+        // kick the pod out of the LB rotation.
+        let snapshot = snap(vec![("alpha", TenantRuntimeState::loading_now())]);
+        let c = TenantCheck::from_snapshot(snapshot, true);
+        assert_eq!(c.status, "pending");
+        assert_eq!((c.total, c.available, c.loading, c.failed), (1, 0, 1, 0));
+        assert!(!c.blocks_readiness());
+    }
+
+    #[test]
+    fn tenant_check_failed_non_strict_is_degraded_but_not_blocking() {
+        let snapshot = snap(vec![(
+            "alpha",
+            TenantRuntimeState::failed_now("secret missing"),
+        )]);
+        let c = TenantCheck::from_snapshot(snapshot, false);
+        assert_eq!(c.status, "degraded");
+        assert_eq!(c.failed, 1);
+        assert_eq!(c.failed_slugs, vec!["alpha"]);
+        assert!(
+            !c.blocks_readiness(),
+            "permissive mode must not take the pod out of rotation"
+        );
+    }
+
+    #[test]
+    fn tenant_check_failed_strict_blocks_readiness() {
+        let snapshot = snap(vec![
+            ("alpha", TenantRuntimeState::available_now(1)),
+            ("beta", TenantRuntimeState::failed_now("dns nxdomain")),
+        ]);
+        let c = TenantCheck::from_snapshot(snapshot, true);
+        assert_eq!(c.status, "degraded");
+        assert_eq!(c.failed, 1);
+        assert!(c.blocks_readiness());
+
+        let (status, Json(body)) = readiness_response(ok_check(), ok_check(), c);
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body.status, "not_ready");
+    }
+
+    #[test]
+    fn tenant_check_failed_slugs_are_sorted() {
+        // Deterministic output keeps monitoring diffs quiet on steady
+        // state; HashMap snapshot order is otherwise arbitrary.
+        let snapshot = snap(vec![
+            ("zulu", TenantRuntimeState::failed_now("x")),
+            ("alpha", TenantRuntimeState::failed_now("y")),
+            ("mike", TenantRuntimeState::failed_now("z")),
+        ]);
+        let c = TenantCheck::from_snapshot(snapshot, true);
+        assert_eq!(c.failed_slugs, vec!["alpha", "mike", "zulu"]);
+    }
+
+    #[test]
+    fn tenant_check_never_leaks_failure_reasons_to_wire() {
+        // The reason field may contain upstream error text not fit for
+        // unauthenticated probes; only slugs go on the wire.
+        let snapshot = snap(vec![(
+            "alpha",
+            TenantRuntimeState::failed_now("upstream api key XYZ rejected"),
+        )]);
+        let c = TenantCheck::from_snapshot(snapshot, false);
+        let wire = serde_json::to_string(&c).unwrap();
+        assert!(!wire.contains("XYZ"), "reason leaked: {wire}");
+        assert!(!wire.contains("rejected"), "reason leaked: {wire}");
+        assert!(wire.contains("\"failedSlugs\""));
+        assert!(wire.contains("alpha"));
+    }
+
+    #[test]
+    fn tenant_check_wire_fields_are_camel_case() {
+        // Wire contract: dashboards key on camelCase. Guard against a
+        // rename sneaking in.
+        let snapshot = snap(vec![("x", TenantRuntimeState::available_now(1))]);
+        let c = TenantCheck::from_snapshot(snapshot, true);
+        let v = serde_json::to_value(&c).unwrap();
+        for key in [
+            "status",
+            "total",
+            "available",
+            "loading",
+            "failed",
+            "strictMode",
+        ] {
+            assert!(v.get(key).is_some(), "missing key {key} in {v}");
+        }
+    }
+
+    #[test]
+    fn tenant_check_mixed_counts_are_exact() {
+        let snapshot = snap(vec![
+            ("a", TenantRuntimeState::available_now(1)),
+            ("b", TenantRuntimeState::available_now(2)),
+            ("c", TenantRuntimeState::loading_now()),
+            ("d", TenantRuntimeState::failed_now("x")),
+            ("e", TenantRuntimeState::failed_now("y")),
+        ]);
+        let c = TenantCheck::from_snapshot(snapshot, false);
+        assert_eq!((c.total, c.available, c.loading, c.failed), (5, 2, 1, 2));
+        // `degraded` wins over `pending` when both apply: operator
+        // attention should focus on failures first.
+        assert_eq!(c.status, "degraded");
     }
 }

--- a/cli/src/server/health.rs
+++ b/cli/src/server/health.rs
@@ -400,6 +400,7 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            redis_url: None,
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),

--- a/cli/src/server/health.rs
+++ b/cli/src/server/health.rs
@@ -400,6 +400,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })
     }
 

--- a/cli/src/server/knowledge_api.rs
+++ b/cli/src/server/knowledge_api.rs
@@ -1980,6 +1980,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })))
     }
 
@@ -2565,6 +2568,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })))
     }
 

--- a/cli/src/server/knowledge_api.rs
+++ b/cli/src/server/knowledge_api.rs
@@ -1980,6 +1980,7 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            redis_url: None,
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
@@ -2568,6 +2569,7 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            redis_url: None,
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),

--- a/cli/src/server/lifecycle.rs
+++ b/cli/src/server/lifecycle.rs
@@ -659,6 +659,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })
     }
 

--- a/cli/src/server/lifecycle.rs
+++ b/cli/src/server/lifecycle.rs
@@ -659,6 +659,7 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            redis_url: None,
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),

--- a/cli/src/server/manifest_hash.rs
+++ b/cli/src/server/manifest_hash.rs
@@ -159,7 +159,10 @@ mod tests {
         // manifests (e.g. role-assignment order matters for audit)
         let a = json!({"x": [1, 2, 3]});
         let b = json!({"x": [3, 2, 1]});
-        assert_ne!(hash_manifest_value(&a).unwrap(), hash_manifest_value(&b).unwrap());
+        assert_ne!(
+            hash_manifest_value(&a).unwrap(),
+            hash_manifest_value(&b).unwrap()
+        );
     }
 
     #[test]
@@ -224,7 +227,10 @@ mod tests {
     fn hash_changes_when_non_secret_content_changes() {
         let v1 = json!({"tenant": {"slug": "a", "name": "A"}});
         let v2 = json!({"tenant": {"slug": "a", "name": "B"}});
-        assert_ne!(hash_manifest_value(&v1).unwrap(), hash_manifest_value(&v2).unwrap());
+        assert_ne!(
+            hash_manifest_value(&v1).unwrap(),
+            hash_manifest_value(&v2).unwrap()
+        );
     }
 
     #[test]
@@ -234,7 +240,10 @@ mod tests {
         // provision_tenant would short-circuit a version bump.
         let v1 = json!({"metadata": {"generation": 1}, "tenant": {"slug": "a", "name": "A"}});
         let v2 = json!({"metadata": {"generation": 2}, "tenant": {"slug": "a", "name": "A"}});
-        assert_ne!(hash_manifest_value(&v1).unwrap(), hash_manifest_value(&v2).unwrap());
+        assert_ne!(
+            hash_manifest_value(&v1).unwrap(),
+            hash_manifest_value(&v2).unwrap()
+        );
     }
 
     #[test]
@@ -261,7 +270,10 @@ mod tests {
         // "omit labels" become indistinguishable operations.
         let absent = json!({"tenant": {"slug": "x", "name": "X"}});
         let empty = json!({"tenant": {"slug": "x", "name": "X"}, "metadata": {}});
-        assert_ne!(hash_manifest_value(&absent).unwrap(), hash_manifest_value(&empty).unwrap());
+        assert_ne!(
+            hash_manifest_value(&absent).unwrap(),
+            hash_manifest_value(&empty).unwrap()
+        );
     }
 
     #[test]
@@ -278,8 +290,7 @@ mod tests {
         // Recomputed from the canonical bytes of the above object:
         //   {"apiVersion":"aeterna.io/v1","kind":"TenantManifest","tenant":{"name":"Acme","slug":"acme"}}
         assert_eq!(
-            h,
-            "sha256:c262fb0d40d2fafbef7d4f4bf277b74760ca87ead31efcbf1549650551c5a483",
+            h, "sha256:c262fb0d40d2fafbef7d4f4bf277b74760ca87ead31efcbf1549650551c5a483",
             "if this assertion fails, read the test body before changing the expected value"
         );
     }

--- a/cli/src/server/mcp_transport.rs
+++ b/cli/src/server/mcp_transport.rs
@@ -376,6 +376,7 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            redis_url: None,
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),

--- a/cli/src/server/mcp_transport.rs
+++ b/cli/src/server/mcp_transport.rs
@@ -376,6 +376,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         });
 
         (server, app_state, tempdir)

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -22,6 +22,7 @@ pub mod sessions;
 pub mod sync;
 pub mod team_api;
 pub mod tenant_api;
+pub mod tenant_runtime_state;
 pub mod user_api;
 pub mod webhooks;
 

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -23,6 +23,7 @@ pub mod sync;
 pub mod team_api;
 pub mod tenant_api;
 pub mod tenant_eager_wire;
+pub mod tenant_lazy_wire;
 pub mod tenant_pubsub;
 pub mod tenant_runtime_state;
 pub mod user_api;

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -22,6 +22,7 @@ pub mod sessions;
 pub mod sync;
 pub mod team_api;
 pub mod tenant_api;
+pub mod tenant_eager_wire;
 pub mod tenant_runtime_state;
 pub mod user_api;
 pub mod webhooks;
@@ -110,6 +111,11 @@ pub struct AppState {
     pub tenant_config_provider: Arc<KubernetesTenantConfigProvider>,
     /// Per-tenant LLM/embedding provider registry with caching.
     pub provider_registry: Arc<TenantProviderRegistry>,
+    /// Per-tenant readiness state recorded by the eager boot loop and
+    /// rewire triggers. Consulted by `/ready` (task 5.3) and tenant-scoped
+    /// routes (task 5.4). See [`tenant_runtime_state`] for the state
+    /// machine.
+    pub tenant_runtime_state: Arc<tenant_runtime_state::TenantRuntimeRegistry>,
     /// Registry of platform-owned Git provider connections (task 3.4).
     pub git_provider_connection_registry:
         Arc<dyn GitProviderConnectionRegistry<Error = GitProviderConnectionError> + Send + Sync>,

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -23,6 +23,7 @@ pub mod sync;
 pub mod team_api;
 pub mod tenant_api;
 pub mod tenant_eager_wire;
+pub mod tenant_pubsub;
 pub mod tenant_runtime_state;
 pub mod user_api;
 pub mod webhooks;
@@ -124,6 +125,13 @@ pub struct AppState {
     /// When present, backup job stores, dead-letter queue, remediation store,
     /// and lifecycle distributed locks use Redis instead of in-memory state.
     pub redis_conn: Option<Arc<redis::aio::ConnectionManager>>,
+    /// Redis connection URL, retained when [`Self::redis_conn`] is `Some`.
+    ///
+    /// Kept alongside the multiplexed manager because Redis Pub/Sub requires
+    /// a dedicated (non-multiplexed) connection per subscriber — the
+    /// manager cannot service `SUBSCRIBE`. Consumers wanting Pub/Sub must
+    /// reopen a client from this URL.
+    pub redis_url: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -24,6 +24,7 @@ pub mod team_api;
 pub mod tenant_api;
 pub mod tenant_eager_wire;
 pub mod tenant_lazy_wire;
+pub mod tenant_metrics;
 pub mod tenant_pubsub;
 pub mod tenant_runtime_state;
 pub mod tenant_wiring_api;

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -397,7 +397,22 @@ pub async fn authenticated_tenant_context(
         };
 
     let ctx = context::request_context(state, effective_headers).await?;
-    let tenant = ctx.require_target_tenant(effective_headers)?.clone();
+    // B2 task 5.4: gate every tenant-scoped handler on wiring state.
+    // `require_available_tenant` runs `require_target_tenant` internally
+    // (so `select_tenant` still fires when no target is bound) and then
+    // consults `TenantRuntimeRegistry`. Loading / LoadingFailed / absent
+    // tenants get a typed 503 `tenant_unavailable` with a `Retry-After`
+    // header — users never see a resolver stall or a confusing 500
+    // from an empty provider cache. Reasons stay out of the response;
+    // the PA status endpoint (task 5.5) is the authenticated surface
+    // that carries diagnostic detail. A single chokepoint here covers
+    // every caller of `authenticated_tenant_context` /
+    // `tenant_scoped_context`, which is every tenant-scoped handler in
+    // the server — no per-handler sweep needed.
+    let tenant = ctx
+        .require_available_tenant(state, effective_headers)
+        .await?
+        .clone();
 
     // Tenant-scoped roles: RequestContext carries *instance-scope* roles
     // (so PlatformAdmin is always visible); legacy handlers expect

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -26,6 +26,7 @@ pub mod tenant_eager_wire;
 pub mod tenant_lazy_wire;
 pub mod tenant_pubsub;
 pub mod tenant_runtime_state;
+pub mod tenant_wiring_api;
 pub mod user_api;
 pub mod webhooks;
 

--- a/cli/src/server/router.rs
+++ b/cli/src/server/router.rs
@@ -18,7 +18,7 @@ use super::auth_middleware::AuthenticationLayer;
 use super::{
     AppState, admin_sync, backup_api, govern_api, health, knowledge_api, lifecycle_api,
     mcp_transport, memory_api, org_api, plugin_auth, project_api, role_grants, sessions, sync,
-    team_api, tenant_api, user_api, webhooks,
+    team_api, tenant_api, tenant_wiring_api, user_api, webhooks,
 };
 
 pub fn build_router(state: Arc<AppState>) -> Router {
@@ -39,6 +39,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .merge(sessions::router(state.clone()))
         .merge(webhooks::router(state.clone()))
         .merge(admin_sync::router(state.clone()))
+        // B2 task 5.5: PA-only wiring status endpoints. Mounted
+        // alongside admin_sync so the /admin/tenants/... namespace
+        // stays contiguous in the router.
+        .merge(tenant_wiring_api::router(state.clone()))
         .merge(tenant_api::router(state.clone()))
         .merge(org_api::router(state.clone()))
         .merge(team_api::router(state.clone()))

--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -4357,6 +4357,23 @@ async fn provision_tenant(
         }
     }
 
+    // ── Post-apply: local re-wire + cross-pod broadcast ─────────────────
+    //
+    // Even a partial apply (`overall_ok == false`) can legitimately change
+    // provider config/secrets, so we broadcast on every provision attempt
+    // that at minimum ensured the tenant row (we returned early above if
+    // that failed). The handler is idempotent; over-broadcasting is
+    // cheap. The local `handle_event` call guarantees this pod's caches
+    // converge immediately without waiting for the pub/sub round-trip —
+    // important because the same HTTP client may hit this pod again on
+    // the very next request and deserves to see the new state.
+    let change = super::tenant_pubsub::TenantChangeEvent::new(
+        tenant_record.slug.clone(),
+        super::tenant_pubsub::TenantChangeKind::Provisioned,
+    );
+    super::tenant_pubsub::handle_event(state.as_ref(), change.clone()).await;
+    super::tenant_pubsub::publish(state.as_ref(), &change).await;
+
     // ── Final response ────────────────────────────────────────────────────
     let status = if overall_ok {
         StatusCode::OK
@@ -4671,6 +4688,7 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            redis_url: None,
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),

--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -4671,6 +4671,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         });
 
         Some((router(state), tenant))

--- a/cli/src/server/tenant_eager_wire.rs
+++ b/cli/src/server/tenant_eager_wire.rs
@@ -1,0 +1,272 @@
+//! Eager tenant wiring (B2 task 5.2 — boot-loop half of design §D5).
+//!
+//! On pod start, the handler [`spawn_eager_wire`] enumerates every active
+//! tenant and primes the provider registry so subsequent requests hit a
+//! warm cache and so misconfigured tenants are surfaced by `/ready` (task
+//! 5.3) instead of by the first user who tries to use them.
+//!
+//! # Scope of this drop
+//!
+//! This module owns *only* the boot loop. The pub/sub subscriber that
+//! listens on `tenant:changed` for cross-pod invalidation and the lazy
+//! fallback that closes the sub-second race window (both per design
+//! §D5) land in follow-up PRs; the public surface here — `spawn_eager_wire`
+//! taking `Arc<AppState>` — is designed so those additions do not
+//! require another wide refactor.
+//!
+//! # Blocking policy
+//!
+//! Boot does **not** block on the wiring completing. The task is spawned
+//! and returns immediately so the HTTP server can bind and serve `/health`
+//! (liveness). What a failed wiring costs is that `/ready` keeps returning
+//! 503 with `LoadingFailed` tenants visible in the status endpoint until
+//! either a rewire succeeds or the tenant is deactivated. Per-tenant
+//! failures do not taint other tenants.
+//!
+//! # Strict mode
+//!
+//! `AETERNA_EAGER_WIRE_STRICT=1` makes any `LoadingFailed` keep `/ready`
+//! at 503 forever. Default (per design §D5 "failure policy: per-tenant")
+//! is permissive — `/ready` flips to 200 once every tenant has *some*
+//! terminal state, so a single misconfigured tenant does not lock the
+//! whole cluster out of load-balancer rotation.
+//!
+//! Strict mode is consulted by the `/ready` handler (5.3), not here —
+//! this module only records state. We expose a helper so the handler
+//! reads the same env var.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use tracing::{debug, error, info, warn};
+
+use super::AppState;
+
+/// Spawn the eager tenant-wiring task.
+///
+/// Returns immediately. The task runs on the tokio runtime and logs
+/// progress at INFO; failures log at WARN with the tenant slug and the
+/// error summary (redacted — downstream producers must not include
+/// secret material in error messages).
+///
+/// The caller owns the `Arc<AppState>` returned by [`super::bootstrap::bootstrap`];
+/// passing a clone keeps the task independent of the HTTP server
+/// lifecycle. Graceful shutdown is driven by `AppState::shutdown_tx`
+/// — the loop checks the watch on each iteration and bails without
+/// writing further state when shutdown is requested.
+pub fn spawn_eager_wire(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        if let Err(e) = run_eager_wire(&state).await {
+            error!(error = %e, "eager tenant wiring loop failed");
+        }
+    });
+}
+
+/// True iff strict mode is enabled. Used by the `/ready` gate (5.3).
+/// Defined here so the env-var spelling is centralised.
+pub fn is_strict_mode() -> bool {
+    matches!(
+        std::env::var("AETERNA_EAGER_WIRE_STRICT").as_deref(),
+        Ok("1" | "true" | "TRUE" | "yes" | "on")
+    )
+}
+
+async fn run_eager_wire(state: &AppState) -> anyhow::Result<()> {
+    let started = Instant::now();
+    let tenants = state.tenant_store.list_tenants(false).await?;
+    info!(
+        tenant_count = tenants.len(),
+        strict_mode = is_strict_mode(),
+        "eager tenant wiring: starting"
+    );
+
+    // Seed every tenant as Loading BEFORE we start resolving — this way
+    // `/ready` cannot observe a partial registry that says "all available"
+    // simply because we haven't recorded the in-flight ones yet. Between
+    // this loop and the resolution loop `all_available` returns false
+    // even if the first tenant already finished.
+    for t in &tenants {
+        state
+            .tenant_runtime_state
+            .mark_loading(t.slug.as_str())
+            .await;
+    }
+
+    let mut ok = 0usize;
+    let mut failed = 0usize;
+    for t in tenants {
+        // Respect shutdown: stop seeding new work but leave already-recorded
+        // state intact. The pod will exit in moments.
+        if *state.shutdown_tx.borrow() {
+            warn!("eager tenant wiring: shutdown requested, aborting");
+            break;
+        }
+
+        let slug = t.slug.clone();
+        let tenant_id = t.id.clone();
+        let started_one = Instant::now();
+        match wire_one(state, &tenant_id).await {
+            Ok(()) => {
+                let rev = state.tenant_runtime_state.mark_available(&slug).await;
+                ok += 1;
+                debug!(
+                    tenant = %slug,
+                    rev,
+                    elapsed_ms = started_one.elapsed().as_millis() as u64,
+                    "tenant wired"
+                );
+            }
+            Err(e) => {
+                // `e` is `anyhow::Error` from `wire_one`; its root-cause
+                // chain is pre-redacted. We still clamp to 256 chars so a
+                // surprise stack trace does not blow up the registry
+                // entry size.
+                let reason = truncate(&format!("{e:#}"), 256);
+                let retries = state.tenant_runtime_state.mark_failed(&slug, &reason).await;
+                failed += 1;
+                warn!(
+                    tenant = %slug,
+                    retry_count = retries,
+                    reason = %reason,
+                    elapsed_ms = started_one.elapsed().as_millis() as u64,
+                    "tenant wiring failed"
+                );
+            }
+        }
+    }
+
+    info!(
+        ok,
+        failed,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "eager tenant wiring: complete"
+    );
+    Ok(())
+}
+
+/// Wire a single tenant: prime the LLM and embedding caches via the
+/// existing [`memory::provider_registry::TenantProviderRegistry`]. A
+/// tenant with neither an LLM nor an embedding provider configured is
+/// considered successfully wired — it just resolves to the platform
+/// defaults at request time and that is a legitimate steady state (e.g.
+/// bootstrap before a manifest is applied).
+///
+/// We intentionally do NOT wire memory-layer backends here. Those are
+/// per-request today via the memory manager; 5.2's scope is limited to
+/// the provider registry. Widening to memory layers is a separate
+/// design decision because some layers are lazy by construction.
+async fn wire_one(state: &AppState, tenant_id: &mk_core::types::TenantId) -> anyhow::Result<()> {
+    // The provider registry caches on success; a miss falls through to
+    // platform defaults and returns `None`, which is NOT an error. Only a
+    // resolution error (bad config, missing secret, unreachable endpoint)
+    // should mark the tenant failed.
+    //
+    // The current `get_*_service` API swallows resolution errors and
+    // returns `None` indistinguishably from "no override configured".
+    // Until that API grows a fallible variant, eager-wiring can only
+    // detect failures that surface as resolver panics or config-provider
+    // errors. This is acceptable for the first drop: the readiness
+    // signal is strictly better than the status quo (none), and the
+    // provider-level failure surface is a known follow-up (see TODO
+    // below).
+    //
+    // TODO(b2-5.2-followup): tighten `get_*_service` to return
+    // `Result<Option<_>, ResolutionError>` so real wiring failures
+    // bubble up here instead of being logged-and-swallowed inside the
+    // registry.
+    let _ = state
+        .provider_registry
+        .get_llm_service(tenant_id, state.tenant_config_provider.as_ref())
+        .await;
+    let _ = state
+        .provider_registry
+        .get_embedding_service(tenant_id, state.tenant_config_provider.as_ref())
+        .await;
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        // Safe char-boundary truncate; avoids splitting a multi-byte char
+        // which would be a panic on some inputs. `floor_char_boundary`
+        // would be cleaner but is nightly.
+        let mut end = max;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &s[..end])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strict_mode_defaults_off() {
+        // Isolate from CI env. `std::env` is process-global; this test
+        // is single-threaded enough for a save/restore dance.
+        let prior = std::env::var("AETERNA_EAGER_WIRE_STRICT").ok();
+        unsafe {
+            std::env::remove_var("AETERNA_EAGER_WIRE_STRICT");
+        }
+        assert!(!is_strict_mode());
+        if let Some(v) = prior {
+            unsafe {
+                std::env::set_var("AETERNA_EAGER_WIRE_STRICT", v);
+            }
+        }
+    }
+
+    #[test]
+    fn strict_mode_parses_truthy_values() {
+        let prior = std::env::var("AETERNA_EAGER_WIRE_STRICT").ok();
+        for v in ["1", "true", "TRUE", "yes", "on"] {
+            unsafe {
+                std::env::set_var("AETERNA_EAGER_WIRE_STRICT", v);
+            }
+            assert!(is_strict_mode(), "expected {v} to enable strict mode");
+        }
+        for v in ["0", "false", "no", "off", ""] {
+            unsafe {
+                std::env::set_var("AETERNA_EAGER_WIRE_STRICT", v);
+            }
+            assert!(!is_strict_mode(), "expected {v} to leave strict off");
+        }
+        match prior {
+            Some(v) => unsafe {
+                std::env::set_var("AETERNA_EAGER_WIRE_STRICT", v);
+            },
+            None => unsafe {
+                std::env::remove_var("AETERNA_EAGER_WIRE_STRICT");
+            },
+        }
+    }
+
+    #[test]
+    fn truncate_preserves_short_strings() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_trims_with_ellipsis() {
+        let s = "x".repeat(300);
+        let out = truncate(&s, 10);
+        assert_eq!(out.chars().count(), 11, "10 chars + ellipsis");
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_respects_utf8_boundaries() {
+        // 4-byte emoji at byte 9. Truncating at max=10 would split the
+        // emoji; the helper must step back to the nearest boundary.
+        let s = "abcdefghi✨✨✨";
+        let out = truncate(s, 10);
+        // Valid UTF-8 by construction of String::from; the real
+        // assertion is "did not panic".
+        assert!(out.ends_with('…'));
+        assert!(out.len() <= s.len());
+    }
+}

--- a/cli/src/server/tenant_eager_wire.rs
+++ b/cli/src/server/tenant_eager_wire.rs
@@ -155,7 +155,10 @@ async fn run_eager_wire(state: &AppState) -> anyhow::Result<()> {
 /// per-request today via the memory manager; 5.2's scope is limited to
 /// the provider registry. Widening to memory layers is a separate
 /// design decision because some layers are lazy by construction.
-async fn wire_one(state: &AppState, tenant_id: &mk_core::types::TenantId) -> anyhow::Result<()> {
+pub(super) async fn wire_one(
+    state: &AppState,
+    tenant_id: &mk_core::types::TenantId,
+) -> anyhow::Result<()> {
     // The provider registry caches on success; a miss falls through to
     // platform defaults and returns `None`, which is NOT an error. Only a
     // resolution error (bad config, missing secret, unreachable endpoint)
@@ -185,7 +188,7 @@ async fn wire_one(state: &AppState, tenant_id: &mk_core::types::TenantId) -> any
     Ok(())
 }
 
-fn truncate(s: &str, max: usize) -> String {
+pub(super) fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {

--- a/cli/src/server/tenant_lazy_wire.rs
+++ b/cli/src/server/tenant_lazy_wire.rs
@@ -1,0 +1,264 @@
+//! On-demand tenant wiring (B2 task 5.2c — lazy-fallback half of design §D5).
+//!
+//! Closes the sub-second race between a tenant being provisioned on pod A
+//! and the `tenant:changed` pub/sub message reaching pod B. Callers that
+//! are about to serve a tenant-scoped request invoke [`ensure_wired`];
+//! the function is idempotent, cheap when the tenant is already `Available`,
+//! and does the minimum work needed otherwise.
+//!
+//! # State transitions
+//!
+//! | Current state           | Action                                                  |
+//! |-------------------------|---------------------------------------------------------|
+//! | `None` (unknown)        | Resolve UUID, mark `Loading`, wire, mark terminal       |
+//! | `Loading { .. }`        | Return as-is (another task owns the wiring)             |
+//! | `Available { .. }`      | Return as-is (cheap path)                               |
+//! | `LoadingFailed { .. }`  | Retry iff `last_attempt_at` older than cooldown         |
+//!
+//! # Cooldown
+//!
+//! The `LoadingFailed` cooldown prevents a stampede against a tenant
+//! with a genuinely broken config (bad secret, unreachable provider).
+//! Default `30s`; overridable via `AETERNA_LAZY_RETRY_COOLDOWN_SECS`.
+//! Inside the cooldown, `ensure_wired` returns the stale `LoadingFailed`
+//! state so the caller can issue a `503 tenant_unavailable` immediately
+//! without hammering the provider.
+//!
+//! # Concurrency
+//!
+//! Two concurrent first-touch requests to the same unknown tenant may
+//! both enter the wiring branch. This is accepted:
+//!
+//! * The provider registry is cache-on-success; the second resolve hits
+//!   the warm cache inside `get_llm_service` (not a duplicate provider
+//!   build).
+//! * The runtime-state registry serialises `mark_loading` / `mark_available`
+//!   under its `RwLock`; `last_rev` is monotonic even under concurrency.
+//!
+//! Adding a per-slug `tokio::sync::Mutex` to strictly serialise lazy
+//! wirings would reduce duplicate resolver work under a provisioning
+//! storm but costs an extra allocation per tenant. Deferred until a
+//! metric (5.6) shows the wasted resolver time matters.
+//!
+//! # Slug ↔ UUID
+//!
+//! `TenantRuntimeRegistry` is keyed by *slug* (stable, human-readable).
+//! `TenantProviderRegistry` is keyed by *TenantId* which in this codebase
+//! is the tenant's UUID string. Lazy wiring must resolve slug → UUID
+//! via the tenant store before priming caches. Missing tenant rows are
+//! surfaced as `LoadingFailed` with `reason = "tenant not found"` — the
+//! caller should translate that to HTTP 404, not 503.
+
+use std::time::{Duration, SystemTime};
+
+use tracing::{debug, warn};
+
+use super::AppState;
+use super::tenant_eager_wire::{truncate, wire_one};
+use super::tenant_runtime_state::TenantRuntimeState;
+
+/// Default cooldown before retrying a `LoadingFailed` tenant.
+///
+/// Chosen to be longer than a typical provider cold-start (10s) and
+/// shorter than a human-observable SLO hit (60s).
+const DEFAULT_FAILED_RETRY_COOLDOWN: Duration = Duration::from_secs(30);
+
+/// Resolve a tenant slug to its internal `TenantId` (UUID).
+///
+/// Returns `Ok(None)` when the slug is unknown to the tenant store;
+/// callers should distinguish that from a real I/O error.
+pub(super) async fn resolve_slug_to_id(
+    state: &AppState,
+    slug: &str,
+) -> anyhow::Result<Option<mk_core::types::TenantId>> {
+    match state.tenant_store.get_tenant(slug).await? {
+        Some(record) => Ok(Some(record.id)),
+        None => Ok(None),
+    }
+}
+
+/// Ensure `slug` has a current wiring on this pod and return the
+/// resulting state.
+///
+/// Never panics. On any error path the runtime state is transitioned
+/// to `LoadingFailed` and that state is returned — the caller is
+/// expected to map it to HTTP 503 (or 404 for the specific
+/// `tenant not found` reason).
+pub async fn ensure_wired(state: &AppState, slug: &str) -> TenantRuntimeState {
+    // Fast path: already in a terminal state that doesn't warrant retry.
+    if let Some(cur) = state.tenant_runtime_state.get(slug).await {
+        match &cur {
+            TenantRuntimeState::Available { .. } | TenantRuntimeState::Loading { .. } => {
+                return cur;
+            }
+            TenantRuntimeState::LoadingFailed {
+                last_attempt_at, ..
+            } => {
+                if !cooldown_elapsed(*last_attempt_at) {
+                    debug!(tenant = %slug, "lazy wire: in cooldown, returning stale failure");
+                    return cur;
+                }
+                debug!(tenant = %slug, "lazy wire: cooldown elapsed, retrying");
+            }
+        }
+    }
+
+    // Slow path: wire now.
+    let tenant_id = match resolve_slug_to_id(state, slug).await {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            // Missing row — mark as not-found so repeated 404s don't
+            // repeatedly hit Postgres inside the cooldown. The reason
+            // string is stable so callers can pattern-match on it.
+            state
+                .tenant_runtime_state
+                .mark_failed(slug, "tenant not found")
+                .await;
+            return failed_snapshot_or(state, slug, "tenant not found").await;
+        }
+        Err(e) => {
+            let reason = truncate(&format!("tenant store lookup failed: {e:#}"), 256);
+            warn!(tenant = %slug, error = %reason, "lazy wire: slug resolution errored");
+            state.tenant_runtime_state.mark_failed(slug, &reason).await;
+            return failed_snapshot_or(state, slug, &reason).await;
+        }
+    };
+
+    state.tenant_runtime_state.mark_loading(slug).await;
+    match wire_one(state, &tenant_id).await {
+        Ok(()) => {
+            let rev = state.tenant_runtime_state.mark_available(slug).await;
+            debug!(tenant = %slug, rev, "lazy wire: available");
+        }
+        Err(e) => {
+            let reason = truncate(&format!("{e:#}"), 256);
+            let retry_count = state.tenant_runtime_state.mark_failed(slug, &reason).await;
+            warn!(
+                tenant = %slug,
+                retry_count,
+                reason = %reason,
+                "lazy wire: failed"
+            );
+        }
+    }
+
+    state
+        .tenant_runtime_state
+        .get(slug)
+        .await
+        .unwrap_or_else(TenantRuntimeState::loading_now)
+}
+
+/// True iff the configured retry cooldown has elapsed since `last_attempt_at`.
+///
+/// Uses wall-clock time for consistency with [`TenantRuntimeState`]
+/// timestamps. A clock going backwards (NTP step) is treated as "cooldown
+/// still active" which errs on the side of not stampeding providers.
+fn cooldown_elapsed(last_attempt_at: SystemTime) -> bool {
+    let cooldown = configured_cooldown();
+    match SystemTime::now().duration_since(last_attempt_at) {
+        Ok(d) => d >= cooldown,
+        Err(_) => false, // clock skew — stay in cooldown
+    }
+}
+
+/// Current cooldown, honoring the `AETERNA_LAZY_RETRY_COOLDOWN_SECS`
+/// override. Malformed values fall back to the default and log once
+/// (in practice the override is set at pod start).
+fn configured_cooldown() -> Duration {
+    match std::env::var("AETERNA_LAZY_RETRY_COOLDOWN_SECS") {
+        Ok(v) => match v.parse::<u64>() {
+            Ok(secs) => Duration::from_secs(secs),
+            Err(_) => DEFAULT_FAILED_RETRY_COOLDOWN,
+        },
+        Err(_) => DEFAULT_FAILED_RETRY_COOLDOWN,
+    }
+}
+
+/// Return the current state for `slug`, falling back to a synthetic
+/// `LoadingFailed{reason}` when the registry has somehow lost the entry
+/// between our `mark_failed` and this read. That race is not expected
+/// under the current registry implementation; the fallback is a belt-
+/// and-braces so callers never have to deal with `None` after we
+/// promised them a terminal state.
+async fn failed_snapshot_or(state: &AppState, slug: &str, reason: &str) -> TenantRuntimeState {
+    state
+        .tenant_runtime_state
+        .get(slug)
+        .await
+        .unwrap_or_else(|| TenantRuntimeState::failed_now(reason))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All env-mutation tests live in one function because `std::env` is
+    /// process-global and `cargo test` parallelises by default. Splitting
+    /// them into separate `#[test]` functions produced a race where one
+    /// test's `remove_var` nuked another's `set_var` mid-assertion.
+    /// Consolidation is strictly weaker than introducing a `Mutex` or
+    /// pulling in `serial_test` \u2014 we just run sequentially.
+    #[test]
+    fn cooldown_env_behaviour_covers_default_override_and_malformed() {
+        let prior = std::env::var("AETERNA_LAZY_RETRY_COOLDOWN_SECS").ok();
+
+        // Default when unset.
+        unsafe {
+            std::env::remove_var("AETERNA_LAZY_RETRY_COOLDOWN_SECS");
+        }
+        assert_eq!(configured_cooldown(), Duration::from_secs(30), "default");
+
+        // Valid override is honoured verbatim.
+        unsafe {
+            std::env::set_var("AETERNA_LAZY_RETRY_COOLDOWN_SECS", "5");
+        }
+        assert_eq!(
+            configured_cooldown(),
+            Duration::from_secs(5),
+            "valid override"
+        );
+
+        // Malformed override falls back to the compiled-in default so
+        // a typo'd manifest value doesn't uncap retry frequency.
+        unsafe {
+            std::env::set_var("AETERNA_LAZY_RETRY_COOLDOWN_SECS", "not a number");
+        }
+        assert_eq!(
+            configured_cooldown(),
+            DEFAULT_FAILED_RETRY_COOLDOWN,
+            "malformed falls back to default"
+        );
+
+        // Restore prior state so co-resident tests in the same process
+        // observe whatever the ambient CI / shell configured.
+        match prior {
+            Some(v) => unsafe {
+                std::env::set_var("AETERNA_LAZY_RETRY_COOLDOWN_SECS", v);
+            },
+            None => unsafe {
+                std::env::remove_var("AETERNA_LAZY_RETRY_COOLDOWN_SECS");
+            },
+        }
+    }
+
+    #[test]
+    fn cooldown_elapsed_on_past_stamp() {
+        let past = SystemTime::now() - Duration::from_secs(120);
+        assert!(cooldown_elapsed(past));
+    }
+
+    #[test]
+    fn cooldown_not_elapsed_on_recent_stamp() {
+        let recent = SystemTime::now() - Duration::from_secs(1);
+        assert!(!cooldown_elapsed(recent));
+    }
+
+    #[test]
+    fn cooldown_not_elapsed_on_future_stamp() {
+        // Clock skew: last_attempt_at is in the future. We must not
+        // retry — that would invite a storm every time NTP re-syncs.
+        let future = SystemTime::now() + Duration::from_secs(60);
+        assert!(!cooldown_elapsed(future));
+    }
+}

--- a/cli/src/server/tenant_metrics.rs
+++ b/cli/src/server/tenant_metrics.rs
@@ -1,0 +1,253 @@
+//! Prometheus metrics for tenant wiring state (B2 task 5.6).
+//!
+//! Emitted from [`TenantRuntimeRegistry`] on every state transition.
+//! Closes the observability loop:
+//!
+//!   5.3 `/ready`                  pod-level traffic gate
+//!   5.4 `require_available_tenant` caller-visible 503
+//!   5.5 `/admin/.../wiring`        PA-only detail (reasons)
+//!   5.6 Prometheus metrics         fleet-level time series     ← this
+//!
+//! # Metric catalog
+//!
+//! | Metric                                    | Type      | Labels         |
+//! |-------------------------------------------|-----------|----------------|
+//! | `tenant_state`                            | gauge     | slug, state    |
+//! | `tenant_wiring_duration_seconds`          | histogram | result         |
+//! | `tenant_state_transitions_total`          | counter   | from, to       |
+//!
+//! ## `tenant_state{slug,state}` — gauge 0/1
+//!
+//! Emitted three series per slug — one for each of `loading`,
+//! `available`, `loadingFailed`. Exactly one is `1`; the others are `0`.
+//! This matches the kube-state-metrics idiom
+//! (`kube_pod_status_phase{phase=...}`) and lets PromQL alerts be written
+//! without hardcoded state enumerations:
+//!
+//! ```promql
+//! # Alert if any tenant has been failing for ≥ 10m
+//! max_over_time(tenant_state{state="loadingFailed"}[10m]) == 1
+//! ```
+//!
+//! On `forget(slug)` all three series are reset to `0`. Prometheus has
+//! no “delete series” API at write time; leaving them at `0` is the
+//! recommended pattern (they will age out of the TSDB after a retention
+//! window).
+//!
+//! ## `tenant_wiring_duration_seconds{result}` — histogram
+//!
+//! Recorded on every transition out of `Loading`:
+//! `result=success` on → Available, `result=failure` on → LoadingFailed.
+//! Duration is `now - since`. Slug is deliberately NOT a label here —
+//! histogram cardinality grows fastest of the three metric types and
+//! the distribution is a fleet-level concern. Operators who need per-
+//! tenant timing look at traces, not Prometheus.
+//!
+//! ## `tenant_state_transitions_total{from,to}` — counter
+//!
+//! Rate of state transitions. Useful for flapping alerts without having
+//! to derive them from the gauge:
+//!
+//! ```promql
+//! # Flap alert: >5 failing rewires/minute across the whole fleet
+//! sum(rate(tenant_state_transitions_total{to="loadingFailed"}[5m])) > 5/60
+//! ```
+//!
+//! Labels are bounded enum values — no cardinality risk.
+//!
+//! # Performance
+//!
+//! Metric emission is fire-and-forget (`metrics` crate dispatches to the
+//! installed recorder); calling it under the registry write lock adds
+//! a handful of hashmap operations per transition, well under the
+//! existing cost of the `RwLock` upgrade. We intentionally do NOT move
+//! emission outside the lock because the prev→next transition has to be
+//! observed atomically for the counter to be correct.
+
+use std::time::SystemTime;
+
+use super::tenant_runtime_state::TenantRuntimeState;
+
+/// Stable label values for `tenant_state{state}`. Kept as `&'static str`
+/// so no allocation per emission.
+const STATE_LOADING: &str = "loading";
+const STATE_AVAILABLE: &str = "available";
+const STATE_LOADING_FAILED: &str = "loadingFailed";
+const STATE_ABSENT: &str = "absent";
+
+/// Map a state to its label. `absent` is reserved for `forget()` so the
+/// transition counter can express “tenant removed” without a dedicated
+/// metric.
+fn state_label(s: Option<&TenantRuntimeState>) -> &'static str {
+    match s {
+        None => STATE_ABSENT,
+        Some(TenantRuntimeState::Loading { .. }) => STATE_LOADING,
+        Some(TenantRuntimeState::Available { .. }) => STATE_AVAILABLE,
+        Some(TenantRuntimeState::LoadingFailed { .. }) => STATE_LOADING_FAILED,
+    }
+}
+
+/// Emit metrics for a state transition.
+///
+/// Invariants upheld by this function:
+/// * Exactly one `tenant_state{slug,state}` series is set to `1` after
+///   the call (unless `next == None`, in which case all three are `0`).
+/// * The transition counter is incremented exactly once.
+/// * The wiring-duration histogram is recorded iff `prev` was `Loading`
+///   and `next` is `Available` or `LoadingFailed`.
+pub fn record_transition(
+    slug: &str,
+    prev: Option<&TenantRuntimeState>,
+    next: Option<&TenantRuntimeState>,
+) {
+    let from = state_label(prev);
+    let to = state_label(next);
+
+    // 1. Transition counter — always.
+    metrics::counter!(
+        "tenant_state_transitions_total",
+        "from" => from,
+        "to" => to,
+    )
+    .increment(1);
+
+    // 2. Gauges: set exactly one (or zero) to 1, the others to 0. We
+    //    emit all three every time so a series that was previously
+    //    `1` on a different state flips back to `0` atomically from
+    //    the recorder's perspective.
+    let slug_owned = slug.to_string();
+    let set = |state_label: &'static str, val: f64| {
+        metrics::gauge!(
+            "tenant_state",
+            "slug" => slug_owned.clone(),
+            "state" => state_label,
+        )
+        .set(val);
+    };
+    match next {
+        None => {
+            set(STATE_LOADING, 0.0);
+            set(STATE_AVAILABLE, 0.0);
+            set(STATE_LOADING_FAILED, 0.0);
+        }
+        Some(TenantRuntimeState::Loading { .. }) => {
+            set(STATE_LOADING, 1.0);
+            set(STATE_AVAILABLE, 0.0);
+            set(STATE_LOADING_FAILED, 0.0);
+        }
+        Some(TenantRuntimeState::Available { .. }) => {
+            set(STATE_LOADING, 0.0);
+            set(STATE_AVAILABLE, 1.0);
+            set(STATE_LOADING_FAILED, 0.0);
+        }
+        Some(TenantRuntimeState::LoadingFailed { .. }) => {
+            set(STATE_LOADING, 0.0);
+            set(STATE_AVAILABLE, 0.0);
+            set(STATE_LOADING_FAILED, 1.0);
+        }
+    }
+
+    // 3. Duration histogram — only on transitions out of Loading.
+    if let (Some(TenantRuntimeState::Loading { since }), Some(n)) = (prev, next) {
+        let result = match n {
+            TenantRuntimeState::Available { .. } => Some("success"),
+            TenantRuntimeState::LoadingFailed { .. } => Some("failure"),
+            // Loading → Loading: idempotent refresh, not a wiring
+            // completion. Skip.
+            TenantRuntimeState::Loading { .. } => None,
+        };
+        if let Some(result) = result {
+            let elapsed = SystemTime::now()
+                .duration_since(*since)
+                .unwrap_or_default()
+                .as_secs_f64();
+            metrics::histogram!(
+                "tenant_wiring_duration_seconds",
+                "result" => result,
+            )
+            .record(elapsed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn state_label_covers_all_variants() {
+        assert_eq!(state_label(None), STATE_ABSENT);
+        assert_eq!(
+            state_label(Some(&TenantRuntimeState::loading_now())),
+            STATE_LOADING
+        );
+        assert_eq!(
+            state_label(Some(&TenantRuntimeState::available_now(1))),
+            STATE_AVAILABLE
+        );
+        assert_eq!(
+            state_label(Some(&TenantRuntimeState::failed_now("x"))),
+            STATE_LOADING_FAILED
+        );
+    }
+
+    /// Smoke test: emitting against the default (no-op) recorder must not
+    /// panic. The real recorder is installed in main() via
+    /// [`crate::server::metrics::create_recorder`]; test runs use the
+    /// no-op default unless a test specifically installs one. This guard
+    /// catches typos in format strings and nil-deref bugs.
+    #[test]
+    fn record_transition_does_not_panic_on_any_combination() {
+        let states: [Option<TenantRuntimeState>; 4] = [
+            None,
+            Some(TenantRuntimeState::Loading {
+                since: SystemTime::now() - Duration::from_millis(50),
+            }),
+            Some(TenantRuntimeState::available_now(1)),
+            Some(TenantRuntimeState::failed_now("r")),
+        ];
+        for prev in states.iter() {
+            for next in states.iter() {
+                record_transition("test", prev.as_ref(), next.as_ref());
+            }
+        }
+    }
+
+    /// The histogram must be recorded only on Loading→Available or
+    /// Loading→LoadingFailed. We verify the selection logic here —
+    /// the metric recording itself is exercised by the
+    /// does_not_panic test above.
+    #[test]
+    fn histogram_only_fires_on_completion_of_wiring() {
+        // These are the two cases where we expect a histogram sample.
+        // Verified indirectly: the function must NOT panic on any,
+        // and the logic must match the match-arms. We simulate the
+        // selection predicate directly.
+        fn should_record(
+            prev: Option<&TenantRuntimeState>,
+            next: Option<&TenantRuntimeState>,
+        ) -> bool {
+            matches!(
+                (prev, next),
+                (
+                    Some(TenantRuntimeState::Loading { .. }),
+                    Some(TenantRuntimeState::Available { .. })
+                        | Some(TenantRuntimeState::LoadingFailed { .. })
+                )
+            )
+        }
+        let loading = TenantRuntimeState::loading_now();
+        let available = TenantRuntimeState::available_now(1);
+        let failed = TenantRuntimeState::failed_now("r");
+
+        assert!(should_record(Some(&loading), Some(&available)));
+        assert!(should_record(Some(&loading), Some(&failed)));
+        // Non-completion transitions do NOT fire:
+        assert!(!should_record(None, Some(&loading)));
+        assert!(!should_record(Some(&loading), Some(&loading))); // idempotent refresh
+        assert!(!should_record(Some(&available), Some(&loading))); // rewire kickoff
+        assert!(!should_record(Some(&failed), Some(&loading))); // retry kickoff
+        assert!(!should_record(Some(&available), None)); // forget
+    }
+}

--- a/cli/src/server/tenant_pubsub.rs
+++ b/cli/src/server/tenant_pubsub.rs
@@ -254,13 +254,28 @@ async fn subscribe_and_consume(state: &AppState, redis_url: &str) -> anyhow::Res
 pub(crate) async fn handle_event(state: &AppState, event: TenantChangeEvent) {
     debug!(slug = %event.slug, kind = ?event.kind, "tenant:changed handling");
 
-    // Resolve slug → TenantId. `TenantId` is itself a slug wrapper in
-    // this codebase (see memory crate), so we can construct directly.
-    // Using `new()` validates; a bad slug gets a warn and is dropped.
-    let tenant_id = match mk_core::types::TenantId::new(event.slug.clone()) {
-        Some(id) => id,
-        None => {
-            warn!(slug = %event.slug, "tenant:changed: invalid slug, dropping");
+    // Resolve slug → TenantId (UUID). `TenantId` wraps the UUID, NOT
+    // the slug — an earlier revision constructed `TenantId::new(slug)`
+    // which produced a value that would never match the
+    // provider-registry cache keyed on UUIDs. The tenant store
+    // round-trip is the authoritative mapping.
+    let tenant_id = match super::tenant_lazy_wire::resolve_slug_to_id(state, &event.slug).await {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            // Tenant row is gone (deletion on the publisher side, or a
+            // stale message for a slug that never existed on this
+            // cluster). Scrub any lingering runtime-state entry so
+            // `/ready` and status endpoints don't report a ghost.
+            warn!(slug = %event.slug, "tenant:changed: slug unknown, forgetting");
+            state.tenant_runtime_state.forget(&event.slug).await;
+            return;
+        }
+        Err(e) => {
+            warn!(
+                slug = %event.slug,
+                error = %e,
+                "tenant:changed: slug resolution failed, dropping event"
+            );
             return;
         }
     };
@@ -275,21 +290,30 @@ pub(crate) async fn handle_event(state: &AppState, event: TenantChangeEvent) {
         TenantChangeKind::Provisioned | TenantChangeKind::Updated | TenantChangeKind::Unknown => {
             state.provider_registry.invalidate_tenant(&tenant_id);
             state.tenant_runtime_state.mark_loading(&event.slug).await;
-            // Re-prime. We swallow the result: errors are already
-            // reflected in the runtime-state registry by
-            // `tenant_eager_wire::wire_one` behaviour when we reuse it.
-            // Inline the minimal resolve to avoid a cross-module call
-            // cycle.
-            let _ = state
-                .provider_registry
-                .get_llm_service(&tenant_id, state.tenant_config_provider.as_ref())
-                .await;
-            let _ = state
-                .provider_registry
-                .get_embedding_service(&tenant_id, state.tenant_config_provider.as_ref())
-                .await;
-            let rev = state.tenant_runtime_state.mark_available(&event.slug).await;
-            info!(slug = %event.slug, rev, kind = ?event.kind, "tenant re-wired");
+            // Re-prime via the shared wiring path so pub/sub,
+            // eager-boot, and lazy-fallback all converge through a
+            // single code path — one place to tighten error handling
+            // once `get_*_service` grows a fallible variant
+            // (see b2-5.2-followup in tenant_eager_wire).
+            match super::tenant_eager_wire::wire_one(state, &tenant_id).await {
+                Ok(()) => {
+                    let rev = state.tenant_runtime_state.mark_available(&event.slug).await;
+                    info!(slug = %event.slug, rev, kind = ?event.kind, "tenant re-wired");
+                }
+                Err(e) => {
+                    let reason = super::tenant_eager_wire::truncate(&format!("{e:#}"), 256);
+                    let retries = state
+                        .tenant_runtime_state
+                        .mark_failed(&event.slug, &reason)
+                        .await;
+                    warn!(
+                        slug = %event.slug,
+                        retry_count = retries,
+                        reason = %reason,
+                        "tenant re-wire failed after tenant:changed"
+                    );
+                }
+            }
         }
     }
 

--- a/cli/src/server/tenant_pubsub.rs
+++ b/cli/src/server/tenant_pubsub.rs
@@ -1,0 +1,341 @@
+//! Cross-pod tenant invalidation via Redis Pub/Sub (B2 task 5.2b, design §D5).
+//!
+//! # Topology
+//!
+//! A single channel — [`CHANNEL`] — carries [`TenantChangeEvent`] payloads.
+//! Every pod subscribes on boot and publishes whenever a tenant-affecting
+//! mutation commits (provisioning, config edit, secret rotation, deactivation).
+//! On receipt, each pod:
+//!
+//! 1. Invalidates the per-tenant provider caches in
+//!    [`memory::provider_registry::TenantProviderRegistry`].
+//! 2. Re-marks the tenant as `Loading` in the runtime state registry.
+//! 3. Re-primes LLM + embedding resolution (equivalent to one pass of the
+//!    eager boot loop, task 5.2a).
+//!
+//! This closes the multi-pod coherence hole where pod A provisions tenant
+//! T and pod B's cache is stale until restart. Latency budget per design:
+//! 95th percentile cache convergence < 1s across the cluster.
+//!
+//! # Design decisions
+//!
+//! * **Fire-and-forget, at-most-once.** Redis Pub/Sub is not durable;
+//!   missed messages (subscriber disconnected) are recovered by the next
+//!   eager boot OR by the lazy fallback path (task 5.2c). A tenant
+//!   outliving its cache TTL will simply re-resolve from Postgres on
+//!   next request.
+//! * **No origin-pod suppression in this drop.** Self-receipt is
+//!   idempotent — invalidating your own freshly-populated cache is
+//!   cheap; the next request re-primes from a warm Postgres row. If this
+//!   becomes a hot-path concern (high-provision-volume workloads) a
+//!   `origin_pod_id` field gets added and the subscriber filters on it.
+//! * **Dedicated connection per subscriber.** `ConnectionManager` cannot
+//!   service `SUBSCRIBE`; we open a fresh `redis::Client` from
+//!   `AppState::redis_url`. The publisher side reuses the manager.
+//! * **Reconnection with bounded backoff.** If the subscriber loop loses
+//!   the connection, it reconnects with exponential backoff capped at
+//!   `RECONNECT_BACKOFF_CAP`. Missed messages during the gap are the
+//!   lazy-fallback/eager-boot's problem, not ours.
+//!
+//! # Non-goals
+//!
+//! * Event ordering across publishers. Two rapid updates to the same
+//!   tenant that arrive out of order still converge to the latest
+//!   Postgres state because each message triggers a full resolve, not
+//!   a delta apply.
+//! * Delivery acknowledgement. Use the DLQ (`redis_publisher`) for
+//!   governance-grade events; this channel is best-effort cache
+//!   coordination.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
+use tokio::time::sleep;
+use tracing::{debug, info, warn};
+
+use super::AppState;
+
+/// Pub/Sub channel name. Matches the convention used by `redis_publisher`
+/// for governance streams (colon-delimited, `aeterna:` prefixed).
+pub const CHANNEL: &str = "aeterna:tenant:changed";
+
+/// Initial reconnect backoff on subscriber failure.
+const RECONNECT_BACKOFF_INITIAL: Duration = Duration::from_millis(250);
+/// Upper bound on reconnect backoff. A minute is more than enough for
+/// transient Redis hiccups; longer outages are visible via `/ready`.
+const RECONNECT_BACKOFF_CAP: Duration = Duration::from_secs(60);
+
+/// Payload published on [`CHANNEL`] for every tenant mutation.
+///
+/// `kind` conveys intent for observability; the handler always performs
+/// a full cache invalidation regardless, so adding a new variant is
+/// strictly additive — older subscribers will log an `Unknown` and still
+/// invalidate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TenantChangeEvent {
+    /// Tenant slug (stable identifier across renames).
+    pub slug: String,
+    /// What happened. Serialized as lowercase for channel compactness.
+    pub kind: TenantChangeKind,
+    /// Publisher wall-clock epoch seconds. Informational only — not used
+    /// for ordering.
+    pub at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TenantChangeKind {
+    /// New tenant just finished provisioning.
+    Provisioned,
+    /// Existing tenant config or secret was updated.
+    Updated,
+    /// Tenant marked inactive. Subscribers should forget cached state.
+    Deactivated,
+    /// Fallback for forward-compat with new kinds added by newer pods.
+    #[serde(other)]
+    Unknown,
+}
+
+impl TenantChangeEvent {
+    /// Construct with `at = now`.
+    pub fn new(slug: impl Into<String>, kind: TenantChangeKind) -> Self {
+        Self {
+            slug: slug.into(),
+            kind,
+            at: chrono::Utc::now().timestamp(),
+        }
+    }
+}
+
+/// Publish a tenant-change event.
+///
+/// No-op (logs at `debug`) when `redis_conn` is `None` — the pod is
+/// running in single-node mode and there are no other subscribers to
+/// notify. Local invalidation in that case is the caller's
+/// responsibility (typically the same handler that calls `publish`).
+///
+/// Errors are logged at WARN and swallowed. A failed publish is not a
+/// user-facing error because the eager boot loop + lazy fallback
+/// provide eventual consistency.
+pub async fn publish(state: &AppState, event: &TenantChangeEvent) {
+    let Some(conn) = state.redis_conn.as_ref() else {
+        debug!(slug = %event.slug, kind = ?event.kind, "tenant:changed publish skipped (no redis)");
+        return;
+    };
+    let payload = match serde_json::to_string(event) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(error = %e, "tenant:changed serialise failed");
+            return;
+        }
+    };
+    // Clone the manager cheaply; `publish` takes `&mut`.
+    let mut conn = (**conn).clone();
+    let res: redis::RedisResult<i64> = conn.publish(CHANNEL, &payload).await;
+    match res {
+        Ok(n) => debug!(
+            slug = %event.slug,
+            kind = ?event.kind,
+            subscribers = n,
+            "tenant:changed published"
+        ),
+        Err(e) => warn!(
+            slug = %event.slug,
+            kind = ?event.kind,
+            error = %e,
+            "tenant:changed publish failed"
+        ),
+    }
+}
+
+/// Spawn the long-lived subscriber task.
+///
+/// No-op when `redis_url` is `None`. Returns immediately. The task
+/// retries on connection loss with exponential backoff and exits
+/// cleanly on `state.shutdown_tx` flip.
+pub fn spawn_subscriber(state: Arc<AppState>) {
+    let Some(redis_url) = state.redis_url.clone() else {
+        info!("tenant:changed subscriber: redis disabled, not spawning");
+        return;
+    };
+    tokio::spawn(async move {
+        run_subscriber(state, redis_url).await;
+    });
+}
+
+async fn run_subscriber(state: Arc<AppState>, redis_url: String) {
+    let mut backoff = RECONNECT_BACKOFF_INITIAL;
+    loop {
+        if *state.shutdown_tx.borrow() {
+            info!("tenant:changed subscriber: shutdown requested");
+            return;
+        }
+        match subscribe_and_consume(&state, &redis_url).await {
+            Ok(()) => {
+                info!("tenant:changed subscriber: stream ended cleanly, reconnecting");
+                backoff = RECONNECT_BACKOFF_INITIAL;
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    backoff_ms = backoff.as_millis() as u64,
+                    "tenant:changed subscriber failed, backing off"
+                );
+            }
+        }
+        // Respect shutdown during the backoff so we don't hold the pod
+        // up past drain.
+        tokio::select! {
+            _ = sleep(backoff) => {}
+            _ = wait_for_shutdown(&state) => {
+                info!("tenant:changed subscriber: shutdown during backoff");
+                return;
+            }
+        }
+        // Exponential, capped.
+        backoff = (backoff * 2).min(RECONNECT_BACKOFF_CAP);
+    }
+}
+
+async fn wait_for_shutdown(state: &AppState) {
+    let mut rx = state.shutdown_tx.subscribe();
+    // `subscribe()` on a watch returns the current value; loop until true.
+    loop {
+        if *rx.borrow() {
+            return;
+        }
+        if rx.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+async fn subscribe_and_consume(state: &AppState, redis_url: &str) -> anyhow::Result<()> {
+    let client = redis::Client::open(redis_url)?;
+    let mut pubsub = client.get_async_pubsub().await?;
+    pubsub.subscribe(CHANNEL).await?;
+    info!(channel = CHANNEL, "tenant:changed subscriber: subscribed");
+
+    let mut stream = pubsub.on_message();
+    while let Some(msg) = stream.next().await {
+        if *state.shutdown_tx.borrow() {
+            return Ok(());
+        }
+        let payload: String = match msg.get_payload::<String>() {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(error = %e, "tenant:changed: malformed payload");
+                continue;
+            }
+        };
+        let event: TenantChangeEvent = match serde_json::from_str(&payload) {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(error = %e, payload = %payload, "tenant:changed: parse failed");
+                continue;
+            }
+        };
+        handle_event(state, event).await;
+    }
+    // `on_message` stream ending means the connection dropped; caller
+    // will reconnect.
+    Ok(())
+}
+
+/// Apply a change event to local state.
+///
+/// Exposed at `pub(crate)` so `provision_tenant` can call it directly
+/// after a successful apply (avoiding a round-trip through Redis just
+/// to update the pod that did the work).
+pub(crate) async fn handle_event(state: &AppState, event: TenantChangeEvent) {
+    debug!(slug = %event.slug, kind = ?event.kind, "tenant:changed handling");
+
+    // Resolve slug → TenantId. `TenantId` is itself a slug wrapper in
+    // this codebase (see memory crate), so we can construct directly.
+    // Using `new()` validates; a bad slug gets a warn and is dropped.
+    let tenant_id = match mk_core::types::TenantId::new(event.slug.clone()) {
+        Some(id) => id,
+        None => {
+            warn!(slug = %event.slug, "tenant:changed: invalid slug, dropping");
+            return;
+        }
+    };
+
+    match event.kind {
+        TenantChangeKind::Deactivated => {
+            // Forget, don't re-prime — tenant is gone from active set.
+            state.provider_registry.invalidate_tenant(&tenant_id);
+            state.tenant_runtime_state.forget(&event.slug).await;
+            info!(slug = %event.slug, "tenant deactivated, cache forgotten");
+        }
+        TenantChangeKind::Provisioned | TenantChangeKind::Updated | TenantChangeKind::Unknown => {
+            state.provider_registry.invalidate_tenant(&tenant_id);
+            state.tenant_runtime_state.mark_loading(&event.slug).await;
+            // Re-prime. We swallow the result: errors are already
+            // reflected in the runtime-state registry by
+            // `tenant_eager_wire::wire_one` behaviour when we reuse it.
+            // Inline the minimal resolve to avoid a cross-module call
+            // cycle.
+            let _ = state
+                .provider_registry
+                .get_llm_service(&tenant_id, state.tenant_config_provider.as_ref())
+                .await;
+            let _ = state
+                .provider_registry
+                .get_embedding_service(&tenant_id, state.tenant_config_provider.as_ref())
+                .await;
+            let rev = state.tenant_runtime_state.mark_available(&event.slug).await;
+            info!(slug = %event.slug, rev, kind = ?event.kind, "tenant re-wired");
+        }
+    }
+
+    // Reserved for later: publish a metric counter increment here
+    // once 5.6 lands so cross-pod invalidations are observable
+    // without scraping logs.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_serialises_with_snake_case_kind() {
+        let ev = TenantChangeEvent::new("acme", TenantChangeKind::Provisioned);
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"kind\":\"provisioned\""), "got: {s}");
+        assert!(s.contains("\"slug\":\"acme\""));
+    }
+
+    #[test]
+    fn unknown_kind_round_trips() {
+        // Older pod receiving a future variant must not panic.
+        let raw = r#"{"slug":"acme","kind":"future_variant_2028","at":123}"#;
+        let ev: TenantChangeEvent = serde_json::from_str(raw).unwrap();
+        assert_eq!(ev.kind, TenantChangeKind::Unknown);
+        assert_eq!(ev.slug, "acme");
+    }
+
+    #[test]
+    fn kind_variants_parse() {
+        for (wire, want) in [
+            ("provisioned", TenantChangeKind::Provisioned),
+            ("updated", TenantChangeKind::Updated),
+            ("deactivated", TenantChangeKind::Deactivated),
+        ] {
+            let raw = format!(r#"{{"slug":"x","kind":"{wire}","at":1}}"#);
+            let ev: TenantChangeEvent = serde_json::from_str(&raw).unwrap();
+            assert_eq!(ev.kind, want, "wire={wire}");
+        }
+    }
+
+    #[test]
+    fn channel_name_matches_design() {
+        // Guard against accidental renames — the channel is a wire
+        // contract with deployed pods.
+        assert_eq!(CHANNEL, "aeterna:tenant:changed");
+    }
+}

--- a/cli/src/server/tenant_runtime_state.rs
+++ b/cli/src/server/tenant_runtime_state.rs
@@ -1,0 +1,499 @@
+//! Per-tenant runtime readiness state (B2 task 5.1).
+//!
+//! This module defines [`TenantRuntimeState`], the state machine every
+//! provisioned tenant passes through inside a running pod, and
+//! [`TenantRuntimeRegistry`], the pod-local, async-safe map from tenant slug
+//! to state.
+//!
+//! # Where this fits
+//!
+//! Task 5.1 is type-only: no boot loop, no pub/sub, no `/ready` wiring yet.
+//! The enum and registry land first so downstream tasks (5.2 eager boot,
+//! 5.3 `/ready` gate, 5.4 per-route 503, 5.5 status endpoint surfacing,
+//! 5.6 Prometheus metrics) have a single, already-tested data type to
+//! read and write. Keeping the drop this small also means the PR can
+//! merge on its own without holding back other B2 work.
+//!
+//! # State machine
+//!
+//! ```text
+//!               ┌──────────────┐
+//!    (insert) → │   Loading    │
+//!               └──────┬───────┘
+//!                      │
+//!           ┌──────────┴──────────┐
+//!           ▼                     ▼
+//!     ┌───────────┐         ┌───────────────┐
+//!     │ Available │ ◄────── │ LoadingFailed │
+//!     └─────┬─────┘  retry  └───────┬───────┘
+//!           │                       │
+//!           └───────► Loading ◄─────┘     (rewire on provision/update)
+//! ```
+//!
+//! A slug with no entry in the registry is *not* the same as `Loading`: it
+//! means the pod has never been asked about the tenant. Callers that
+//! require an explicit answer (`/ready`, per-route 503) must treat
+//! "absent" and "Loading" separately — see [`TenantRuntimeRegistry::get`]
+//! and the lookup helpers below.
+//!
+//! # Concurrency model
+//!
+//! The registry is backed by a `tokio::sync::RwLock<HashMap<String, _>>`.
+//! Readers outnumber writers by many orders of magnitude on the hot path
+//! (every tenant-scoped request hits `get`; writes happen on boot, on
+//! pub/sub invalidation, and on provision). We chose an async RwLock over
+//! `parking_lot` so holders can `.await` across internal operations in
+//! future tasks without deadlocking — eager boot (5.2) will want to hold
+//! a write guard while awaiting a DB fetch, for example.
+//!
+//! # Why not `Arc<DashMap<..>>`?
+//!
+//! `dashmap` is already a transitive dep, but its sharded locks don't
+//! integrate cleanly with async code and the per-slug contention here is
+//! bounded by tenant count, not QPS: a single `RwLock<HashMap>` holds up
+//! easily into the thousands of tenants. We can swap later if a profile
+//! demands it; the public API is the only thing downstream tasks bind to.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use serde::Serialize;
+use tokio::sync::RwLock;
+
+/// Per-tenant readiness state in the pod-local registry.
+///
+/// The variants intentionally carry only the minimum needed by the
+/// `/ready` gate (5.3) and the status endpoint (5.5): a reason string on
+/// failure, a `since` timestamp on `Loading`, and a monotonically-growing
+/// `rev` on `Available` so we can detect stale observations after a
+/// rewire. Richer diagnostics (attempt counts, last-seen errors) belong in
+/// metrics and structured logs, not in the state itself — that keeps the
+/// enum cheap to clone and cheap to serialize.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(
+    tag = "state",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum TenantRuntimeState {
+    /// Wiring is in progress. Entered on boot, on a `tenant:changed`
+    /// pub/sub notification, and on synchronous rewire inside
+    /// `provision_tenant`.
+    Loading {
+        /// Wall-clock time wiring started, UTC epoch seconds.
+        #[serde(with = "serde_epoch")]
+        since: SystemTime,
+    },
+
+    /// Providers (LLM / embedding / memory) are registered on this pod
+    /// and the tenant is serving traffic.
+    Available {
+        /// Monotonic revision bumped on every successful rewire. Lets
+        /// callers distinguish "Pod A saw rev=7 but the handler ran against
+        /// rev=8" — useful in the status endpoint and in metrics labels.
+        rev: u64,
+        /// Wall-clock time the current wiring landed.
+        #[serde(with = "serde_epoch")]
+        wired_at: SystemTime,
+    },
+
+    /// The last wiring attempt failed. Requests to this tenant return
+    /// `503 tenant_unavailable` (5.4) and `/ready` flips to 503 when
+    /// strict mode is on (5.3).
+    LoadingFailed {
+        /// Human-readable summary suitable for surfacing in error bodies
+        /// and logs. Never leaks secret material — producers must redact
+        /// before calling.
+        reason: String,
+        /// When the last failing attempt finished.
+        #[serde(with = "serde_epoch")]
+        last_attempt_at: SystemTime,
+        /// How many consecutive failing attempts have happened since the
+        /// last `Available`. Reset to 0 on any successful rewire.
+        retry_count: u32,
+    },
+}
+
+impl TenantRuntimeState {
+    /// Convenience constructor for the initial `Loading` transition,
+    /// stamped with `SystemTime::now()`. Helps keep call sites short.
+    pub fn loading_now() -> Self {
+        Self::Loading {
+            since: SystemTime::now(),
+        }
+    }
+
+    /// Convenience constructor for the success transition.
+    pub fn available_now(rev: u64) -> Self {
+        Self::Available {
+            rev,
+            wired_at: SystemTime::now(),
+        }
+    }
+
+    /// Convenience constructor for a fresh failure (retry_count = 1).
+    /// Callers that need to increment retry_count must go through
+    /// [`TenantRuntimeRegistry::mark_failed`] so the increment reads the
+    /// prior state under the registry lock.
+    pub fn failed_now(reason: impl Into<String>) -> Self {
+        Self::LoadingFailed {
+            reason: reason.into(),
+            last_attempt_at: SystemTime::now(),
+            retry_count: 1,
+        }
+    }
+
+    /// True iff the tenant can currently serve traffic on this pod.
+    pub fn is_available(&self) -> bool {
+        matches!(self, Self::Available { .. })
+    }
+
+    /// True iff the last wiring attempt failed and hasn't been retried
+    /// into success.
+    pub fn is_failed(&self) -> bool {
+        matches!(self, Self::LoadingFailed { .. })
+    }
+}
+
+/// Pod-local, async-safe registry keyed by tenant slug.
+///
+/// Wrap in `Arc` and store on `AppState`. `Clone` is cheap (Arc bump).
+#[derive(Debug, Default)]
+struct RegistryInner {
+    /// Current observable state per slug.
+    state: HashMap<String, TenantRuntimeState>,
+    /// Highest `rev` ever assigned to each slug. Kept separately from
+    /// the state enum so `Loading` and `LoadingFailed` transitions don't
+    /// lose the monotonic counter — the next `Available` still gets
+    /// `last_rev + 1`. This preserves "rev only ever increases" across
+    /// any number of rewire cycles.
+    last_rev: HashMap<String, u64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TenantRuntimeRegistry {
+    inner: Arc<RwLock<RegistryInner>>,
+}
+
+impl TenantRuntimeRegistry {
+    /// Create an empty registry. Pre-sized for typical single-digit-thousands
+    /// tenant counts; the `RwLock<HashMap>` grows on demand regardless.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot the state of a single tenant. Returns `None` when no entry
+    /// exists — callers MUST treat this as "unknown to this pod" rather
+    /// than "available", otherwise a missing-entry race on boot would let
+    /// unwireable tenants serve traffic.
+    pub async fn get(&self, slug: &str) -> Option<TenantRuntimeState> {
+        self.inner.read().await.state.get(slug).cloned()
+    }
+
+    /// Upsert a state for a slug. Returns the previous state if any.
+    /// This is the low-level primitive; most callers should use the
+    /// `mark_*` helpers which carry the correct state-machine transitions.
+    ///
+    /// If `state` is `Available { rev, .. }`, the registry's internal
+    /// `last_rev` is advanced to `max(last_rev, rev)` so a subsequent
+    /// `mark_available` starts from at least `rev + 1`.
+    pub async fn set(&self, slug: &str, state: TenantRuntimeState) -> Option<TenantRuntimeState> {
+        let mut guard = self.inner.write().await;
+        if let TenantRuntimeState::Available { rev, .. } = &state {
+            let entry = guard.last_rev.entry(slug.to_string()).or_insert(0);
+            if *rev > *entry {
+                *entry = *rev;
+            }
+        }
+        guard.state.insert(slug.to_string(), state)
+    }
+
+    /// Transition `slug` to `Loading { since = now }`. Idempotent —
+    /// re-calling while already `Loading` refreshes the `since` stamp so
+    /// long-running wirings can show progress via the status endpoint.
+    pub async fn mark_loading(&self, slug: &str) {
+        self.inner
+            .write()
+            .await
+            .state
+            .insert(slug.to_string(), TenantRuntimeState::loading_now());
+    }
+
+    /// Transition `slug` to `Available`. Increments `last_rev` under the
+    /// write lock so the counter is monotonic across concurrent rewires
+    /// and survives intermediate `Loading`/`LoadingFailed` transitions.
+    pub async fn mark_available(&self, slug: &str) -> u64 {
+        let mut guard = self.inner.write().await;
+        let next_rev = guard
+            .last_rev
+            .get(slug)
+            .copied()
+            .unwrap_or(0)
+            .saturating_add(1);
+        guard.last_rev.insert(slug.to_string(), next_rev);
+        guard.state.insert(
+            slug.to_string(),
+            TenantRuntimeState::available_now(next_rev),
+        );
+        next_rev
+    }
+
+    /// Transition `slug` to `LoadingFailed`. Increments `retry_count` if
+    /// the prior state was already `LoadingFailed`, else starts at 1.
+    /// Reading the prior state under the write lock guarantees the count
+    /// is monotonic under concurrent failures.
+    pub async fn mark_failed(&self, slug: &str, reason: impl Into<String>) -> u32 {
+        let reason = reason.into();
+        let mut guard = self.inner.write().await;
+        let retry_count = match guard.state.get(slug) {
+            Some(TenantRuntimeState::LoadingFailed { retry_count, .. }) => {
+                retry_count.saturating_add(1)
+            }
+            _ => 1,
+        };
+        guard.state.insert(
+            slug.to_string(),
+            TenantRuntimeState::LoadingFailed {
+                reason,
+                last_attempt_at: SystemTime::now(),
+                retry_count,
+            },
+        );
+        retry_count
+    }
+
+    /// Remove a tenant's entry entirely. Used on tenant deletion so the
+    /// slug is not reported in `/admin/.../status` or `/ready` after the
+    /// row is gone. Also clears the stored `last_rev` so a future
+    /// re-creation of the same slug starts rev counting from 1 — slug
+    /// reuse after deletion is an operator-initiated event, and leaking
+    /// the prior count would confuse status dashboards.
+    pub async fn forget(&self, slug: &str) -> Option<TenantRuntimeState> {
+        let mut guard = self.inner.write().await;
+        guard.last_rev.remove(slug);
+        guard.state.remove(slug)
+    }
+
+    /// Snapshot the whole registry as `(slug, state)` pairs. Used by the
+    /// `/ready` gate (5.3) and the status endpoint (5.5) to render a
+    /// consistent view without holding the lock during serialization.
+    ///
+    /// The returned vector is unsorted; callers that need a deterministic
+    /// order should sort by slug at the call site.
+    pub async fn snapshot(&self) -> Vec<(String, TenantRuntimeState)> {
+        self.inner
+            .read()
+            .await
+            .state
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+
+    /// True iff every tenant in the registry is `Available`. Used by the
+    /// `/ready` gate (5.3). An empty registry returns `true` — the pod
+    /// has not been told about any tenant and therefore has nothing to
+    /// fail; the eager boot loop is responsible for populating the
+    /// registry before `/ready` can legitimately return 200.
+    pub async fn all_available(&self) -> bool {
+        self.inner
+            .read()
+            .await
+            .state
+            .values()
+            .all(TenantRuntimeState::is_available)
+    }
+
+    /// Count of tenants in `LoadingFailed`. Cheap gauge-friendly number
+    /// for 5.6 metrics; a full snapshot isn't required just to report
+    /// the cardinality.
+    pub async fn failed_count(&self) -> usize {
+        self.inner
+            .read()
+            .await
+            .state
+            .values()
+            .filter(|s| s.is_failed())
+            .count()
+    }
+}
+
+/// Serialize `SystemTime` as UTC epoch seconds. Kept module-private; the
+/// enum is the public surface.
+mod serde_epoch {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use serde::{Serialize, Serializer};
+
+    pub fn serialize<S>(t: &SystemTime, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let secs = t
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        secs.serialize(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn empty_registry_is_all_available_vacuously() {
+        // An empty registry is "all available" because there is nothing
+        // to be not-available. The boot-loop contract (task 5.2) is what
+        // prevents `/ready` from returning 200 prematurely by ensuring
+        // at least one tenant is present before the gate flips.
+        let r = TenantRuntimeRegistry::new();
+        assert!(r.all_available().await);
+        assert_eq!(r.failed_count().await, 0);
+        assert!(r.snapshot().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn absent_tenant_is_not_available() {
+        // Absence ≠ Available. The lookup helpers used by per-route 503
+        // (task 5.4) rely on this distinction to avoid serving traffic
+        // on pods that haven't heard of a tenant yet.
+        let r = TenantRuntimeRegistry::new();
+        assert!(r.get("ghost").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn mark_loading_then_available_flows() {
+        let r = TenantRuntimeRegistry::new();
+        r.mark_loading("acme").await;
+        match r.get("acme").await {
+            Some(TenantRuntimeState::Loading { .. }) => {}
+            other => panic!("expected Loading, got {other:?}"),
+        }
+        let rev = r.mark_available("acme").await;
+        assert_eq!(rev, 1, "first Available must be rev=1");
+        assert!(r.all_available().await);
+    }
+
+    #[tokio::test]
+    async fn mark_available_is_monotonic_across_rewires() {
+        // Rewire on provision should bump `rev` so callers can detect
+        // "the value I observed is stale". We do NOT reset rev on a
+        // transient Loading state in between — rev only ever increases.
+        let r = TenantRuntimeRegistry::new();
+        assert_eq!(r.mark_available("acme").await, 1);
+        r.mark_loading("acme").await;
+        assert_eq!(r.mark_available("acme").await, 2);
+        r.mark_loading("acme").await;
+        assert_eq!(r.mark_available("acme").await, 3);
+    }
+
+    #[tokio::test]
+    async fn mark_failed_increments_retry_count() {
+        let r = TenantRuntimeRegistry::new();
+        assert_eq!(r.mark_failed("acme", "boom 1").await, 1);
+        assert_eq!(r.mark_failed("acme", "boom 2").await, 2);
+        assert_eq!(r.mark_failed("acme", "boom 3").await, 3);
+        assert_eq!(r.failed_count().await, 1, "failed_count is per-slug");
+        match r.get("acme").await {
+            Some(TenantRuntimeState::LoadingFailed {
+                reason,
+                retry_count,
+                ..
+            }) => {
+                assert_eq!(retry_count, 3);
+                assert_eq!(reason, "boom 3", "latest reason wins");
+            }
+            other => panic!("expected LoadingFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn success_resets_retry_count_on_next_failure() {
+        // The contract: retry_count counts CONSECUTIVE failures. A
+        // successful rewire in between must reset the counter, otherwise
+        // operators lose the "currently flapping" signal.
+        let r = TenantRuntimeRegistry::new();
+        assert_eq!(r.mark_failed("acme", "a").await, 1);
+        assert_eq!(r.mark_failed("acme", "b").await, 2);
+        r.mark_available("acme").await;
+        assert_eq!(
+            r.mark_failed("acme", "c").await,
+            1,
+            "must reset after success"
+        );
+    }
+
+    #[tokio::test]
+    async fn all_available_requires_every_tenant_available() {
+        let r = TenantRuntimeRegistry::new();
+        r.mark_available("a").await;
+        r.mark_available("b").await;
+        assert!(r.all_available().await);
+        r.mark_failed("b", "rot").await;
+        assert!(!r.all_available().await, "one failure taints the pod");
+    }
+
+    #[tokio::test]
+    async fn forget_removes_the_entry() {
+        let r = TenantRuntimeRegistry::new();
+        r.mark_available("doomed").await;
+        let prior = r.forget("doomed").await;
+        assert!(prior.is_some());
+        assert!(r.get("doomed").await.is_none());
+        assert!(r.forget("doomed").await.is_none(), "forget is idempotent");
+    }
+
+    #[tokio::test]
+    async fn snapshot_is_consistent_with_underlying_state() {
+        let r = TenantRuntimeRegistry::new();
+        r.mark_loading("a").await;
+        r.mark_available("b").await;
+        r.mark_failed("c", "kaboom").await;
+        let mut snap = r.snapshot().await;
+        snap.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(snap.len(), 3);
+        assert_eq!(snap[0].0, "a");
+        assert!(matches!(snap[0].1, TenantRuntimeState::Loading { .. }));
+        assert_eq!(snap[1].0, "b");
+        assert!(snap[1].1.is_available());
+        assert_eq!(snap[2].0, "c");
+        assert!(snap[2].1.is_failed());
+    }
+
+    #[test]
+    fn state_serializes_with_tag_discriminator() {
+        // Status endpoint (5.5) will emit these over JSON. Lock the
+        // serde tag shape now so a future renamer trips a test, not a
+        // dashboard.
+        let s = TenantRuntimeState::Available {
+            rev: 7,
+            wired_at: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+        };
+        let v = serde_json::to_value(&s).unwrap();
+        assert_eq!(v["state"], "available");
+        assert_eq!(v["rev"], 7);
+        assert_eq!(v["wiredAt"], 1_700_000_000);
+    }
+
+    #[test]
+    fn loading_and_failed_serialize_distinguishably() {
+        let loading = TenantRuntimeState::Loading {
+            since: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(100),
+        };
+        let failed = TenantRuntimeState::LoadingFailed {
+            reason: "missing secret".into(),
+            last_attempt_at: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(200),
+            retry_count: 3,
+        };
+        let v1 = serde_json::to_value(&loading).unwrap();
+        assert_eq!(v1["state"], "loading");
+        assert_eq!(v1["since"], 100);
+        let v2 = serde_json::to_value(&failed).unwrap();
+        assert_eq!(v2["state"], "loadingFailed");
+        assert_eq!(v2["reason"], "missing secret");
+        assert_eq!(v2["lastAttemptAt"], 200);
+        assert_eq!(v2["retryCount"], 3);
+    }
+}

--- a/cli/src/server/tenant_runtime_state.rs
+++ b/cli/src/server/tenant_runtime_state.rs
@@ -206,18 +206,22 @@ impl TenantRuntimeRegistry {
                 *entry = *rev;
             }
         }
-        guard.state.insert(slug.to_string(), state)
+        let prev = guard.state.insert(slug.to_string(), state.clone());
+        // B2 task 5.6: emit metrics under the write lock so the
+        // prev→next transition is observed atomically. See module doc
+        // on tenant_metrics for the rationale.
+        super::tenant_metrics::record_transition(slug, prev.as_ref(), Some(&state));
+        prev
     }
 
     /// Transition `slug` to `Loading { since = now }`. Idempotent —
     /// re-calling while already `Loading` refreshes the `since` stamp so
     /// long-running wirings can show progress via the status endpoint.
     pub async fn mark_loading(&self, slug: &str) {
-        self.inner
-            .write()
-            .await
-            .state
-            .insert(slug.to_string(), TenantRuntimeState::loading_now());
+        let mut guard = self.inner.write().await;
+        let next = TenantRuntimeState::loading_now();
+        let prev = guard.state.insert(slug.to_string(), next.clone());
+        super::tenant_metrics::record_transition(slug, prev.as_ref(), Some(&next));
     }
 
     /// Transition `slug` to `Available`. Increments `last_rev` under the
@@ -232,10 +236,9 @@ impl TenantRuntimeRegistry {
             .unwrap_or(0)
             .saturating_add(1);
         guard.last_rev.insert(slug.to_string(), next_rev);
-        guard.state.insert(
-            slug.to_string(),
-            TenantRuntimeState::available_now(next_rev),
-        );
+        let next = TenantRuntimeState::available_now(next_rev);
+        let prev = guard.state.insert(slug.to_string(), next.clone());
+        super::tenant_metrics::record_transition(slug, prev.as_ref(), Some(&next));
         next_rev
     }
 
@@ -252,14 +255,13 @@ impl TenantRuntimeRegistry {
             }
             _ => 1,
         };
-        guard.state.insert(
-            slug.to_string(),
-            TenantRuntimeState::LoadingFailed {
-                reason,
-                last_attempt_at: SystemTime::now(),
-                retry_count,
-            },
-        );
+        let next = TenantRuntimeState::LoadingFailed {
+            reason,
+            last_attempt_at: SystemTime::now(),
+            retry_count,
+        };
+        let prev = guard.state.insert(slug.to_string(), next.clone());
+        super::tenant_metrics::record_transition(slug, prev.as_ref(), Some(&next));
         retry_count
     }
 
@@ -272,7 +274,12 @@ impl TenantRuntimeRegistry {
     pub async fn forget(&self, slug: &str) -> Option<TenantRuntimeState> {
         let mut guard = self.inner.write().await;
         guard.last_rev.remove(slug);
-        guard.state.remove(slug)
+        let prev = guard.state.remove(slug);
+        // Zero out the per-slug gauges and log the absent transition.
+        // See tenant_metrics module doc on why series are zeroed rather
+        // than deleted.
+        super::tenant_metrics::record_transition(slug, prev.as_ref(), None);
+        prev
     }
 
     /// Snapshot the whole registry as `(slug, state)` pairs. Used by the

--- a/cli/src/server/tenant_wiring_api.rs
+++ b/cli/src/server/tenant_wiring_api.rs
@@ -1,0 +1,250 @@
+//! Admin-only endpoints for inspecting pod-local tenant wiring state.
+//!
+//! B2 task 5.5. Completes the observability triangle:
+//!
+//! | Endpoint                                | Auth        | Reveals reasons? |
+//! |-----------------------------------------|-------------|------------------|
+//! | `/ready`                                | none        | no (counts only) |
+//! | handler 503 via `require_available_tenant` | user auth | no               |
+//! | `/api/v1/admin/tenants/.../wiring`      | PA          | **yes**          |
+//!
+//! Reasons can carry upstream error text, redacted-secret hints, or
+//! tenant-identifying detail that must not escape to unauthenticated
+//! surfaces. PlatformAdmin auth is the contract for seeing them.
+//!
+//! # Per-pod semantics
+//!
+//! The response reflects the state of the pod serving the request,
+//! *not* a cluster-wide view. Operators investigating a divergence
+//! (“pod A reports Available, pod B reports LoadingFailed”) should
+//! hit each pod directly — usually via `kubectl port-forward` or a
+//! debug service that bypasses the LB. Exposing a cluster-wide
+//! aggregator would require cross-pod RPC and is out of scope for B2.
+//!
+//! # Endpoints
+//!
+//! * `GET /admin/tenants/wiring`
+//!     — every tenant known to this pod, in registry-order
+//!
+//! * `GET /admin/tenants/{slug}/wiring`
+//!     — one tenant; 404 if this pod has no entry for it (the pod
+//!       hasn't wired it and no `/ready` or shield call has triggered
+//!       lazy wiring)
+//!
+//! Both endpoints are `GET` with no side effects — they do NOT call
+//! `ensure_wired`, intentionally. A status endpoint that silently
+//! primes state would make it impossible to distinguish “this pod
+//! has never seen this tenant” from “this pod failed to wire it”.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use mk_core::types::{Role, RoleIdentifier};
+use serde::Serialize;
+use serde_json::json;
+
+use super::tenant_runtime_state::TenantRuntimeState;
+use super::{AppState, authenticated_platform_context};
+
+pub fn router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/admin/tenants/wiring", get(list_wiring))
+        .route("/admin/tenants/{slug}/wiring", get(get_wiring))
+        .with_state(state)
+}
+
+/// Per-tenant wire envelope. `TenantRuntimeState` already uses
+/// `#[serde(tag = "state", rename_all_fields = "camelCase")]`, so
+/// flattening produces a flat object with `state` as the discriminator
+/// and the payload fields (`reason`, `retryCount`, `lastAttemptAt`,
+/// `rev`, `wiredAt`, `since`) at the top level.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WiringEnvelope {
+    slug: String,
+    #[serde(flatten)]
+    runtime: TenantRuntimeState,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WiringListResponse {
+    /// In-registry iteration order. Not sorted on purpose: sort order
+    /// is chosen by the client (an admin UI typically sorts by status
+    /// descending; Prometheus ingestion cares about labels, not order).
+    tenants: Vec<WiringEnvelope>,
+    total: usize,
+}
+
+/// PA gate. Kept local rather than reusing `context::require_platform_admin`
+/// because this endpoint authenticates off raw headers (no full
+/// `RequestContext` — there’s no tenant to resolve), which matches the
+/// admin_sync.rs pattern for platform-scoped admin routes.
+async fn require_platform_admin(state: &AppState, headers: &HeaderMap) -> Result<(), Response> {
+    let (_uid, roles) = authenticated_platform_context(state, headers).await?;
+    if !is_platform_admin(&roles) {
+        return Err(error_response(
+            StatusCode::FORBIDDEN,
+            "forbidden",
+            "PlatformAdmin role required",
+        ));
+    }
+    Ok(())
+}
+
+/// Whether the role set grants platform-admin privileges.
+/// Split out so unit tests can exercise the predicate directly without
+/// spinning an `AppState`.
+fn is_platform_admin(roles: &[RoleIdentifier]) -> bool {
+    let pa: RoleIdentifier = Role::PlatformAdmin.into();
+    roles.contains(&pa)
+}
+
+#[tracing::instrument(skip_all, fields(slug = %slug))]
+async fn get_wiring(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(slug): Path<String>,
+) -> Response {
+    if let Err(resp) = require_platform_admin(&state, &headers).await {
+        return resp;
+    }
+    match state.tenant_runtime_state.get(&slug).await {
+        Some(runtime) => Json(WiringEnvelope { slug, runtime }).into_response(),
+        None => error_response(
+            StatusCode::NOT_FOUND,
+            "tenant_not_wired",
+            &format!(
+                "No wiring state on this pod for tenant '{slug}'. The pod may \
+                 not have touched this tenant yet; a handler request to the \
+                 tenant (or a /ready scrape after lazy wire) will populate it."
+            ),
+        ),
+    }
+}
+
+#[tracing::instrument(skip_all)]
+async fn list_wiring(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    if let Err(resp) = require_platform_admin(&state, &headers).await {
+        return resp;
+    }
+    // `snapshot()` is a `RwLock::read` clone of the inner map. O(N) in
+    // the number of tenants on this pod; single-digit thousands is well
+    // inside the admin endpoint budget, and we accept tearing-free point-
+    // in-time semantics. If the map ever grows beyond that, we paginate.
+    let snapshot = state.tenant_runtime_state.snapshot().await;
+    let total = snapshot.len();
+    let tenants = snapshot
+        .into_iter()
+        .map(|(slug, runtime)| WiringEnvelope { slug, runtime })
+        .collect();
+    Json(WiringListResponse { tenants, total }).into_response()
+}
+
+fn error_response(status: StatusCode, code: &str, message: &str) -> Response {
+    (status, Json(json!({"error": code, "message": message}))).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    //! End-to-end HTTP tests for this router live in
+    //! `cli/tests/tenant_wiring_api_integration_test.rs` (follow-up) where
+    //! a real `AppState` is available. The unit tests here lock the wire
+    //! contract that the integration layer would otherwise duplicate.
+
+    use super::*;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn envelope_flattens_available_state() {
+        let env = WiringEnvelope {
+            slug: "acme".to_string(),
+            runtime: TenantRuntimeState::Available {
+                rev: 7,
+                wired_at: SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+            },
+        };
+        let v = serde_json::to_value(&env).unwrap();
+        assert_eq!(v["slug"], "acme");
+        assert_eq!(v["state"], "available");
+        assert_eq!(v["rev"], 7);
+        // `wired_at` field is camelCased by `rename_all_fields` on the
+        // enum and serialized as epoch seconds by `serde_epoch`.
+        assert_eq!(v["wiredAt"], 1_700_000_000);
+    }
+
+    #[test]
+    fn envelope_flattens_failed_state_including_reason() {
+        // Reason IS exposed here by design — the PA gate is the
+        // authorisation boundary. If PA auth is ever bypassed (bug),
+        // this test is the canary: it locks the wire to carry the
+        // reason so a broken gate shows up as a visible regression
+        // elsewhere, not a silent information leak.
+        let env = WiringEnvelope {
+            slug: "acme".to_string(),
+            runtime: TenantRuntimeState::LoadingFailed {
+                reason: "secret openai.api_key missing".to_string(),
+                last_attempt_at: SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+                retry_count: 3,
+            },
+        };
+        let v = serde_json::to_value(&env).unwrap();
+        assert_eq!(v["state"], "loadingFailed");
+        assert_eq!(v["reason"], "secret openai.api_key missing");
+        assert_eq!(v["retryCount"], 3);
+        assert_eq!(v["lastAttemptAt"], 1_700_000_000);
+    }
+
+    #[test]
+    fn list_response_includes_total() {
+        let resp = WiringListResponse {
+            tenants: vec![
+                WiringEnvelope {
+                    slug: "a".into(),
+                    runtime: TenantRuntimeState::available_now(1),
+                },
+                WiringEnvelope {
+                    slug: "b".into(),
+                    runtime: TenantRuntimeState::loading_now(),
+                },
+            ],
+            total: 2,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["total"], 2);
+        assert_eq!(v["tenants"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn is_platform_admin_accepts_pa_role() {
+        let pa: RoleIdentifier = Role::PlatformAdmin.into();
+        assert!(is_platform_admin(&[pa]));
+    }
+
+    #[test]
+    fn is_platform_admin_rejects_other_roles() {
+        // Viewer is the lowest-privilege non-PA role; if this test
+        // passes for Viewer it passes a fortiori for every other
+        // non-PA role (Developer, TechLead, Architect, Admin,
+        // TenantAdmin, Agent).
+        let viewer: RoleIdentifier = Role::Viewer.into();
+        assert!(!is_platform_admin(&[viewer]));
+    }
+
+    #[test]
+    fn is_platform_admin_rejects_empty_roles() {
+        assert!(!is_platform_admin(&[]));
+    }
+
+    #[test]
+    fn error_response_shape_is_stable() {
+        // Admin UIs key on the `error` field; don’t let a drive-by
+        // refactor change it to `code` or `type`.
+        let resp = error_response(StatusCode::FORBIDDEN, "forbidden", "no");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/cli/src/server/webhooks.rs
+++ b/cli/src/server/webhooks.rs
@@ -796,6 +796,7 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            redis_url: None,
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),

--- a/cli/src/server/webhooks.rs
+++ b/cli/src/server/webhooks.rs
@@ -796,6 +796,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })
     }
 

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -354,6 +354,7 @@ async fn test_app_state_with_plugin_auth(
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            redis_url: None,
             tenant_runtime_state: std::sync::Arc::new(
                 aeterna::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -354,6 +354,9 @@ async fn test_app_state_with_plugin_auth(
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                aeterna::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         }),
         tempdir,
     ))

--- a/mk_core/src/secret.rs
+++ b/mk_core/src/secret.rs
@@ -208,7 +208,11 @@ impl schemars::JsonSchema for SecretBytes {
 /// so future backends (external secret managers, cloud KV stores, etc.)
 /// can be added as additive variants.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum SecretReference {
     /// Encrypted blob stored in the `tenant_secrets` Postgres table. The row
     /// holds a KMS-wrapped DEK and an AES-256-GCM ciphertext.
@@ -299,8 +303,14 @@ mod tests {
             secret_id: Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap(),
         };
         let j = serde_json::to_string(&r).unwrap();
-        assert!(j.contains("\"secretId\""), "expected camelCase secretId on wire, got: {j}");
-        assert!(!j.contains("\"secret_id\""), "snake_case secret_id leaked on wire: {j}");
+        assert!(
+            j.contains("\"secretId\""),
+            "expected camelCase secretId on wire, got: {j}"
+        );
+        assert!(
+            !j.contains("\"secret_id\""),
+            "snake_case secret_id leaked on wire: {j}"
+        );
 
         // Deserialize MUST accept camelCase (the canonical shape) and
         // MUST reject snake_case so we do not have two valid wire shapes.

--- a/openspec/changes/harden-tenant-provisioning/tasks.md
+++ b/openspec/changes/harden-tenant-provisioning/tasks.md
@@ -38,7 +38,7 @@
 
 ### 5. Per-tenant provider state and readiness gate _(design per 0.2)_
 
-- [ ] 5.1 Define `TenantRuntimeState` enum `{ Loading, Available, LoadingFailed { reason } }`.
+- [x] 5.1 Define `TenantRuntimeState` enum `{ Loading, Available, LoadingFailed { reason } }`. _(PR: `feat/b2-tenant-runtime-state` — adds `cli/src/server/tenant_runtime_state.rs` with the enum, an async-safe `TenantRuntimeRegistry`, monotonic `rev` counter that survives Loading/Failed transitions, `retry_count` on consecutive failures, and 11 unit tests.)_
 - [!] 5.2 Implement the wiring model chosen in 0.2. If lazy: record first-resolution outcome per tenant and surface it. If eager: startup loop over persisted tenants.
 - [~] 5.3 Extend `/ready` (`cli/src/server/health.rs:40`, handler at L58) to include a tenant-state check in addition to current PG + vector checks. Return 503 until bootstrap completes AND all tenants resolved (per 0.2).
 - [ ] 5.4 In tenant-scoped routes (`/api/v1/memory/*` and siblings), short-circuit to HTTP 503 `{error: "tenant_unavailable", tenantSlug, reason}` when target tenant is `LoadingFailed`.


### PR DESCRIPTION
## Draft integration PR — full B2 tenant-wiring stack vs master

**Do not merge this PR.** Individual feature PRs (#108–#116) are the review units. This PR exists solely to run CI against master with everything composed, which the stacked PRs cannot do (each stacked PR’s CI runs against its parent branch, not master).

## Composition

| PR    | Task    | Branch                                    |
|-------|---------|-------------------------------------------|
| #108  | 5.1     | `feat/b2-tenant-runtime-state`            |
| #109  | 5.2a    | `feat/b2-eager-tenant-wiring`             |
| #110  | 5.2b    | `feat/b2-tenant-pubsub-invalidation`      |
| #111  | 5.2c    | `feat/b2-tenant-lazy-wire`                |
| #112  | 5.3     | `feat/b2-ready-tenant-gate`               |
| #113  | 5.4     | `feat/b2-tenant-unavailable-shield`       |
| #114  | 5.5     | `feat/b2-tenant-wiring-status`            |
| #115  | 5.6     | `feat/b2-tenant-metrics`                  |
| #116  | 5.4f    | `feat/b2-handler-shield-sweep`            |

9 feature branches merged non-fast-forward onto current master. Zero conflicts during composition.

## Local verification (before push)

- `cargo test -p aeterna --lib`: **704/704 green** (60s)
- `cargo clippy -p aeterna --all-features --tests -- -D warnings`: **clean**
- `cargo fmt -p aeterna --check`: **clean**
- Full stack compiles against current master tip.

## How to use this PR

1. CI runs end-to-end against master — catches any integration gap that the individual PRs’ CI cannot.
2. Reviewers review the **individual** PRs (#108 first, then follow the stack). This PR is purely a canary.
3. As individual PRs merge bottom-up, this integration branch will be deleted — each merge retargets the next PR’s base automatically, and CI for each then naturally runs against master.

## Merge order

Bottom-up, one at a time:

    #108 → #109 → #110 → #111 → #112 → #113 → #116 → #114 → #115

(#116 can go any time after #113 lands — it depends on the shield API landed in 5.4.)

## Scope summary

- 9 new source modules under `cli/src/server/`
- 70+ new unit tests (registry, eager-wire, pubsub, lazy-wire, /ready, shield, wiring API, metrics)
- 1 chokepoint migration activating the shield on every tenant handler
- Full design §D5 implementation: eager boot ⊗ pub/sub invalidation ⊗ lazy fallback
- 3 observability surfaces: `/ready`, PA `/admin/tenants/.../wiring`, Prometheus metrics
