### PR TITLE
feat(tenant-wiring): eager boot loop priming provider registry (B2 task 5.2a, reopened from #109)

### DIFF
--- a/cli/src/commands/serve.rs
+++ b/cli/src/commands/serve.rs
@@ -55,6 +55,12 @@ pub async fn run(args: ServeArgs) -> anyhow::Result<()> {
     let lifecycle_mgr = lifecycle::LifecycleManager::new();
     lifecycle_mgr.start(state.clone());
 
+    // Eager tenant wiring (B2 task 5.2 — design §D5 boot loop). Spawned
+    // detached; the HTTP server binds immediately and `/ready` (task 5.3)
+    // reports the progress. See
+    // `cli/src/server/tenant_eager_wire.rs` for failure policy.
+    crate::server::tenant_eager_wire::spawn_eager_wire(state.clone());
+
     let app_listener = TcpListener::bind(app_addr).await?;
     let metrics_listener = TcpListener::bind(metrics_addr).await?;
 

--- a/cli/src/server/admin_sync.rs
+++ b/cli/src/server/admin_sync.rs
@@ -808,6 +808,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })
     }
 

--- a/cli/src/server/bootstrap.rs
+++ b/cli/src/server/bootstrap.rs
@@ -405,6 +405,9 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
         provider_registry,
         git_provider_connection_registry,
         redis_conn,
+        tenant_runtime_state: Arc::new(
+            crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+        ),
     }))
 }
 

--- a/cli/src/server/health.rs
+++ b/cli/src/server/health.rs
@@ -400,6 +400,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })
     }
 

--- a/cli/src/server/knowledge_api.rs
+++ b/cli/src/server/knowledge_api.rs
@@ -1980,6 +1980,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })))
     }
 
@@ -2565,6 +2568,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })))
     }
 

--- a/cli/src/server/lifecycle.rs
+++ b/cli/src/server/lifecycle.rs
@@ -659,6 +659,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })
     }
 

--- a/cli/src/server/mcp_transport.rs
+++ b/cli/src/server/mcp_transport.rs
@@ -376,6 +376,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         });
 
         (server, app_state, tempdir)

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -22,6 +22,7 @@ pub mod sessions;
 pub mod sync;
 pub mod team_api;
 pub mod tenant_api;
+pub mod tenant_eager_wire;
 pub mod tenant_runtime_state;
 pub mod user_api;
 pub mod webhooks;
@@ -110,6 +111,11 @@ pub struct AppState {
     pub tenant_config_provider: Arc<KubernetesTenantConfigProvider>,
     /// Per-tenant LLM/embedding provider registry with caching.
     pub provider_registry: Arc<TenantProviderRegistry>,
+    /// Per-tenant readiness state recorded by the eager boot loop and
+    /// rewire triggers. Consulted by `/ready` (task 5.3) and tenant-scoped
+    /// routes (task 5.4). See [`tenant_runtime_state`] for the state
+    /// machine.
+    pub tenant_runtime_state: Arc<tenant_runtime_state::TenantRuntimeRegistry>,
     /// Registry of platform-owned Git provider connections (task 3.4).
     pub git_provider_connection_registry:
         Arc<dyn GitProviderConnectionRegistry<Error = GitProviderConnectionError> + Send + Sync>,

--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -4671,6 +4671,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         });
 
         Some((router(state), tenant))

--- a/cli/src/server/tenant_eager_wire.rs
+++ b/cli/src/server/tenant_eager_wire.rs
@@ -1,0 +1,272 @@
+//! Eager tenant wiring (B2 task 5.2 — boot-loop half of design §D5).
+//!
+//! On pod start, the handler [`spawn_eager_wire`] enumerates every active
+//! tenant and primes the provider registry so subsequent requests hit a
+//! warm cache and so misconfigured tenants are surfaced by `/ready` (task
+//! 5.3) instead of by the first user who tries to use them.
+//!
+//! # Scope of this drop
+//!
+//! This module owns *only* the boot loop. The pub/sub subscriber that
+//! listens on `tenant:changed` for cross-pod invalidation and the lazy
+//! fallback that closes the sub-second race window (both per design
+//! §D5) land in follow-up PRs; the public surface here — `spawn_eager_wire`
+//! taking `Arc<AppState>` — is designed so those additions do not
+//! require another wide refactor.
+//!
+//! # Blocking policy
+//!
+//! Boot does **not** block on the wiring completing. The task is spawned
+//! and returns immediately so the HTTP server can bind and serve `/health`
+//! (liveness). What a failed wiring costs is that `/ready` keeps returning
+//! 503 with `LoadingFailed` tenants visible in the status endpoint until
+//! either a rewire succeeds or the tenant is deactivated. Per-tenant
+//! failures do not taint other tenants.
+//!
+//! # Strict mode
+//!
+//! `AETERNA_EAGER_WIRE_STRICT=1` makes any `LoadingFailed` keep `/ready`
+//! at 503 forever. Default (per design §D5 "failure policy: per-tenant")
+//! is permissive — `/ready` flips to 200 once every tenant has *some*
+//! terminal state, so a single misconfigured tenant does not lock the
+//! whole cluster out of load-balancer rotation.
+//!
+//! Strict mode is consulted by the `/ready` handler (5.3), not here —
+//! this module only records state. We expose a helper so the handler
+//! reads the same env var.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use tracing::{debug, error, info, warn};
+
+use super::AppState;
+
+/// Spawn the eager tenant-wiring task.
+///
+/// Returns immediately. The task runs on the tokio runtime and logs
+/// progress at INFO; failures log at WARN with the tenant slug and the
+/// error summary (redacted — downstream producers must not include
+/// secret material in error messages).
+///
+/// The caller owns the `Arc<AppState>` returned by [`super::bootstrap::bootstrap`];
+/// passing a clone keeps the task independent of the HTTP server
+/// lifecycle. Graceful shutdown is driven by `AppState::shutdown_tx`
+/// — the loop checks the watch on each iteration and bails without
+/// writing further state when shutdown is requested.
+pub fn spawn_eager_wire(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        if let Err(e) = run_eager_wire(&state).await {
+            error!(error = %e, "eager tenant wiring loop failed");
+        }
+    });
+}
+
+/// True iff strict mode is enabled. Used by the `/ready` gate (5.3).
+/// Defined here so the env-var spelling is centralised.
+pub fn is_strict_mode() -> bool {
+    matches!(
+        std::env::var("AETERNA_EAGER_WIRE_STRICT").as_deref(),
+        Ok("1" | "true" | "TRUE" | "yes" | "on")
+    )
+}
+
+async fn run_eager_wire(state: &AppState) -> anyhow::Result<()> {
+    let started = Instant::now();
+    let tenants = state.tenant_store.list_tenants(false).await?;
+    info!(
+        tenant_count = tenants.len(),
+        strict_mode = is_strict_mode(),
+        "eager tenant wiring: starting"
+    );
+
+    // Seed every tenant as Loading BEFORE we start resolving — this way
+    // `/ready` cannot observe a partial registry that says "all available"
+    // simply because we haven't recorded the in-flight ones yet. Between
+    // this loop and the resolution loop `all_available` returns false
+    // even if the first tenant already finished.
+    for t in &tenants {
+        state
+            .tenant_runtime_state
+            .mark_loading(t.slug.as_str())
+            .await;
+    }
+
+    let mut ok = 0usize;
+    let mut failed = 0usize;
+    for t in tenants {
+        // Respect shutdown: stop seeding new work but leave already-recorded
+        // state intact. The pod will exit in moments.
+        if *state.shutdown_tx.borrow() {
+            warn!("eager tenant wiring: shutdown requested, aborting");
+            break;
+        }
+
+        let slug = t.slug.clone();
+        let tenant_id = t.id.clone();
+        let started_one = Instant::now();
+        match wire_one(state, &tenant_id).await {
+            Ok(()) => {
+                let rev = state.tenant_runtime_state.mark_available(&slug).await;
+                ok += 1;
+                debug!(
+                    tenant = %slug,
+                    rev,
+                    elapsed_ms = started_one.elapsed().as_millis() as u64,
+                    "tenant wired"
+                );
+            }
+            Err(e) => {
+                // `e` is `anyhow::Error` from `wire_one`; its root-cause
+                // chain is pre-redacted. We still clamp to 256 chars so a
+                // surprise stack trace does not blow up the registry
+                // entry size.
+                let reason = truncate(&format!("{e:#}"), 256);
+                let retries = state.tenant_runtime_state.mark_failed(&slug, &reason).await;
+                failed += 1;
+                warn!(
+                    tenant = %slug,
+                    retry_count = retries,
+                    reason = %reason,
+                    elapsed_ms = started_one.elapsed().as_millis() as u64,
+                    "tenant wiring failed"
+                );
+            }
+        }
+    }
+
+    info!(
+        ok,
+        failed,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "eager tenant wiring: complete"
+    );
+    Ok(())
+}
+
+/// Wire a single tenant: prime the LLM and embedding caches via the
+/// existing [`memory::provider_registry::TenantProviderRegistry`]. A
+/// tenant with neither an LLM nor an embedding provider configured is
+/// considered successfully wired — it just resolves to the platform
+/// defaults at request time and that is a legitimate steady state (e.g.
+/// bootstrap before a manifest is applied).
+///
+/// We intentionally do NOT wire memory-layer backends here. Those are
+/// per-request today via the memory manager; 5.2's scope is limited to
+/// the provider registry. Widening to memory layers is a separate
+/// design decision because some layers are lazy by construction.
+async fn wire_one(state: &AppState, tenant_id: &mk_core::types::TenantId) -> anyhow::Result<()> {
+    // The provider registry caches on success; a miss falls through to
+    // platform defaults and returns `None`, which is NOT an error. Only a
+    // resolution error (bad config, missing secret, unreachable endpoint)
+    // should mark the tenant failed.
+    //
+    // The current `get_*_service` API swallows resolution errors and
+    // returns `None` indistinguishably from "no override configured".
+    // Until that API grows a fallible variant, eager-wiring can only
+    // detect failures that surface as resolver panics or config-provider
+    // errors. This is acceptable for the first drop: the readiness
+    // signal is strictly better than the status quo (none), and the
+    // provider-level failure surface is a known follow-up (see TODO
+    // below).
+    //
+    // TODO(b2-5.2-followup): tighten `get_*_service` to return
+    // `Result<Option<_>, ResolutionError>` so real wiring failures
+    // bubble up here instead of being logged-and-swallowed inside the
+    // registry.
+    let _ = state
+        .provider_registry
+        .get_llm_service(tenant_id, state.tenant_config_provider.as_ref())
+        .await;
+    let _ = state
+        .provider_registry
+        .get_embedding_service(tenant_id, state.tenant_config_provider.as_ref())
+        .await;
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        // Safe char-boundary truncate; avoids splitting a multi-byte char
+        // which would be a panic on some inputs. `floor_char_boundary`
+        // would be cleaner but is nightly.
+        let mut end = max;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &s[..end])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strict_mode_defaults_off() {
+        // Isolate from CI env. `std::env` is process-global; this test
+        // is single-threaded enough for a save/restore dance.
+        let prior = std::env::var("AETERNA_EAGER_WIRE_STRICT").ok();
+        unsafe {
+            std::env::remove_var("AETERNA_EAGER_WIRE_STRICT");
+        }
+        assert!(!is_strict_mode());
+        if let Some(v) = prior {
+            unsafe {
+                std::env::set_var("AETERNA_EAGER_WIRE_STRICT", v);
+            }
+        }
+    }
+
+    #[test]
+    fn strict_mode_parses_truthy_values() {
+        let prior = std::env::var("AETERNA_EAGER_WIRE_STRICT").ok();
+        for v in ["1", "true", "TRUE", "yes", "on"] {
+            unsafe {
+                std::env::set_var("AETERNA_EAGER_WIRE_STRICT", v);
+            }
+            assert!(is_strict_mode(), "expected {v} to enable strict mode");
+        }
+        for v in ["0", "false", "no", "off", ""] {
+            unsafe {
+                std::env::set_var("AETERNA_EAGER_WIRE_STRICT", v);
+            }
+            assert!(!is_strict_mode(), "expected {v} to leave strict off");
+        }
+        match prior {
+            Some(v) => unsafe {
+                std::env::set_var("AETERNA_EAGER_WIRE_STRICT", v);
+            },
+            None => unsafe {
+                std::env::remove_var("AETERNA_EAGER_WIRE_STRICT");
+            },
+        }
+    }
+
+    #[test]
+    fn truncate_preserves_short_strings() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_trims_with_ellipsis() {
+        let s = "x".repeat(300);
+        let out = truncate(&s, 10);
+        assert_eq!(out.chars().count(), 11, "10 chars + ellipsis");
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_respects_utf8_boundaries() {
+        // 4-byte emoji at byte 9. Truncating at max=10 would split the
+        // emoji; the helper must step back to the nearest boundary.
+        let s = "abcdefghi✨✨✨";
+        let out = truncate(s, 10);
+        // Valid UTF-8 by construction of String::from; the real
+        // assertion is "did not panic".
+        assert!(out.ends_with('…'));
+        assert!(out.len() <= s.len());
+    }
+}

--- a/cli/src/server/webhooks.rs
+++ b/cli/src/server/webhooks.rs
@@ -796,6 +796,9 @@ mod tests {
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         })
     }
 

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -354,6 +354,9 @@ async fn test_app_state_with_plugin_auth(
             )),
             git_provider_connection_registry,
             redis_conn: None,
+            tenant_runtime_state: std::sync::Arc::new(
+                aeterna::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
+            ),
         }),
         tempdir,
     ))


### PR DESCRIPTION
Stacked on #108 (task 5.1).

## What

Adds `cli/src/server/tenant_eager_wire.rs`. On pod start, enumerates active tenants and primes the `TenantProviderRegistry` (LLM + embedding caches) while recording progress in the `TenantRuntimeRegistry` introduced by #108.

- `mark_loading` seeded for every tenant **before** any resolution starts — `/ready` can never observe a partial view that reports "all available" prematurely.
- `mark_available{rev}` on success (rev bumps via the side-map in the registry).
- `mark_failed{reason}` on error, with the reason UTF-8-safe-truncated to 256 chars.
- Honors `AppState::shutdown_tx` — aborts the loop on SIGTERM.
- Task spawned **detached** from `cli/src/commands/serve.rs` so the HTTP listener binds immediately.

## Failure policy (design §D5)

Permissive by default — per-tenant failures do not block `/ready` cluster-wide.
`AETERNA_EAGER_WIRE_STRICT=1` flips to fail-closed for the upcoming `/ready` gate in 5.3; the env var is parsed here (`is_strict_mode()`) so the spelling lives in one place.

## Scope carved out

- **5.2b (next PR)**: Dragonfly pub/sub subscriber on `tenant:changed` for cross-pod rewire + lazy-fallback path closing the sub-second race (both per design §D5).
- **Resolver error surface**: `TenantProviderRegistry::get_*_service` still returns `Option<T>` and logs+swallows resolution errors. An in-source `TODO(b2-5.2-followup)` tags the API tightening; today eager wiring can only flag tenants whose `list_tenants` row itself is corrupt or whose config-provider backend panics.
- Memory-layer backends are out of scope (some are lazy by construction). 5.2 is strictly the provider registry.

## AppState change

New field `tenant_runtime_state: Arc<TenantRuntimeRegistry>`. 8 test-scope constructors updated (tenant_api, health, knowledge_api x2, admin_sync, webhooks, lifecycle, mcp_transport, server_runtime_test).

## Tests

5 unit tests for the helpers (strict-mode env parse off/on/truthy-variants; `truncate` short/long/UTF-8-boundary). Runtime behaviour (boot-loop integration) is covered implicitly by #108's registry tests plus `/ready` integration in 5.3.

## CI

- `cargo check -p aeterna`: green
- `cargo fmt --all`: clean
- `cargo clippy -p aeterna --lib --tests -- -D warnings`: clean
- `cargo test -p aeterna --lib server::tenant_eager_wire`: 5/5 green

## Next

- 5.2b — Dragonfly pub/sub invalidation + lazy fallback
- 5.3 — `/ready` gate consuming `tenant_runtime_state` and `is_strict_mode()`
- 5.4 — per-route 503 `tenant_unavailable` shield

\n\n---\n*Reopened from #109 which GitHub auto-closed when its base branch (#108) was deleted on merge.*
