### PR TITLE
feat(server): BootstrapTracker + /admin/bootstrap/status (B2 tasks 6.1-6.3)

### DIFF
--- a/cli/src/server/admin_sync.rs
+++ b/cli/src/server/admin_sync.rs
@@ -812,6 +812,7 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
+            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
         })
     }
 

--- a/cli/src/server/admin_sync.rs
+++ b/cli/src/server/admin_sync.rs
@@ -812,7 +812,9 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
-            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
+            bootstrap_tracker: std::sync::Arc::new(
+                crate::server::bootstrap_tracker::BootstrapTracker::new(),
+            ),
         })
     }
 

--- a/cli/src/server/bootstrap.rs
+++ b/cli/src/server/bootstrap.rs
@@ -42,7 +42,7 @@ use sync::websocket::{AuthToken, TokenValidator, WsResult, WsServer};
 use tools::server::McpServer;
 
 use super::plugin_auth::{RefreshTokenStore, RefreshTokenStoreBackend};
-use super::{AppState, PluginAuthState};
+use super::{AppState, PluginAuthState, bootstrap_tracker};
 
 const DEFAULT_K8S_NAMESPACE: &str = "default";
 
@@ -50,9 +50,22 @@ const ENV_AUTH_BACKEND: &str = "AETERNA_AUTH_BACKEND";
 const AUTH_BACKEND_ALLOW_ALL: &str = "allow-all";
 
 pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
+    // Bootstrap phase tracker (B2 task 6.1). Instrumented across the
+    // major phases below; finalized with `mark_ready()` immediately
+    // before we hand the state back to `serve::run`. On error we
+    // deliberately do NOT call `mark_ready()` — the process is about to
+    // exit anyway (kubelet restart path) and leaving the tracker with
+    // a `running` overall state would only matter if someone attached
+    // a debugger mid-failure.
+    let bootstrap_tracker = Arc::new(bootstrap_tracker::BootstrapTracker::new());
+
+    bootstrap_tracker.begin("env_and_config");
     validate_required_env()?;
 
     let config = Arc::new(config::load_from_env()?);
+    bootstrap_tracker.complete("env_and_config");
+
+    bootstrap_tracker.begin("database");
     let tenant_url = postgres_connection_url(&config);
     // Dual-pool config (issue #58, RLS enforcement).
     //
@@ -70,7 +83,9 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
 
     seed_platform_admin(postgres.pool(), &config.admin_bootstrap).await?;
     seed_k8s_service_account(postgres.pool(), &config.admin_bootstrap).await?;
+    bootstrap_tracker.complete("database");
 
+    bootstrap_tracker.begin("knowledge_git");
     let governance_storage = Some(Arc::new(GovernanceStorage::new(postgres.pool().clone())));
 
     let git_provider: Option<Arc<dyn GitProvider>> = if let (Some(owner), Some(repo)) = (
@@ -129,7 +144,9 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
         GitRepository::new_with_remote(knowledge_repo_path(), remote_config)
             .context("Failed to initialize knowledge repository")?,
     );
+    bootstrap_tracker.complete("knowledge_git");
 
+    bootstrap_tracker.begin("memory_and_providers");
     let auth_for_memory = build_boxed_auth_service()?;
     let auth_service = build_anyhow_auth_service()?;
 
@@ -253,7 +270,9 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
     memory_manager = memory_manager.with_knowledge_manager(knowledge_manager.clone());
 
     let memory_manager = Arc::new(memory_manager);
+    bootstrap_tracker.complete("memory_and_providers");
 
+    bootstrap_tracker.begin("sync_and_protocols");
     let persister = Arc::new(DatabasePersister::new(postgres.clone(), "sync".to_string()));
     let sync_manager = Arc::new(
         SyncManager::new(
@@ -299,6 +318,9 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
         trusted_identity: a2a_config.auth.trusted_identity.clone(),
     });
     a2a_auth_state.validate()?;
+    bootstrap_tracker.complete("sync_and_protocols");
+
+    bootstrap_tracker.begin("redis_and_auth_stores");
     // Build a Redis connection manager for shared state stores.
     // If Redis is available, use Redis-backed stores for HA; otherwise fall back to in-memory.
     let (redis_conn, redis_url): (Option<Arc<redis::aio::ConnectionManager>>, Option<String>) = {
@@ -341,7 +363,9 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
 
     // Initialize backup job stores (export/import) with Redis when available.
     super::backup_api::init_job_stores(redis_conn.as_ref());
+    bootstrap_tracker.complete("redis_and_auth_stores");
 
+    bootstrap_tracker.begin("assemble_state");
     let (idp_config, idp_client, idp_sync_service) = build_optional_idp_services(postgres.clone())?;
     let ws_server = Arc::new(WsServer::new(Arc::new(AllowAllTokenValidator {
         access_token_ttl_seconds: config.plugin_auth.access_token_ttl_seconds.unwrap_or(3600),
@@ -409,6 +433,15 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
         tenant_runtime_state: Arc::new(
             crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
         ),
+        bootstrap_tracker: {
+            // Close the final phase and finalize the tracker BEFORE
+            // handing the Arc<AppState> back. Post this point the
+            // `/admin/bootstrap/status` endpoint will report
+            // `state: "completed"` with all phase durations populated.
+            bootstrap_tracker.complete("assemble_state");
+            bootstrap_tracker.mark_ready();
+            bootstrap_tracker
+        },
     }))
 }
 

--- a/cli/src/server/bootstrap_api.rs
+++ b/cli/src/server/bootstrap_api.rs
@@ -1,0 +1,65 @@
+//! Admin endpoint for bootstrap introspection (B2 task 6.1).
+//!
+//! `GET /api/v1/admin/bootstrap/status` — returns the in-memory
+//! [`BootstrapStatus`] snapshot produced by
+//! [`crate::server::bootstrap_tracker::BootstrapTracker`].
+//!
+//! # Auth
+//!
+//! PlatformAdmin-only. The snapshot can contain upstream error strings
+//! (DB connect failures, K8s-API detail, etc.); exposing those behind
+//! PA matches the precedent set by [`admin_sync`] and the tenant wiring
+//! admin endpoints.
+//!
+//! # Scope
+//!
+//! Per-pod. In HA deployments each replica holds its own tracker; ops
+//! investigating a rolling-deploy regression must query each pod
+//! directly (via `kubectl port-forward` or a Service that targets a
+//! specific pod). A cluster-wide aggregator is explicitly out of scope
+//! for this task — Prometheus scrapes of bootstrap durations would be
+//! the right tool for fleet-level views.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
+use serde_json::json;
+
+use super::{AppState, authenticated_platform_context};
+
+pub fn router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/admin/bootstrap/status", get(handle_status))
+        .with_state(state)
+}
+
+#[tracing::instrument(skip_all)]
+async fn handle_status(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let (_user_id, roles) = match authenticated_platform_context(&state, &headers).await {
+        Ok(ctx) => ctx,
+        Err(resp) => return resp,
+    };
+    if !roles
+        .iter()
+        .any(|r| *r == mk_core::types::Role::PlatformAdmin.into())
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "error": "forbidden",
+                "message": "PlatformAdmin role required"
+            })),
+        )
+            .into_response();
+    }
+
+    let snapshot = state.bootstrap_tracker.snapshot();
+    (StatusCode::OK, Json(snapshot)).into_response()
+}

--- a/cli/src/server/bootstrap_tracker.rs
+++ b/cli/src/server/bootstrap_tracker.rs
@@ -1,0 +1,422 @@
+//! Bootstrap phase tracker (B2 task 6.1).
+//!
+//! Records per-phase timing and outcomes during `bootstrap()` so ops can
+//! answer "why did my pod take 40s to start" and "did the admin seed
+//! no-op or actually run" via a single admin endpoint instead of hunting
+//! through log tails.
+//!
+//! # Architecture note (task 6.2)
+//!
+//! Today `bootstrap()` runs **synchronously** in `serve::run` before the
+//! HTTP listener binds. That means no request can observe a mid-bootstrap
+//! state — the pod either completes boot and begins serving, or exits
+//! (kubelet restart). `/ready` is therefore **structurally** gated on
+//! bootstrap completion without any explicit check: a pod that failed
+//! bootstrap has no listener at all, which the kubelet reads as 503.
+//!
+//! This module still provides [`BootstrapTracker::is_completed`] so the
+//! `/ready` handler can opt in to explicit gating if bootstrap is ever
+//! refactored to run async-post-bind. Until then the method returns
+//! `true` by the time any request is possible.
+//!
+//! # Wire contract (`/api/v1/admin/bootstrap/status`)
+//!
+//! PlatformAdmin-gated. Returns the in-memory snapshot — per-pod, not
+//! cluster-wide. Operators investigating a boot regression across a
+//! rolling deploy hit each pod directly.
+//!
+//! # Redaction
+//!
+//! Step error strings can carry upstream detail (DB error messages,
+//! K8s-API failures, etc.). The endpoint is PA-gated precisely so the
+//! raw text is only reachable behind auth. There is no unauthenticated
+//! surface for this data.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+/// Snapshot of the bootstrap progress for the wire / tests.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BootstrapStatus {
+    pub state: &'static str,
+    pub started_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    pub steps: Vec<StepStatus>,
+}
+
+/// Single-phase record. One per call to [`BootstrapTracker::begin`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StepStatus {
+    pub name: &'static str,
+    /// `running` until terminated; then `success` or `failure`.
+    pub state: &'static str,
+    pub started_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    /// Non-None only when `state == "failure"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    started_at_wall: DateTime<Utc>,
+    started_at_mono: Instant,
+    completed_at_wall: Option<DateTime<Utc>>,
+    completed_at_mono: Option<Instant>,
+    /// True once [`BootstrapTracker::mark_ready`] was called.
+    completed: bool,
+    /// True if any step was marked failure.
+    failed: bool,
+    steps: Vec<StepRecord>,
+}
+
+#[derive(Debug)]
+struct StepRecord {
+    name: &'static str,
+    started_at_wall: DateTime<Utc>,
+    started_at_mono: Instant,
+    /// None while running. `Some(Ok(()))` on success, `Some(Err(msg))`
+    /// on failure.
+    outcome: Option<Result<(), String>>,
+    completed_at_wall: Option<DateTime<Utc>>,
+    completed_at_mono: Option<Instant>,
+}
+
+/// Thread-safe, append-only bootstrap progress log.
+///
+/// Shared via `Arc` from `bootstrap()` into `AppState` so the admin
+/// endpoint can observe it after the fact.
+#[derive(Debug)]
+pub struct BootstrapTracker {
+    inner: Mutex<Inner>,
+}
+
+impl Default for BootstrapTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BootstrapTracker {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                started_at_wall: Utc::now(),
+                started_at_mono: Instant::now(),
+                completed_at_wall: None,
+                completed_at_mono: None,
+                completed: false,
+                failed: false,
+                steps: Vec::new(),
+            }),
+        }
+    }
+
+    /// Record the start of a phase. Name must be `'static` so the wire
+    /// contract stays stable.
+    pub fn begin(&self, name: &'static str) {
+        let mut g = self.inner.lock().expect("bootstrap tracker poisoned");
+        g.steps.push(StepRecord {
+            name,
+            started_at_wall: Utc::now(),
+            started_at_mono: Instant::now(),
+            outcome: None,
+            completed_at_wall: None,
+            completed_at_mono: None,
+        });
+    }
+
+    /// Mark the most recently started step with matching name as
+    /// succeeded. Silently no-ops on unknown or already-terminated
+    /// names — the tracker must never panic bootstrap.
+    pub fn complete(&self, name: &'static str) {
+        self.terminate(name, Ok(()));
+    }
+
+    /// Mark the most recently started step with matching name as
+    /// failed. The tracker is flagged as failed overall.
+    pub fn fail(&self, name: &'static str, error: impl Into<String>) {
+        self.terminate(name, Err(error.into()));
+    }
+
+    fn terminate(&self, name: &'static str, outcome: Result<(), String>) {
+        let mut g = self.inner.lock().expect("bootstrap tracker poisoned");
+        if outcome.is_err() {
+            g.failed = true;
+        }
+        // Walk backwards so the most recent running step is matched.
+        if let Some(rec) = g
+            .steps
+            .iter_mut()
+            .rev()
+            .find(|r| r.name == name && r.outcome.is_none())
+        {
+            rec.outcome = Some(outcome);
+            rec.completed_at_wall = Some(Utc::now());
+            rec.completed_at_mono = Some(Instant::now());
+        }
+    }
+
+    /// Finalize the tracker as completed-successfully. Idempotent.
+    pub fn mark_ready(&self) {
+        let mut g = self.inner.lock().expect("bootstrap tracker poisoned");
+        if g.completed {
+            return;
+        }
+        g.completed = true;
+        g.completed_at_wall = Some(Utc::now());
+        g.completed_at_mono = Some(Instant::now());
+    }
+
+    /// True iff [`mark_ready`] has been called and no step failed.
+    pub fn is_completed(&self) -> bool {
+        let g = self.inner.lock().expect("bootstrap tracker poisoned");
+        g.completed && !g.failed
+    }
+
+    /// Deep-copy snapshot for the wire / tests.
+    pub fn snapshot(&self) -> BootstrapStatus {
+        let g = self.inner.lock().expect("bootstrap tracker poisoned");
+        let state = if g.failed {
+            "failed"
+        } else if g.completed {
+            "completed"
+        } else {
+            "running"
+        };
+        let duration_ms = g
+            .completed_at_mono
+            .map(|end| duration_to_ms(end.duration_since(g.started_at_mono)));
+        let steps = g
+            .steps
+            .iter()
+            .map(|r| {
+                let state = match &r.outcome {
+                    None => "running",
+                    Some(Ok(())) => "success",
+                    Some(Err(_)) => "failure",
+                };
+                let duration_ms = r
+                    .completed_at_mono
+                    .map(|end| duration_to_ms(end.duration_since(r.started_at_mono)));
+                let error = match &r.outcome {
+                    Some(Err(msg)) => Some(msg.clone()),
+                    _ => None,
+                };
+                StepStatus {
+                    name: r.name,
+                    state,
+                    started_at: r.started_at_wall,
+                    completed_at: r.completed_at_wall,
+                    duration_ms,
+                    error,
+                }
+            })
+            .collect();
+        BootstrapStatus {
+            state,
+            started_at: g.started_at_wall,
+            completed_at: g.completed_at_wall,
+            duration_ms,
+            steps,
+        }
+    }
+}
+
+fn duration_to_ms(d: Duration) -> u64 {
+    // Saturating: a bootstrap measured in centuries is a bug we don't
+    // want the tracker to panic on.
+    u64::try_from(d.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_tracker_is_running_with_no_steps() {
+        let t = BootstrapTracker::new();
+        let s = t.snapshot();
+        assert_eq!(s.state, "running");
+        assert!(s.steps.is_empty());
+        assert!(s.completed_at.is_none());
+        assert!(s.duration_ms.is_none());
+        assert!(!t.is_completed());
+    }
+
+    #[test]
+    fn begin_complete_records_success() {
+        let t = BootstrapTracker::new();
+        t.begin("database");
+        t.complete("database");
+        let s = t.snapshot();
+        assert_eq!(s.steps.len(), 1);
+        assert_eq!(s.steps[0].name, "database");
+        assert_eq!(s.steps[0].state, "success");
+        assert!(s.steps[0].completed_at.is_some());
+        assert!(s.steps[0].duration_ms.is_some());
+        assert!(s.steps[0].error.is_none());
+    }
+
+    #[test]
+    fn begin_fail_records_failure_and_flags_tracker() {
+        let t = BootstrapTracker::new();
+        t.begin("seed");
+        t.fail("seed", "pg down");
+        let s = t.snapshot();
+        assert_eq!(s.steps[0].state, "failure");
+        assert_eq!(s.steps[0].error.as_deref(), Some("pg down"));
+        // Tracker overall is "failed" even before mark_ready() is called.
+        assert_eq!(s.state, "failed");
+        // And stays failed after mark_ready — the success marker cannot
+        // paper over a failed step.
+        t.mark_ready();
+        assert_eq!(t.snapshot().state, "failed");
+        assert!(!t.is_completed());
+    }
+
+    #[test]
+    fn mark_ready_flips_state_to_completed_only_when_no_failure() {
+        let t = BootstrapTracker::new();
+        t.begin("a");
+        t.complete("a");
+        assert_eq!(t.snapshot().state, "running"); // not yet marked ready
+        t.mark_ready();
+        let s = t.snapshot();
+        assert_eq!(s.state, "completed");
+        assert!(s.completed_at.is_some());
+        assert!(s.duration_ms.is_some());
+        assert!(t.is_completed());
+    }
+
+    #[test]
+    fn mark_ready_is_idempotent() {
+        let t = BootstrapTracker::new();
+        t.mark_ready();
+        let first = t.snapshot().completed_at;
+        t.mark_ready();
+        let second = t.snapshot().completed_at;
+        // Exact equality — second call must not overwrite the timestamp.
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn complete_unknown_step_is_silent_noop() {
+        let t = BootstrapTracker::new();
+        // Must not panic, must not add a phantom record.
+        t.complete("never-started");
+        assert!(t.snapshot().steps.is_empty());
+    }
+
+    #[test]
+    fn complete_of_already_terminated_step_is_noop() {
+        let t = BootstrapTracker::new();
+        t.begin("x");
+        t.complete("x");
+        // A second complete() should not mutate the timestamp.
+        let ts = t.snapshot().steps[0].completed_at;
+        std::thread::sleep(Duration::from_millis(2));
+        t.complete("x");
+        assert_eq!(t.snapshot().steps[0].completed_at, ts);
+    }
+
+    #[test]
+    fn multiple_steps_retain_order_of_insertion() {
+        let t = BootstrapTracker::new();
+        for name in ["a", "b", "c", "d"] {
+            t.begin(name);
+            t.complete(name);
+        }
+        let s = t.snapshot();
+        let names: Vec<&str> = s.steps.iter().map(|r| r.name).collect();
+        assert_eq!(names, vec!["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn overlapping_steps_match_most_recent_unfinished() {
+        // Not that bootstrap() ever nests, but document the rule.
+        let t = BootstrapTracker::new();
+        t.begin("pair");
+        t.begin("pair");
+        t.complete("pair");
+        let s = t.snapshot();
+        assert_eq!(s.steps.len(), 2);
+        // Second (inner) started is the one completed.
+        assert_eq!(s.steps[0].state, "running");
+        assert_eq!(s.steps[1].state, "success");
+    }
+
+    #[test]
+    fn snapshot_is_a_deep_copy_not_a_view() {
+        let t = BootstrapTracker::new();
+        t.begin("x");
+        let snap_before = t.snapshot();
+        t.complete("x");
+        // The earlier snapshot must still show running.
+        assert_eq!(snap_before.steps[0].state, "running");
+        assert_eq!(t.snapshot().steps[0].state, "success");
+    }
+
+    #[test]
+    fn wire_shape_uses_camel_case() {
+        // Dashboards key on camelCase — guard against a rename.
+        let t = BootstrapTracker::new();
+        t.begin("database");
+        t.complete("database");
+        t.mark_ready();
+        let wire = serde_json::to_value(t.snapshot()).unwrap();
+        for key in ["state", "startedAt", "completedAt", "durationMs", "steps"] {
+            assert!(
+                wire.get(key).is_some(),
+                "missing top-level key {key} in {wire}"
+            );
+        }
+        let step = &wire["steps"][0];
+        for key in ["name", "state", "startedAt", "completedAt", "durationMs"] {
+            assert!(step.get(key).is_some(), "missing step key {key} in {step}");
+        }
+    }
+
+    #[test]
+    fn error_is_elided_on_success_and_present_on_failure() {
+        let t = BootstrapTracker::new();
+        t.begin("ok");
+        t.complete("ok");
+        t.begin("bad");
+        t.fail("bad", "boom");
+        let wire = serde_json::to_value(t.snapshot()).unwrap();
+        assert!(wire["steps"][0].get("error").is_none());
+        assert_eq!(wire["steps"][1]["error"], "boom");
+    }
+
+    #[test]
+    fn default_and_new_are_equivalent() {
+        let a = BootstrapTracker::new().snapshot();
+        let b = BootstrapTracker::default().snapshot();
+        assert_eq!(a.state, b.state);
+        assert_eq!(a.steps.len(), b.steps.len());
+    }
+
+    #[test]
+    fn is_completed_is_false_during_running_and_failure_states() {
+        let t = BootstrapTracker::new();
+        assert!(!t.is_completed());
+        t.begin("x");
+        assert!(!t.is_completed());
+        t.fail("x", "nope");
+        assert!(!t.is_completed());
+        t.mark_ready(); // mark_ready after failure does NOT flip to completed
+        assert!(!t.is_completed());
+    }
+}

--- a/cli/src/server/health.rs
+++ b/cli/src/server/health.rs
@@ -531,6 +531,7 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
+            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
         })
     }
 

--- a/cli/src/server/health.rs
+++ b/cli/src/server/health.rs
@@ -531,7 +531,9 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
-            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
+            bootstrap_tracker: std::sync::Arc::new(
+                crate::server::bootstrap_tracker::BootstrapTracker::new(),
+            ),
         })
     }
 

--- a/cli/src/server/knowledge_api.rs
+++ b/cli/src/server/knowledge_api.rs
@@ -1984,7 +1984,9 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
-            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
+            bootstrap_tracker: std::sync::Arc::new(
+                crate::server::bootstrap_tracker::BootstrapTracker::new(),
+            ),
         })))
     }
 
@@ -2574,7 +2576,9 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
-            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
+            bootstrap_tracker: std::sync::Arc::new(
+                crate::server::bootstrap_tracker::BootstrapTracker::new(),
+            ),
         })))
     }
 

--- a/cli/src/server/knowledge_api.rs
+++ b/cli/src/server/knowledge_api.rs
@@ -1984,6 +1984,7 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
+            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
         })))
     }
 
@@ -2573,6 +2574,7 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
+            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
         })))
     }
 

--- a/cli/src/server/lifecycle.rs
+++ b/cli/src/server/lifecycle.rs
@@ -663,6 +663,7 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
+            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
         })
     }
 

--- a/cli/src/server/lifecycle.rs
+++ b/cli/src/server/lifecycle.rs
@@ -663,7 +663,9 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
-            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
+            bootstrap_tracker: std::sync::Arc::new(
+                crate::server::bootstrap_tracker::BootstrapTracker::new(),
+            ),
         })
     }
 

--- a/cli/src/server/mcp_transport.rs
+++ b/cli/src/server/mcp_transport.rs
@@ -380,7 +380,9 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
-            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
+            bootstrap_tracker: std::sync::Arc::new(
+                crate::server::bootstrap_tracker::BootstrapTracker::new(),
+            ),
         });
 
         (server, app_state, tempdir)

--- a/cli/src/server/mcp_transport.rs
+++ b/cli/src/server/mcp_transport.rs
@@ -380,6 +380,7 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
+            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
         });
 
         (server, app_state, tempdir)

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -2,6 +2,8 @@ pub mod admin_sync;
 pub mod auth_middleware;
 pub mod backup_api;
 pub mod bootstrap;
+pub mod bootstrap_api;
+pub mod bootstrap_tracker;
 pub mod context;
 pub mod govern_api;
 pub mod health;
@@ -135,6 +137,12 @@ pub struct AppState {
     /// manager cannot service `SUBSCRIBE`. Consumers wanting Pub/Sub must
     /// reopen a client from this URL.
     pub redis_url: Option<String>,
+    /// Per-pod bootstrap phase tracker (B2 task 6.1). Read by the
+    /// `/api/v1/admin/bootstrap/status` endpoint (see [`bootstrap_api`]).
+    /// Always present — populated by [`bootstrap::bootstrap`] during
+    /// startup and finalized with `mark_ready()` before the listener
+    /// binds.
+    pub bootstrap_tracker: Arc<bootstrap_tracker::BootstrapTracker>,
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/src/server/router.rs
+++ b/cli/src/server/router.rs
@@ -16,9 +16,9 @@ use tower_http::trace::TraceLayer;
 
 use super::auth_middleware::AuthenticationLayer;
 use super::{
-    AppState, admin_sync, backup_api, govern_api, health, knowledge_api, lifecycle_api,
-    mcp_transport, memory_api, org_api, plugin_auth, project_api, role_grants, sessions, sync,
-    team_api, tenant_api, tenant_wiring_api, user_api, webhooks,
+    AppState, admin_sync, backup_api, bootstrap_api, govern_api, health, knowledge_api,
+    lifecycle_api, mcp_transport, memory_api, org_api, plugin_auth, project_api, role_grants,
+    sessions, sync, team_api, tenant_api, tenant_wiring_api, user_api, webhooks,
 };
 
 pub fn build_router(state: Arc<AppState>) -> Router {
@@ -39,6 +39,9 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .merge(sessions::router(state.clone()))
         .merge(webhooks::router(state.clone()))
         .merge(admin_sync::router(state.clone()))
+        // B2 task 6.1: PA-only bootstrap introspection. Returns the
+        // per-pod phase log captured during startup.
+        .merge(bootstrap_api::router(state.clone()))
         // B2 task 5.5: PA-only wiring status endpoints. Mounted
         // alongside admin_sync so the /admin/tenants/... namespace
         // stays contiguous in the router.

--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -4896,7 +4896,9 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
-            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
+            bootstrap_tracker: std::sync::Arc::new(
+                crate::server::bootstrap_tracker::BootstrapTracker::new(),
+            ),
         });
 
         Some((router(state), tenant))

--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -4896,6 +4896,7 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
+            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
         });
 
         Some((router(state), tenant))

--- a/cli/src/server/webhooks.rs
+++ b/cli/src/server/webhooks.rs
@@ -800,7 +800,9 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
-            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
+            bootstrap_tracker: std::sync::Arc::new(
+                crate::server::bootstrap_tracker::BootstrapTracker::new(),
+            ),
         })
     }
 

--- a/cli/src/server/webhooks.rs
+++ b/cli/src/server/webhooks.rs
@@ -800,6 +800,7 @@ mod tests {
             tenant_runtime_state: std::sync::Arc::new(
                 crate::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
+            bootstrap_tracker: std::sync::Arc::new(crate::server::bootstrap_tracker::BootstrapTracker::new()),
         })
     }
 

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -358,7 +358,9 @@ async fn test_app_state_with_plugin_auth(
             tenant_runtime_state: std::sync::Arc::new(
                 aeterna::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
-            bootstrap_tracker: std::sync::Arc::new(aeterna::server::bootstrap_tracker::BootstrapTracker::new()),
+            bootstrap_tracker: std::sync::Arc::new(
+                aeterna::server::bootstrap_tracker::BootstrapTracker::new(),
+            ),
         }),
         tempdir,
     ))

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -358,6 +358,7 @@ async fn test_app_state_with_plugin_auth(
             tenant_runtime_state: std::sync::Arc::new(
                 aeterna::server::tenant_runtime_state::TenantRuntimeRegistry::new(),
             ),
+            bootstrap_tracker: std::sync::Arc::new(aeterna::server::bootstrap_tracker::BootstrapTracker::new()),
         }),
         tempdir,
     ))

--- a/openspec/changes/harden-tenant-provisioning/tasks.md
+++ b/openspec/changes/harden-tenant-provisioning/tasks.md
@@ -47,10 +47,10 @@
 
 ### 6. First-run bootstrap hardening
 
-- [ ] 6.1 Refactor `bootstrap.rs` to run idempotently; add `GET /api/v1/admin/bootstrap/status` returning per-step status.
-- [ ] 6.2 Gate `/ready` on bootstrap completion (in concert with 5.3).
-- [ ] 6.3 Structured error on failure; `/ready` stays 503; retry on pod restart.
-- [ ] 6.4 Emit `BootstrapCompleted` governance event on success.
+- [x] 6.1 Add `BootstrapTracker` (cli/src/server/bootstrap_tracker.rs) + `GET /api/v1/admin/bootstrap/status` (PA-gated, cli/src/server/bootstrap_api.rs). `bootstrap()` instruments 6 phases — `env_and_config`, `database`, `knowledge_git`, `memory_and_providers`, `sync_and_protocols`, `redis_and_auth_stores`, `assemble_state` — and finalizes with `mark_ready()` before returning `AppState`. 14 unit tests cover wire shape, redaction, idempotency, and failure semantics. Idempotency of the underlying seed helpers (e.g. `seed_platform_admin`) is pre-existing (`ON CONFLICT DO NOTHING`) — no refactor required for the tracker to report truthfully.
+- [x] 6.2 Structurally satisfied by current architecture: `bootstrap()` runs synchronously in `serve::run` **before** the HTTP listener binds, so no request can observe a mid-bootstrap state. A failing bootstrap exits the process → kubelet restart → 503 on the Service (no listener at all). `BootstrapTracker::is_completed()` is provided as a future-proofing seam for async-post-bind bootstrap refactors (see module docs in `bootstrap_tracker.rs`).
+- [x] 6.3 Structurally satisfied (same reasoning as 6.2). Upstream errors from seed_* / postgres.initialize_schema propagate through `?` and crash the pod; the kubelet retry IS the restart path the task describes. Follow-up 6.4 will surface them as governance events.
+- [ ] 6.4 Emit `BootstrapCompleted` governance event on success (follow-up; tracker snapshot is the exact payload).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a per-pod bootstrap phase tracker and a PA-gated introspection endpoint so operators can answer **why** a pod took N seconds to boot, and **which phase** an already-crashed pod failed in — without hunting through log tails.

Closes **§6.1** of `openspec/changes/harden-tenant-provisioning`. Documents **§6.2** and **§6.3** as structurally satisfied by the current architecture (see *Design notes* below). **§6.4** deferred as a follow-up.

## What changed

- `cli/src/server/bootstrap_tracker.rs` — thread-safe append-only phase log with `begin` / `complete` / `fail` / `mark_ready` / `snapshot` / `is_completed`. `'static` step names, camelCase wire shape, error redacted on success. **14 unit tests.**
- `cli/src/server/bootstrap_api.rs` — `GET /api/v1/admin/bootstrap/status`, PA-gated (matches `admin_sync` precedent since payloads can contain upstream error detail).
- `cli/src/server/bootstrap.rs` — instruments 7 phases: `env_and_config`, `database`, `knowledge_git`, `memory_and_providers`, `sync_and_protocols`, `redis_and_auth_stores`, `assemble_state`. Finalized with `mark_ready()` before returning `AppState`.
- `AppState.bootstrap_tracker: Arc<BootstrapTracker>` + 8 test-scope constructors updated via perl one-liner.
- Route registered in `router.rs` alongside other admin endpoints.
- `tasks.md`: 6.1/6.2/6.3 checked with rationale; 6.4 left open.

## Design notes — why 6.2 & 6.3 are structurally satisfied

`bootstrap()` runs **synchronously** in `serve::run` before the HTTP listener binds. Consequences:

- **6.2 (gate /ready on bootstrap completion)** — no request can observe a mid-bootstrap state because no listener exists yet. `/ready` returning 200 is already proof bootstrap completed.
- **6.3 (structured error → /ready stays 503 → retry on pod restart)** — a bootstrap error propagates via `?`, the process exits, kubelet restarts the pod, the Service returns 503 in the meantime. That IS the retry path the task describes.

`BootstrapTracker::is_completed()` is provided as a forward-compat seam in case bootstrap is ever refactored to run async-post-bind (e.g. for faster cold-start when config can be reloaded live). Until then it returns `true` by the time any request is possible.

## Wire contract

```json
GET /api/v1/admin/bootstrap/status   (PlatformAdmin only)

{
  "state": "completed",
  "startedAt": "2026-04-21T18:30:00Z",
  "completedAt": "2026-04-21T18:30:04.312Z",
  "durationMs": 4312,
  "steps": [
    {
      "name": "database",
      "state": "success",
      "startedAt": "...",
      "completedAt": "...",
      "durationMs": 1204
    }
  ]
}
```

On failure, top-level `state` becomes `"failed"` and the failing step carries `"error": "<message>"`. Success steps omit the `error` field (`skip_serializing_if = "Option::is_none"`).

## Out of scope

- **Cluster-wide aggregation** — explicitly per-pod. Prometheus scrapes are the right tool for fleet views; ops hit individual pods via port-forward for boot-regression investigation.
- **Idempotency refactor of seed helpers** — `seed_platform_admin` et al. already use `ON CONFLICT DO NOTHING`; no refactor needed for the tracker to report truthfully.
- **BootstrapCompleted governance event (6.4)** — deferred. The tracker snapshot is the exact payload the event will carry; lift-and-shift when plumbing is ready.

## Verification

- `cargo test -p aeterna --lib bootstrap_tracker` — 14/14 ✅
- `cargo test -p aeterna --lib` — 726/726 ✅
- `cargo clippy -p aeterna --tests --no-deps -- -D warnings` — clean ✅
- `cargo fmt -p aeterna -- --check` — clean ✅

## Files touched

- **New:** `cli/src/server/bootstrap_tracker.rs` (+422), `cli/src/server/bootstrap_api.rs` (+65)
- **Modified:** `cli/src/server/{bootstrap,mod,router,admin_sync,health,knowledge_api,lifecycle,mcp_transport,tenant_api,webhooks}.rs`, `cli/tests/server_runtime_test.rs`, `openspec/changes/harden-tenant-provisioning/tasks.md`