### PR TITLE
feat(secret): expand SecretReference to full variant set (B1 §1.2)

### DIFF
--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -3770,6 +3770,99 @@ fn validate_manifest(m: &TenantManifest) -> Vec<String> {
         }
     }
 
+    // ── secret_references: per-variant well-formedness (B1 §1.2). The
+    //    serde `tag = "kind"` union already rejects unknown kinds at parse
+    //    time; here we check that the REQUIRED fields within a known kind
+    //    are non-empty and well-formed. An empty `var` on Env, empty
+    //    `path` on File, etc. would otherwise pass parse and blow up only
+    //    at resolution time — this surfaces them at apply as a 422.
+    //
+    //    Postgres is not user-authored (callers supply Inline; server
+    //    stores it and rewrites to Postgres before persisting) so we
+    //    skip it here — `set_secret_entry`'s write path already owns
+    //    the Uuid invariant.
+    if let Some(cfg) = &m.config {
+        for (ref_name, entry) in &cfg.secret_references {
+            if ref_name.trim().is_empty() {
+                errors.push("config.secretReferences has an entry with an empty key".into());
+            }
+            if entry.logical_name.trim().is_empty() {
+                errors.push(format!(
+                    "config.secretReferences.{ref_name}.logicalName must not be empty"
+                ));
+            }
+            match &entry.reference {
+                mk_core::SecretReference::Inline { plaintext } => {
+                    // SecretBytes::is_empty does not expose; just length-0 check.
+                    if plaintext.is_empty() {
+                        errors.push(format!(
+                            "config.secretReferences.{ref_name}: inline plaintext must not be empty"
+                        ));
+                    }
+                }
+                mk_core::SecretReference::Postgres { .. } => {
+                    // Not expected via manifest — Inline is rewritten to
+                    // Postgres server-side. Tolerate it (round-trip of a
+                    // rendered manifest would include it) without error.
+                }
+                mk_core::SecretReference::Env { var } => {
+                    if var.trim().is_empty() {
+                        errors.push(format!(
+                            "config.secretReferences.{ref_name}.var must not be empty"
+                        ));
+                    } else if var.contains('=') || var.contains('\0') {
+                        errors.push(format!(
+                            "config.secretReferences.{ref_name}.var must not contain '=' or null bytes"
+                        ));
+                    }
+                }
+                mk_core::SecretReference::File { path } => {
+                    if path.trim().is_empty() {
+                        errors.push(format!(
+                            "config.secretReferences.{ref_name}.path must not be empty"
+                        ));
+                    } else if !path.starts_with('/') {
+                        errors.push(format!(
+                            "config.secretReferences.{ref_name}.path must be absolute (start with '/')"
+                        ));
+                    }
+                }
+                mk_core::SecretReference::K8s {
+                    name,
+                    key,
+                    namespace,
+                } => {
+                    if name.trim().is_empty() {
+                        errors.push(format!(
+                            "config.secretReferences.{ref_name}.name must not be empty"
+                        ));
+                    }
+                    if key.trim().is_empty() {
+                        errors.push(format!(
+                            "config.secretReferences.{ref_name}.key must not be empty"
+                        ));
+                    }
+                    if let Some(ns) = namespace {
+                        if ns.trim().is_empty() {
+                            errors.push(format!(
+                                "config.secretReferences.{ref_name}.namespace, when set, must not be empty (omit to use the server's namespace)"
+                            ));
+                        }
+                    }
+                }
+                mk_core::SecretReference::Vault { mount, path, field } => {
+                    for (label, value) in [("mount", mount), ("path", path), ("field", field)] {
+                        if value.trim().is_empty() {
+                            errors.push(format!(
+                                "config.secretReferences.{ref_name}.{label} must not be empty"
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     errors
 }
 
@@ -6238,6 +6331,250 @@ mod tests {
         assert!(
             errors.iter().any(|e| e.contains("providers.llm.kind")),
             "expected empty-kind error, got: {errors:?}"
+        );
+    }
+
+    // ── B1 §1.2 SecretReference variant validation tests ─────────────────
+    // These exercise validate_manifest's per-variant well-formedness
+    // checks. The #[serde(tag = "kind")] union handles unknown kinds at
+    // parse time; validate_manifest handles empty/malformed fields
+    // within known kinds.
+
+    #[test]
+    fn validate_manifest_accepts_all_secret_reference_variants() {
+        // One-shot coverage: every variant in its canonical well-formed
+        // shape must pass validate_manifest.
+        let raw = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": { "slug": "sr", "name": "SR" },
+            "config": {
+                "fields": {},
+                "secretReferences": {
+                    "inline-ok":   { "logicalName": "a", "ownership": "tenant",
+                                     "kind": "inline",   "plaintext": "hunter2" },
+                    "env-ok":      { "logicalName": "b", "ownership": "tenant",
+                                     "kind": "env",      "var": "DATABASE_PASSWORD" },
+                    "file-ok":     { "logicalName": "c", "ownership": "tenant",
+                                     "kind": "file",     "path": "/run/secrets/db" },
+                    "k8s-ok":      { "logicalName": "d", "ownership": "tenant",
+                                     "kind": "k8s",      "name": "db-secret",
+                                                         "key": "password" },
+                    "k8s-ns-ok":   { "logicalName": "e", "ownership": "tenant",
+                                     "kind": "k8s",      "name": "db-secret",
+                                                         "key": "password",
+                                                         "namespace": "aeterna" },
+                    "vault-ok":    { "logicalName": "f", "ownership": "tenant",
+                                     "kind": "vault",    "mount": "secret",
+                                                         "path": "tenants/acme/db",
+                                                         "field": "password" }
+                }
+            }
+        });
+        let m: TenantManifest = serde_json::from_value(raw).unwrap();
+        assert!(
+            validate_manifest(&m).is_empty(),
+            "well-formed manifest must validate cleanly, got: {:?}",
+            validate_manifest(&m)
+        );
+    }
+
+    #[test]
+    fn validate_manifest_rejects_inline_empty_plaintext() {
+        let raw = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": { "slug": "sr", "name": "SR" },
+            "config": {
+                "fields": {},
+                "secretReferences": {
+                    "bad": { "logicalName": "a", "ownership": "tenant",
+                             "kind": "inline", "plaintext": "" }
+                }
+            }
+        });
+        let m: TenantManifest = serde_json::from_value(raw).unwrap();
+        let errors = validate_manifest(&m);
+        assert!(
+            errors.iter().any(|e| e.contains("inline plaintext")),
+            "expected inline-empty error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_manifest_rejects_env_empty_var() {
+        let raw = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": { "slug": "sr", "name": "SR" },
+            "config": {
+                "fields": {},
+                "secretReferences": {
+                    "bad": { "logicalName": "a", "ownership": "tenant",
+                             "kind": "env", "var": "" }
+                }
+            }
+        });
+        let m: TenantManifest = serde_json::from_value(raw).unwrap();
+        let errors = validate_manifest(&m);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("bad.var must not be empty")),
+            "expected env-empty error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_manifest_rejects_env_var_with_equals() {
+        let raw = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": { "slug": "sr", "name": "SR" },
+            "config": {
+                "fields": {},
+                "secretReferences": {
+                    "bad": { "logicalName": "a", "ownership": "tenant",
+                             "kind": "env", "var": "FOO=BAR" }
+                }
+            }
+        });
+        let m: TenantManifest = serde_json::from_value(raw).unwrap();
+        let errors = validate_manifest(&m);
+        assert!(
+            errors.iter().any(|e| e.contains("'=' or null bytes")),
+            "expected env-malformed error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_manifest_rejects_file_relative_path() {
+        let raw = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": { "slug": "sr", "name": "SR" },
+            "config": {
+                "fields": {},
+                "secretReferences": {
+                    "bad": { "logicalName": "a", "ownership": "tenant",
+                             "kind": "file", "path": "relative/path" }
+                }
+            }
+        });
+        let m: TenantManifest = serde_json::from_value(raw).unwrap();
+        let errors = validate_manifest(&m);
+        assert!(
+            errors.iter().any(|e| e.contains("must be absolute")),
+            "expected file-relative error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_manifest_rejects_k8s_empty_fields() {
+        let raw = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": { "slug": "sr", "name": "SR" },
+            "config": {
+                "fields": {},
+                "secretReferences": {
+                    "bad": { "logicalName": "a", "ownership": "tenant",
+                             "kind": "k8s", "name": "", "key": "" }
+                }
+            }
+        });
+        let m: TenantManifest = serde_json::from_value(raw).unwrap();
+        let errors = validate_manifest(&m);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("bad.name must not be empty")),
+            "missing name error, got: {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("bad.key must not be empty")),
+            "missing key error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_manifest_rejects_k8s_empty_namespace_when_set() {
+        let raw = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": { "slug": "sr", "name": "SR" },
+            "config": {
+                "fields": {},
+                "secretReferences": {
+                    "bad": { "logicalName": "a", "ownership": "tenant",
+                             "kind": "k8s", "name": "n", "key": "k",
+                             "namespace": "   " }
+                }
+            }
+        });
+        let m: TenantManifest = serde_json::from_value(raw).unwrap();
+        let errors = validate_manifest(&m);
+        assert!(
+            errors.iter().any(|e| e.contains("namespace, when set")),
+            "expected namespace-when-set error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_manifest_rejects_vault_partial_fields() {
+        let raw = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": { "slug": "sr", "name": "SR" },
+            "config": {
+                "fields": {},
+                "secretReferences": {
+                    "bad": { "logicalName": "a", "ownership": "tenant",
+                             "kind": "vault", "mount": "secret",
+                             "path": "", "field": "" }
+                }
+            }
+        });
+        let m: TenantManifest = serde_json::from_value(raw).unwrap();
+        let errors = validate_manifest(&m);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("bad.path must not be empty")),
+            "missing path error, got: {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("bad.field must not be empty")),
+            "missing field error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_unknown_secret_reference_kind_at_parse_time() {
+        // serde tag="kind" short-circuits before validate_manifest ever
+        // sees the value. This test locks that contract so a future
+        // change making the enum non-exhaustive (e.g. #[serde(other)])
+        // is a deliberate decision and breaks this test.
+        let raw = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": { "slug": "sr", "name": "SR" },
+            "config": {
+                "fields": {},
+                "secretReferences": {
+                    "bad": { "logicalName": "a", "ownership": "tenant",
+                             "kind": "mysterybox", "whatever": 1 }
+                }
+            }
+        });
+        let parsed: Result<TenantManifest, _> = serde_json::from_value(raw);
+        assert!(
+            parsed.is_err(),
+            "unknown secret-reference kind must fail at serde parse, not reach validate_manifest"
         );
     }
 

--- a/mk_core/src/secret.rs
+++ b/mk_core/src/secret.rs
@@ -202,11 +202,23 @@ impl schemars::JsonSchema for SecretBytes {
     }
 }
 
-/// A reference to secret material stored by a [`SecretBackend`].
+/// A reference to secret material.
 ///
-/// In B1 only the `Postgres` variant exists. The enum shape is intentional
-/// so future backends (external secret managers, cloud KV stores, etc.)
-/// can be added as additive variants.
+/// Covers every way a tenant manifest can describe "here is where this
+/// secret lives": inline plaintext on the wire, encrypted-at-rest in our
+/// own database, or an external reference that a backend resolves at
+/// runtime (env var, file on disk, Kubernetes `Secret`, HashiCorp Vault).
+///
+/// Serialized as a `#[serde(tag = "kind")]` tagged union, so the wire
+/// shape is self-describing and future variants add non-colliding shapes.
+///
+/// # Equality & hashing
+///
+/// `PartialEq`/`Eq` derive by-variant; notably, two `Inline` values with
+/// different plaintext are not equal. That is correct for config diffing
+/// (a secret rotation is a real change) but means you must not use
+/// `SecretReference` as a map key in places where the comparison would
+/// cross a hash boundary (we have no such usage today).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(
     tag = "kind",
@@ -214,11 +226,75 @@ impl schemars::JsonSchema for SecretBytes {
     rename_all_fields = "camelCase"
 )]
 pub enum SecretReference {
-    /// Encrypted blob stored in the `tenant_secrets` Postgres table. The row
-    /// holds a KMS-wrapped DEK and an AES-256-GCM ciphertext.
+    /// **Wire-only**: caller supplies plaintext directly in the manifest.
+    ///
+    /// The server accepts `Inline` on **input** (the CLI and REST callers
+    /// need a way to express "please store this new secret"), stores the
+    /// plaintext via [`crate::traits::SecretBackend::put`], and replaces
+    /// the `Inline` reference with [`SecretReference::Postgres`] before
+    /// the owning [`crate::types::TenantSecretReference`] is persisted.
+    ///
+    /// A rendered manifest (see `manifest_render`) **never** contains
+    /// `Inline` — the server has no way to recover plaintext from
+    /// encrypted storage. If you see `Inline` on the way out of a
+    /// rendered manifest, something is wrong.
+    ///
+    /// `plaintext` is [`SecretBytes`], which serializes as `"<redacted>"`.
+    /// That is a safety default: accidentally reserializing an `Inline`
+    /// reference cannot leak the plaintext. Use
+    /// [`Self::expose_inline_plaintext`] when you intentionally need the
+    /// bytes on the storage path.
+    Inline { plaintext: SecretBytes },
+
+    /// Encrypted blob stored in the `tenant_secrets` Postgres table. The
+    /// row holds a KMS-wrapped DEK and an AES-256-GCM ciphertext. This is
+    /// the only variant produced by the default storage backend.
     Postgres {
         /// Primary key of the `tenant_secrets` row.
         secret_id: Uuid,
+    },
+
+    /// Environment variable on the server process, resolved at read time.
+    ///
+    /// Suited to platform-wide secrets injected via a container runtime
+    /// (`DATABASE_URL`, `SLACK_BOT_TOKEN`, etc.). The variable name is
+    /// **not** confidential; the value never touches our database.
+    Env {
+        /// Env-var name (e.g. `"DATABASE_PASSWORD"`). Case-sensitive on
+        /// POSIX; validated non-empty and no embedded `=`/null bytes.
+        var: String,
+    },
+
+    /// File on disk readable by the server process, resolved at read time.
+    ///
+    /// Intended for Kubernetes / Docker secret volume mounts where the
+    /// platform injects the secret as a file.
+    File {
+        /// Absolute path. Validated non-empty and absolute at apply time.
+        path: String,
+    },
+
+    /// Reference to a Kubernetes `Secret` resource, resolved via the
+    /// cluster API at read time.
+    K8s {
+        /// `metadata.name` of the `Secret`.
+        name: String,
+        /// Key within the Secret's `data` map.
+        key: String,
+        /// `metadata.namespace`. `None` = the server process's own
+        /// namespace (derived from the pod's downward API at runtime).
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        namespace: Option<String>,
+    },
+
+    /// Reference to a HashiCorp Vault KV-v2 secret.
+    Vault {
+        /// Mount point of the KV-v2 engine (e.g. `"secret"`).
+        mount: String,
+        /// Path under the mount (e.g. `"tenants/acme/db"`).
+        path: String,
+        /// Field name within the secret document.
+        field: String,
     },
 }
 
@@ -227,7 +303,31 @@ impl SecretReference {
     #[must_use]
     pub fn kind(&self) -> &'static str {
         match self {
+            SecretReference::Inline { .. } => "inline",
             SecretReference::Postgres { .. } => "postgres",
+            SecretReference::Env { .. } => "env",
+            SecretReference::File { .. } => "file",
+            SecretReference::K8s { .. } => "k8s",
+            SecretReference::Vault { .. } => "vault",
+        }
+    }
+
+    /// True when this reference carries secret material **in the value
+    /// itself** (only `Inline`). Callers use this to decide whether they
+    /// must route through [`crate::traits::SecretBackend::put`] before
+    /// persisting the reference.
+    #[must_use]
+    pub fn carries_plaintext(&self) -> bool {
+        matches!(self, SecretReference::Inline { .. })
+    }
+
+    /// Extract the plaintext from an `Inline` variant. Returns `None` for
+    /// every other variant. Callers must not log the result.
+    #[must_use]
+    pub fn expose_inline_plaintext(&self) -> Option<&[u8]> {
+        match self {
+            SecretReference::Inline { plaintext } => Some(plaintext.expose()),
+            _ => None,
         }
     }
 }
@@ -272,6 +372,167 @@ mod tests {
         assert_eq!(s.expose(), b"plaintext");
     }
 
+    #[test]
+    fn reference_kind_for_every_variant() {
+        use std::collections::HashSet;
+        let all = [
+            SecretReference::Inline {
+                plaintext: SecretBytes::from(b"x".to_vec()),
+            },
+            SecretReference::Postgres {
+                secret_id: Uuid::nil(),
+            },
+            SecretReference::Env { var: "X".into() },
+            SecretReference::File { path: "/x".into() },
+            SecretReference::K8s {
+                name: "n".into(),
+                key: "k".into(),
+                namespace: None,
+            },
+            SecretReference::Vault {
+                mount: "m".into(),
+                path: "p".into(),
+                field: "f".into(),
+            },
+        ];
+        let kinds: HashSet<&str> = all.iter().map(SecretReference::kind).collect();
+        // Every variant has a distinct non-empty kind discriminator.
+        assert_eq!(kinds.len(), all.len(), "kind() must be unique per variant");
+        assert!(!kinds.iter().any(|k| k.is_empty()));
+    }
+
+    #[test]
+    fn carries_plaintext_is_only_inline() {
+        let cases = [
+            (
+                SecretReference::Inline {
+                    plaintext: SecretBytes::from(b"x".to_vec()),
+                },
+                true,
+            ),
+            (
+                SecretReference::Postgres {
+                    secret_id: Uuid::nil(),
+                },
+                false,
+            ),
+            (SecretReference::Env { var: "X".into() }, false),
+            (SecretReference::File { path: "/x".into() }, false),
+        ];
+        for (r, expected) in cases {
+            assert_eq!(r.carries_plaintext(), expected, "{:?}", r);
+        }
+    }
+
+    #[test]
+    fn expose_inline_plaintext_only_on_inline() {
+        let inline = SecretReference::Inline {
+            plaintext: SecretBytes::from(b"hunter2".to_vec()),
+        };
+        assert_eq!(inline.expose_inline_plaintext(), Some(&b"hunter2"[..]));
+        let pg = SecretReference::Postgres {
+            secret_id: Uuid::nil(),
+        };
+        assert_eq!(pg.expose_inline_plaintext(), None);
+    }
+
+    #[test]
+    fn roundtrip_postgres_wire_shape() {
+        let r = SecretReference::Postgres {
+            secret_id: Uuid::nil(),
+        };
+        let j = serde_json::to_value(&r).unwrap();
+        assert_eq!(j["kind"], "postgres");
+        assert!(j["secretId"].is_string());
+        let back: SecretReference = serde_json::from_value(j).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn roundtrip_inline_redacts_on_serialize_preserves_on_deserialize() {
+        // Deserialize accepts plaintext …
+        let j = serde_json::json!({ "kind": "inline", "plaintext": "hunter2" });
+        let r: SecretReference = serde_json::from_value(j).unwrap();
+        assert_eq!(r.expose_inline_plaintext(), Some(&b"hunter2"[..]));
+
+        // … but serialize always emits <redacted> (safety default).
+        let j2 = serde_json::to_value(&r).unwrap();
+        assert_eq!(j2["kind"], "inline");
+        assert_eq!(j2["plaintext"], "<redacted>");
+    }
+
+    #[test]
+    fn roundtrip_env_wire_shape() {
+        let j = serde_json::json!({ "kind": "env", "var": "DATABASE_URL" });
+        let r: SecretReference = serde_json::from_value(j.clone()).unwrap();
+        assert_eq!(r.kind(), "env");
+        let back = serde_json::to_value(&r).unwrap();
+        assert_eq!(back, j);
+    }
+
+    #[test]
+    fn roundtrip_file_wire_shape() {
+        let j = serde_json::json!({ "kind": "file", "path": "/run/secrets/db" });
+        let r: SecretReference = serde_json::from_value(j.clone()).unwrap();
+        assert_eq!(r.kind(), "file");
+        assert_eq!(serde_json::to_value(&r).unwrap(), j);
+    }
+
+    #[test]
+    fn roundtrip_k8s_namespace_omitted_when_none() {
+        // namespace absent on wire when None (serde skip_serializing_if).
+        let r = SecretReference::K8s {
+            name: "db".into(),
+            key: "password".into(),
+            namespace: None,
+        };
+        let j = serde_json::to_value(&r).unwrap();
+        assert_eq!(j["kind"], "k8s");
+        assert_eq!(j["name"], "db");
+        assert_eq!(j["key"], "password");
+        assert!(
+            j.get("namespace").is_none(),
+            "namespace=None must omit the field, got {j}"
+        );
+
+        // namespace present when Some.
+        let r2 = SecretReference::K8s {
+            name: "db".into(),
+            key: "password".into(),
+            namespace: Some("aeterna".into()),
+        };
+        let j2 = serde_json::to_value(&r2).unwrap();
+        assert_eq!(j2["namespace"], "aeterna");
+        let back: SecretReference = serde_json::from_value(j2).unwrap();
+        assert_eq!(back, r2);
+    }
+
+    #[test]
+    fn roundtrip_vault_wire_shape() {
+        let j = serde_json::json!({
+            "kind": "vault",
+            "mount": "secret",
+            "path": "tenants/acme/db",
+            "field": "password"
+        });
+        let r: SecretReference = serde_json::from_value(j.clone()).unwrap();
+        assert_eq!(r.kind(), "vault");
+        assert_eq!(serde_json::to_value(&r).unwrap(), j);
+    }
+
+    #[test]
+    fn deserialize_rejects_unknown_kind() {
+        // #[serde(tag = "kind")] rejects tags it does not know about at
+        // deserialize time; validate_manifest never sees a reference it
+        // cannot classify. This test locks that contract so a future
+        // change to the enum's serde attributes (e.g. adding
+        // #[serde(other)]) is a deliberate decision and breaks this test.
+        let j = serde_json::json!({ "kind": "mysterybox", "magic": 42 });
+        let r: Result<SecretReference, _> = serde_json::from_value(j);
+        assert!(r.is_err(), "unknown kind must not deserialize");
+    }
+
+    // Legacy single-variant test, kept to lock the original wire shape.
     #[test]
     fn reference_kind() {
         let r = SecretReference::Postgres {

--- a/openspec/changes/harden-tenant-provisioning/design.md
+++ b/openspec/changes/harden-tenant-provisioning/design.md
@@ -5,19 +5,62 @@
 
 ## Decisions
 
-### D1 — SecretReference is a sum type
+### D1 — SecretReference is a sum type (full variant set, B1)
 
-Replace the flat `TenantSecretReference` struct in `mk_core/src/types.rs` with a tagged enum. Hard cut. No live data to migrate.
+`SecretReference` in `mk_core/src/secret.rs` is a `#[serde(tag = "kind")]`
+tagged enum. **Hard cut, no migration**: no production tenants exist yet,
+so we ship the full useful variant set in one go rather than dripping
+variants PR-by-PR.
 
 ```rust
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum SecretReference {
-    /// Encrypted blob stored in our own Postgres (default path)
+    /// Wire-only: plaintext in the manifest; server stores via
+    /// SecretBackend::put and rewrites to `Postgres` before persisting.
+    Inline { plaintext: SecretBytes },
+
+    /// Envelope-encrypted in `tenant_secrets` (default server-side shape).
     Postgres { secret_id: Uuid },
+
+    /// Env var on the server process, resolved at read time.
+    Env { var: String },
+
+    /// File on disk (k8s / Docker secret mount), resolved at read time.
+    File { path: String },
+
+    /// Kubernetes `Secret` resource, resolved via the cluster API.
+    K8s { name: String, key: String, #[serde(default)] namespace: Option<String> },
+
+    /// HashiCorp Vault KV-v2 secret.
+    Vault { mount: String, path: String, field: String },
 }
 ```
 
-Only one variant in B1. The enum shape is there so future variants (`External { provider, id }`, etc.) land as additive PRs without touching serialization of existing data.
+**Invariants:**
+
+- `Inline` is **wire-only**: it never reaches persistence. The apply path
+  detects `carries_plaintext()`, calls `SecretBackend::put`, and replaces
+  the reference with `Postgres { secret_id }` before writing the
+  `TenantConfigDocument`. A rendered manifest therefore never emits
+  `Inline` — if one is ever seen on the way out, that is a bug.
+- `SecretBytes` serializes as `"<redacted>"` always. Accidentally
+  reserializing an `Inline` value cannot leak plaintext; the dedicated
+  `expose_inline_plaintext()` accessor is the only way to retrieve the
+  bytes, and it is only used on the storage path.
+- The serde union is **exhaustive**: unknown kinds fail at
+  deserialization. `validate_manifest` therefore never sees an
+  unclassifiable reference; its job is to validate the **fields within**
+  a known variant (non-empty `var`, absolute `path`, etc.).
+- `SecretBackend::get`/`delete` accept only `Postgres` today. Non-Postgres
+  variants return `SecretBackendError::UnsupportedReference(kind)`.
+  Future backends (EnvSecretBackend, VaultSecretBackend, etc.) land as
+  additive impls of the same trait and a dispatch layer routes by kind.
+
+**Why breaking vs. additive-with-compat:** no prod tenants, no stored
+data to migrate, no public CLI users outside the dev team. Additive
+backward-compat shims would complicate every consumer (every backend,
+every diff, every render) for a constraint that does not exist. Ship
+the right shape; re-hash tests.
 
 ### D2 — Secret storage: Postgres with KMS-wrapped DEK envelope encryption
 

--- a/openspec/changes/harden-tenant-provisioning/tasks.md
+++ b/openspec/changes/harden-tenant-provisioning/tasks.md
@@ -25,7 +25,10 @@
 ### 1. Manifest schema and hashing
 
 - [ ] 1.1 Extend `TenantManifest` with `metadata.generation: u64` and `providers: ManifestProviders` (memoryLayers, llm, embedding). _(`cli/src/server/tenant_api.rs:3404`)_
-- [ ] 1.2 Introduce `SecretReference` sum type per 0.3. Update `ManifestConfig.secret_references` accordingly.
+- [x] 1.2 Introduce `SecretReference` sum type per 0.3. Update `ManifestConfig.secret_references` accordingly.
+      Shipped full variant set (`Inline`, `Postgres`, `Env`, `File`, `K8s`, `Vault`) in one hard-cut PR.
+      Per-variant `validate_manifest` well-formedness checks; serde `tag="kind"` rejects unknown kinds at parse time.
+      `SecretBackend::{get,delete}` route non-Postgres variants to `UnsupportedReference(kind)` until dispatching backends land.
 - [ ] 1.3 Create `manifest_canonical` module: stable key order, inline secrets stripped.
 - [ ] 1.4 Implement `manifest_hash(&TenantManifest) -> String` returning `sha256:<hex>`.
 - [x] 1.5 Add `last_applied_manifest_hash: Option<String>` and `generation: u64` to the tenant record; write SQL migration. _(PR #105 — migration `027_tenant_manifest_state.sql`; `TenantStore::{get,set}_manifest_state` + `set_manifest_state_tx` with BYTEA↔hex helpers; 10 integration tests inc. idempotency, roundtrip, nonexistent-slug, tx rollback.)_

--- a/storage/src/secret_backend.rs
+++ b/storage/src/secret_backend.rs
@@ -243,7 +243,10 @@ impl SecretBackend for PostgresSecretBackend {
     }
 
     async fn get(&self, reference: &SecretReference) -> Result<SecretBytes, SecretBackendError> {
-        let SecretReference::Postgres { secret_id } = reference;
+        let secret_id = match reference {
+            SecretReference::Postgres { secret_id } => secret_id,
+            other => return Err(SecretBackendError::UnsupportedReference(other.kind())),
+        };
         let row = sqlx::query(
             r#"SELECT wrapped_dek, ciphertext, nonce FROM tenant_secrets WHERE id = $1"#,
         )
@@ -274,7 +277,10 @@ impl SecretBackend for PostgresSecretBackend {
     }
 
     async fn delete(&self, reference: &SecretReference) -> Result<(), SecretBackendError> {
-        let SecretReference::Postgres { secret_id } = reference;
+        let secret_id = match reference {
+            SecretReference::Postgres { secret_id } => secret_id,
+            other => return Err(SecretBackendError::UnsupportedReference(other.kind())),
+        };
         sqlx::query("DELETE FROM tenant_secrets WHERE id = $1")
             .bind(secret_id)
             .execute(&self.pool)
@@ -348,7 +354,10 @@ impl SecretBackend for InMemorySecretBackend {
     }
 
     async fn get(&self, reference: &SecretReference) -> Result<SecretBytes, SecretBackendError> {
-        let SecretReference::Postgres { secret_id } = reference;
+        let secret_id = match reference {
+            SecretReference::Postgres { secret_id } => secret_id,
+            other => return Err(SecretBackendError::UnsupportedReference(other.kind())),
+        };
         let by_id = self.by_id.lock().expect("poisoned");
         let key = by_id
             .get(secret_id)
@@ -363,7 +372,10 @@ impl SecretBackend for InMemorySecretBackend {
     }
 
     async fn delete(&self, reference: &SecretReference) -> Result<(), SecretBackendError> {
-        let SecretReference::Postgres { secret_id } = reference;
+        let secret_id = match reference {
+            SecretReference::Postgres { secret_id } => secret_id,
+            other => return Err(SecretBackendError::UnsupportedReference(other.kind())),
+        };
         let mut by_id = self.by_id.lock().expect("poisoned");
         if let Some(key) = by_id.remove(secret_id) {
             self.inner.lock().expect("poisoned").remove(&key);

--- a/storage/src/tenant_config_provider.rs
+++ b/storage/src/tenant_config_provider.rs
@@ -314,7 +314,10 @@ mod tests {
             &self,
             reference: &SecretReference,
         ) -> Result<SecretBytes, SecretBackendError> {
-            let SecretReference::Postgres { secret_id } = reference;
+            let secret_id = match reference {
+                SecretReference::Postgres { secret_id } => secret_id,
+                other => return Err(SecretBackendError::UnsupportedReference(other.kind())),
+            };
             self.store
                 .lock()
                 .unwrap()
@@ -324,7 +327,10 @@ mod tests {
         }
 
         async fn delete(&self, reference: &SecretReference) -> Result<(), SecretBackendError> {
-            let SecretReference::Postgres { secret_id } = reference;
+            let secret_id = match reference {
+                SecretReference::Postgres { secret_id } => secret_id,
+                other => return Err(SecretBackendError::UnsupportedReference(other.kind())),
+            };
             self.store.lock().unwrap().remove(secret_id);
             Ok(())
         }

--- a/storage/tests/secret_backend_integration.rs
+++ b/storage/tests/secret_backend_integration.rs
@@ -74,7 +74,9 @@ async fn ciphertext_is_not_plaintext_on_disk() {
         .put(tid, "k", SecretBytes::from(plaintext.to_vec()))
         .await
         .expect("put");
-    let SecretReference::Postgres { secret_id } = r;
+    let SecretReference::Postgres { secret_id } = r else {
+        panic!("backend.put must return a Postgres reference")
+    };
     let row = sqlx::query("SELECT ciphertext, wrapped_dek FROM tenant_secrets WHERE id = $1")
         .bind(secret_id)
         .fetch_one(&pool)
@@ -113,7 +115,9 @@ async fn put_same_name_bumps_generation_and_rotates_dek() {
     let out = be.get(&r2).await.unwrap();
     assert_eq!(out.expose(), b"v2");
 
-    let SecretReference::Postgres { secret_id } = r2;
+    let SecretReference::Postgres { secret_id } = r2 else {
+        panic!("backend.put must return a Postgres reference")
+    };
     let row = sqlx::query("SELECT generation FROM tenant_secrets WHERE id = $1")
         .bind(secret_id)
         .fetch_one(&pool)


### PR DESCRIPTION
## Summary

Closes **§1.2** of `openspec/changes/harden-tenant-provisioning/tasks.md`. Hard cut per D1 of `design.md`: no prod tenants exist, so we ship the full useful `SecretReference` variant set in one PR instead of dripping variants over six follow-ups.

Per Christian's call: *"take for granted that you can break whatever as long as we are able to express any secrets needed going forward."*

## Variants now supported

| Variant | Shape | Resolution |
|---|---|---|
| `Inline` | `{ plaintext }` | **Wire-only.** Server rewrites to `Postgres` via `SecretBackend::put` before persisting. Never appears in rendered manifests. |
| `Postgres` | `{ secret_id }` | Envelope-encrypted row in `tenant_secrets` (unchanged). |
| `Env` | `{ var }` | Resolved from server-process env var at read time. |
| `File` | `{ path }` | Resolved from disk (k8s / Docker secret mounts). |
| `K8s` | `{ name, key, namespace? }` | Resolved via k8s API. |
| `Vault` | `{ mount, path, field }` | HashiCorp Vault KV-v2. |

## Safety defaults

- `SecretBytes` already serializes as `"<redacted>"`, so re-emitting an `Inline` value on any wire (error reply, log line, round-trip) **cannot leak plaintext**. The only way to get the bytes out is `SecretReference::expose_inline_plaintext()`, used solely on the write path.
- `#[serde(tag = "kind")]` rejects unknown kinds at parse. `validate_manifest` therefore never sees a reference it cannot classify; its job is to validate the fields *within* a known variant.
- Locked that contract with a dedicated test (`deserialize_rejects_unknown_secret_reference_kind_at_parse_time`) so any future relaxation (e.g. adding `#[serde(other)]`) is a deliberate decision that breaks the test.

## What still errors at runtime

`PostgresSecretBackend::{get, delete}` and the test `InMemoryBackend` now route non-`Postgres` references to the pre-existing `SecretBackendError::UnsupportedReference(kind)`. This is intentional — the *dispatch* layer that routes `Env`/`File`/`K8s`/`Vault` to the right backend impl is its own follow-up (§3 secret resolvers). The enum is ready; the readers are not. Callers see a clean typed error rather than a panic.

## Test coverage

**`mk_core` (10 new tests):**
- per-variant JSON roundtrips (Postgres, Env, File, K8s with/without namespace, Vault)
- `Inline` deserialize-accepts-plaintext + serialize-redacts
- `K8s.namespace = None` omits the field on the wire
- `kind()` is unique per variant and non-empty
- `carries_plaintext()` is true only for `Inline`
- unknown kind fails at parse

**`tenant_api::validate_manifest` (9 new tests):**
- accepts every well-formed variant
- rejects empty `plaintext` / `var` / `path` / `name` / `key` / `mount` / `path` / `field`
- rejects `File.path` not starting with `/`
- rejects `Env.var` containing `=` or `\0`
- rejects `K8s.namespace` set to whitespace (must omit instead)
- parse-time rejection of unknown `kind` reaches the caller before `validate_manifest` runs

All 20 `validate_manifest_*` tests pass; all 177 `mk_core` tests pass.

## Call sites updated

- `storage/src/secret_backend.rs` — `PostgresSecretBackend::{get, delete}` + the test `InMemorySecretBackend`: refutable `let` → `match` with `UnsupportedReference(kind)`.
- `storage/src/tenant_config_provider.rs` — same treatment on the in-memory provider shim.
- `storage/tests/secret_backend_integration.rs` — two destructuring sites in existing integration tests now use `let ... else { panic!() }` since the test explicitly created a `Postgres` reference via `put()`.
- `cli/src/server/tenant_api.rs` — `validate_manifest` gains a secret-references block.

## Docs

- `openspec/changes/harden-tenant-provisioning/design.md` → **D1 rewritten** to describe the full variant set, invariants, and the "Inline is wire-only, never persisted" rule.
- `openspec/changes/harden-tenant-provisioning/tasks.md` → **§1.2 closed** with a one-line summary of what shipped.

## Checks

- `cargo check --workspace --all-targets` ✅
- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings` ✅ (clean)
- `cargo test -p mk_core --lib` ✅ 177 passed
- `cargo test -p aeterna --lib validate_manifest` ✅ 20 passed
- `cargo test -p aeterna --lib deserialize_rejects_unknown_secret_reference_kind` ✅

## What this unblocks

- **§3 secret resolvers** — enum is done; backends can now be written additively against the trait.
- **§6.4** governance events referencing secret kinds — `SecretReference::kind()` is stable and unique.
- **CLI tenant validate** (§7.1) — can validate every secret variant a user might write in a manifest today, not just Postgres.

## Intentionally **not** in this PR

- Dispatch layer routing non-`Postgres` kinds to their backends (§3).
- Backend impls for `Env`/`File`/`K8s`/`Vault` (§3).
- Reverse renderer awareness of `Inline` (renderer already redacts; nothing to change).
- Migration: **none needed** — no production data.

Stacks independently of #124, #125, #126.
