### PR TITLE
fix(opal): end views schism and tenant-scope fetcher endpoints (#130)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5423,6 +5423,7 @@ dependencies = [
  "sqlx 0.9.0-alpha.1",
  "storage",
  "tempfile",
+ "testing",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",

--- a/idp-sync/src/github.rs
+++ b/idp-sync/src/github.rs
@@ -630,95 +630,31 @@ pub async fn initialize_github_sync_schema(pool: &PgPool) -> IdpSyncResult<()> {
     Ok(())
 }
 
+/// Initializes OPAL views that are NOT owned by the storage migration tree.
+///
+/// # History
+///
+/// Up to PR #129 this function also defined `v_hierarchy` and
+/// `v_user_permissions` against the legacy `organizational_units` table
+/// (with UUIDs synthesized via `uuid_generate_v5`). Those definitions
+/// raced migration `009_organizational_referential.sql` /
+/// `028_tenant_scoped_hierarchy.sql` via `CREATE OR REPLACE VIEW` —
+/// whichever ran last won, and any `aeterna admin sync github` call
+/// silently reverted the migration's tenant-scoped definition and
+/// pointed the view at synthesized UUIDs that didn't match the real
+/// `companies.id` values.
+///
+/// That race is resolved by PR #130: the migration is now the single
+/// canonical definer of `v_hierarchy` and `v_user_permissions`. This
+/// function retains ownership of views whose definitions are still
+/// idp-sync-specific:
+///
+/// - `v_agent_permissions` — joined across `agents` + `users`; no
+///   migration owns this yet. Tracked for relocation in #130.
+/// - `v_code_search_repositories` / `v_code_search_requests` /
+///   `v_code_search_identities` — empty-result stubs held here until
+///   the Code Search schema lands in its own migration.
 async fn initialize_opal_views(pool: &PgPool) -> IdpSyncResult<()> {
-    sqlx::query(
-        r"
-        CREATE OR REPLACE VIEW v_hierarchy AS
-        WITH RECURSIVE unit_tree AS (
-            SELECT
-                id,
-                name,
-                type,
-                slug,
-                parent_id,
-                tenant_id,
-                metadata,
-                id AS root_id
-            FROM organizational_units
-            WHERE type = 'company'
-
-            UNION ALL
-
-            SELECT
-                ou.id,
-                ou.name,
-                ou.type,
-                ou.slug,
-                ou.parent_id,
-                ou.tenant_id,
-                ou.metadata,
-                ut.root_id
-            FROM organizational_units ou
-            JOIN unit_tree ut ON ou.parent_id = ut.id
-        )
-        SELECT
-            uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8'::UUID, c.id) AS company_id,
-            c.slug AS company_slug,
-            c.name AS company_name,
-            CASE WHEN o.id IS NOT NULL THEN uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8'::UUID, o.id) END AS org_id,
-            o.slug AS org_slug,
-            o.name AS org_name,
-            CASE WHEN t.id IS NOT NULL THEN uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8'::UUID, t.id) END AS team_id,
-            t.slug AS team_slug,
-            t.name AS team_name,
-            CASE WHEN p.id IS NOT NULL THEN uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8'::UUID, p.id) END AS project_id,
-            p.slug AS project_slug,
-            p.name AS project_name,
-            p.metadata->>'git_remote' AS git_remote
-        FROM unit_tree c
-        LEFT JOIN unit_tree o ON o.parent_id = c.id AND o.type = 'organization'
-        LEFT JOIN unit_tree t ON t.parent_id = o.id AND t.type = 'team'
-        LEFT JOIN unit_tree p ON p.parent_id = t.id AND p.type = 'project'
-        WHERE c.type = 'company'
-        ",
-    )
-    .execute(pool)
-    .await
-    .map_err(IdpSyncError::DatabaseError)?;
-
-    sqlx::query(
-        r"
-        CREATE OR REPLACE VIEW v_user_permissions AS
-        SELECT
-            u.id AS user_id,
-            u.email,
-            u.display_name AS user_name,
-            CASE WHEN u.is_active THEN 'active' ELSE 'inactive' END AS user_status,
-            uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8'::UUID, team_ou.id) AS team_id,
-            COALESCE(gr.role, m.role) AS role,
-            COALESCE(gr_permissions.permissions, '[]'::JSONB) AS permissions,
-            uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8'::UUID, org_ou.id) AS org_id,
-            uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8'::UUID, company_ou.id) AS company_id,
-            company_ou.slug AS company_slug,
-            org_ou.slug AS org_slug,
-            team_ou.slug AS team_slug
-        FROM users u
-        JOIN memberships m ON m.user_id = u.id
-        JOIN organizational_units team_ou ON team_ou.id = m.team_id::TEXT
-        LEFT JOIN organizational_units org_ou ON org_ou.id = team_ou.parent_id AND org_ou.type IN ('organization', 'company')
-        LEFT JOIN organizational_units company_ou ON company_ou.id = org_ou.parent_id AND company_ou.type = 'company'
-        LEFT JOIN governance_roles gr ON gr.principal_id = u.id AND gr.principal_type = 'user'
-            AND gr.team_id = uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8'::UUID, team_ou.id)
-            AND gr.revoked_at IS NULL
-        LEFT JOIN LATERAL (
-            SELECT '[]'::JSONB AS permissions
-        ) gr_permissions ON TRUE
-        ",
-    )
-    .execute(pool)
-    .await
-    .map_err(IdpSyncError::DatabaseError)?;
-
     sqlx::query(
         r"
         CREATE OR REPLACE VIEW v_agent_permissions AS

--- a/opal-fetcher/Cargo.toml
+++ b/opal-fetcher/Cargo.toml
@@ -56,6 +56,7 @@ cedar-policy = { workspace = true }
 tempfile = { workspace = true }
 wiremock = { workspace = true }
 tokio-test = "0.4"
+testing = { workspace = true }
 
 [lints]
 workspace = true

--- a/opal-fetcher/src/entities.rs
+++ b/opal-fetcher/src/entities.rs
@@ -17,8 +17,13 @@ use crate::error::Result;
 // ============================================================================
 
 /// Row from the `v_hierarchy` view.
+///
+/// `tenant_id` is surfaced by migration `028_tenant_scoped_hierarchy.sql`
+/// as the first column of the view. Handlers MUST filter by this column
+/// before returning rows to OPAL — see `handlers::get_hierarchy`.
 #[derive(Debug, Clone, FromRow)]
 pub struct HierarchyRow {
+    pub tenant_id: Uuid,
     pub company_id: Option<Uuid>,
     pub company_slug: Option<String>,
     pub company_name: Option<String>,
@@ -35,8 +40,13 @@ pub struct HierarchyRow {
 }
 
 /// Row from the `v_user_permissions` view.
+///
+/// `tenant_id` is surfaced by migration `028_tenant_scoped_hierarchy.sql`
+/// as the first column of the view. Handlers MUST filter by this column
+/// before returning rows to OPAL — see `handlers::get_users`.
 #[derive(Debug, Clone, FromRow)]
 pub struct UserPermissionRow {
+    pub tenant_id: Uuid,
     pub user_id: Uuid,
     pub email: String,
     pub user_name: Option<String>,
@@ -528,6 +538,7 @@ mod tests {
 
     fn sample_user_row() -> UserPermissionRow {
         UserPermissionRow {
+            tenant_id: Uuid::new_v4(),
             user_id: Uuid::new_v4(),
             email: "alice@acme.com".to_string(),
             user_name: Some("Alice".to_string()),
@@ -545,6 +556,7 @@ mod tests {
 
     fn sample_hierarchy_row() -> HierarchyRow {
         HierarchyRow {
+            tenant_id: Uuid::new_v4(),
             company_id: Some(Uuid::new_v4()),
             company_slug: Some("acme-corp".to_string()),
             company_name: Some("Acme Corporation".to_string()),

--- a/opal-fetcher/src/handlers.rs
+++ b/opal-fetcher/src/handlers.rs
@@ -1,8 +1,14 @@
 //! HTTP request handlers for the OPAL Data Fetcher.
 
-use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
-use serde::Serialize;
+use axum::{
+    Json,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use uuid::Uuid;
 
 use crate::entities::{
     AgentPermissionRow, CedarEntitiesResponse, HierarchyRow, ProjectTeamAssignmentRow,
@@ -11,6 +17,18 @@ use crate::entities::{
 };
 use crate::error::Result;
 use crate::state::AppState;
+
+/// Query parameters carrying the tenant context for a fetcher request.
+///
+/// Every entity-returning endpoint requires a `tenant` UUID. Returning the
+/// globally-merged entity set would leak cross-tenant identifiers into the
+/// OPAL → Cedar pipeline and evaluate policies against mismatched
+/// principals (see issue #130). OPAL's data-source client is configured
+/// per-tenant; the tenant parameter is the wire expression of that scope.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TenantQuery {
+    pub tenant: Uuid,
+}
 
 /// Health check response.
 #[derive(Debug, Serialize)]
@@ -66,18 +84,31 @@ opal_fetcher_up 1
     (StatusCode::OK, metrics)
 }
 
-/// GET /v1/hierarchy
+/// GET /v1/hierarchy?tenant=<uuid>
 ///
 /// Returns the organizational hierarchy (Company → Organization → Team →
-/// Project) as Cedar entities for OPAL consumption.
+/// Project) as Cedar entities for OPAL consumption, scoped to a single
+/// tenant. The `tenant` query parameter is **required** — missing it
+/// returns 400 via `serde_urlencoded` deserialization failure, surfaced
+/// by axum's `Query` extractor.
+///
+/// Isolation contract: rows are filtered by `v_hierarchy.tenant_id = $1`
+/// (column exposed by migration `028_tenant_scoped_hierarchy.sql`) and
+/// `project_team_assignments.tenant_id = $1`. Cross-tenant rows are
+/// never returned even if a tenant UUID is guessed correctly for a
+/// different tenant's data — the filter is authoritative at the SQL
+/// layer, not at a policy layer downstream.
 pub async fn get_hierarchy(
     State(state): State<Arc<AppState>>,
+    Query(params): Query<TenantQuery>,
 ) -> Result<Json<CedarEntitiesResponse>> {
-    tracing::debug!("Fetching organizational hierarchy");
+    let tenant_id = params.tenant;
+    tracing::debug!(%tenant_id, "Fetching organizational hierarchy");
 
     let rows: Vec<HierarchyRow> = sqlx::query_as(
         r"
         SELECT
+            tenant_id,
             company_id,
             company_slug,
             company_name,
@@ -92,21 +123,25 @@ pub async fn get_hierarchy(
             project_name,
             git_remote
         FROM v_hierarchy
+        WHERE tenant_id = $1
         ",
     )
+    .bind(tenant_id)
     .fetch_all(&state.pool)
     .await?;
 
     let count = rows.len();
-    tracing::debug!(row_count = count, "Fetched hierarchy rows");
+    tracing::debug!(%tenant_id, row_count = count, "Fetched hierarchy rows");
 
     let mut entities = transform_hierarchy(rows)?;
     let assignment_rows: Vec<ProjectTeamAssignmentRow> = sqlx::query_as(
         r"
         SELECT project_id, team_id, tenant_id, assignment_type
         FROM project_team_assignments
+        WHERE tenant_id = $1::TEXT
         ",
     )
+    .bind(tenant_id.to_string())
     .fetch_all(&state.pool)
     .await?;
     let assignments = collect_project_team_assignments(assignment_rows);
@@ -115,6 +150,7 @@ pub async fn get_hierarchy(
     let response = CedarEntitiesResponse::new(entities);
 
     tracing::info!(
+        %tenant_id,
         entity_count = response.count,
         "Returning hierarchy entities"
     );
@@ -122,15 +158,24 @@ pub async fn get_hierarchy(
     Ok(Json(response))
 }
 
-/// GET /v1/users
+/// GET /v1/users?tenant=<uuid>
 ///
-/// Returns users with their team memberships and roles as Cedar entities.
-pub async fn get_users(State(state): State<Arc<AppState>>) -> Result<Json<CedarEntitiesResponse>> {
-    tracing::debug!("Fetching user permissions");
+/// Returns users with their team memberships and roles as Cedar entities,
+/// scoped to a single tenant. The `tenant` query parameter is **required**.
+///
+/// Isolation contract: rows are filtered by `v_user_permissions.tenant_id
+/// = $1` (column exposed by migration `028_tenant_scoped_hierarchy.sql`).
+pub async fn get_users(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<TenantQuery>,
+) -> Result<Json<CedarEntitiesResponse>> {
+    let tenant_id = params.tenant;
+    tracing::debug!(%tenant_id, "Fetching user permissions");
 
     let rows: Vec<UserPermissionRow> = sqlx::query_as(
         r"
         SELECT
+            tenant_id,
             user_id,
             email,
             user_name,
@@ -144,30 +189,58 @@ pub async fn get_users(State(state): State<Arc<AppState>>) -> Result<Json<CedarE
             org_slug,
             team_slug
         FROM v_user_permissions
+        WHERE tenant_id = $1
         ",
     )
+    .bind(tenant_id)
     .fetch_all(&state.pool)
     .await?;
 
     let count = rows.len();
-    tracing::debug!(row_count = count, "Fetched user permission rows");
+    tracing::debug!(%tenant_id, row_count = count, "Fetched user permission rows");
 
     let role_entities = transform_roles(&rows);
     let mut entities = transform_users(rows)?;
     entities.extend(role_entities);
     let response = CedarEntitiesResponse::new(entities);
 
-    tracing::info!(entity_count = response.count, "Returning user entities");
+    tracing::info!(
+        %tenant_id,
+        entity_count = response.count,
+        "Returning user entities"
+    );
 
     Ok(Json(response))
 }
 
-/// GET /v1/agents
+/// GET /v1/agents?tenant=<uuid>
 ///
 /// Returns agents with their delegation chains and capabilities as Cedar
 /// entities.
-pub async fn get_agents(State(state): State<Arc<AppState>>) -> Result<Json<CedarEntitiesResponse>> {
-    tracing::debug!("Fetching agent permissions");
+///
+/// # ⚠️ Known gap — tracked in issue #130 / follow-up
+///
+/// The `agents` table (migration `009_organizational_referential.sql`)
+/// has NO `tenant_id` column today. An agent's tenant is only knowable
+/// transitively via `agents.allowed_company_ids → companies.tenant_id`,
+/// and that set can in principle span multiple tenants. This handler
+/// therefore **requires** a `tenant` query param to match the contract
+/// of its siblings (so OPAL can be configured uniformly across all
+/// fetcher endpoints) but the current implementation still returns the
+/// full agent set and emits a WARN. The follow-up work to this PR adds
+/// `agents.tenant_id` + backfill + a filtered `v_agent_permissions`
+/// view; at that point this handler becomes a SQL-layer filter like
+/// `get_hierarchy` / `get_users` above and the WARN is removed.
+pub async fn get_agents(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<TenantQuery>,
+) -> Result<Json<CedarEntitiesResponse>> {
+    let tenant_id = params.tenant;
+    tracing::warn!(
+        %tenant_id,
+        "agent-permissions endpoint currently returns cross-tenant rows; \
+         tenant filtering pending agents.tenant_id schema work (see #130)"
+    );
 
     let rows: Vec<AgentPermissionRow> = sqlx::query_as(
         r"
@@ -193,49 +266,94 @@ pub async fn get_agents(State(state): State<Arc<AppState>>) -> Result<Json<Cedar
     .await?;
 
     let count = rows.len();
-    tracing::debug!(row_count = count, "Fetched agent permission rows");
+    tracing::debug!(
+        %tenant_id,
+        row_count = count,
+        "Fetched agent permission rows (unfiltered — see handler docs)"
+    );
 
     let entities = transform_agents(rows)?;
     let response = CedarEntitiesResponse::new(entities);
 
-    tracing::info!(entity_count = response.count, "Returning agent entities");
+    tracing::info!(
+        %tenant_id,
+        entity_count = response.count,
+        "Returning agent entities (unfiltered — see handler docs)"
+    );
 
     Ok(Json(response))
 }
 
-/// GET /v1/all
+/// GET /v1/all?tenant=<uuid>
 ///
-/// Returns all entities (hierarchy, users, agents, and Code Search) in a single response.
-/// Useful for initial full sync.
+/// Returns all entities (hierarchy, users, agents, and Code Search) in a
+/// single response, scoped to a single tenant. Useful for initial full
+/// sync of one tenant's OPAL data-source. The `tenant` query parameter
+/// is **required**.
+///
+/// Tenant-filtering applied: hierarchy, users, code-search repositories
+/// / requests / identities, and project-team assignments. Agents are
+/// NOT filtered — see `get_agents` docstring for the tracked gap.
 pub async fn get_all_entities(
     State(state): State<Arc<AppState>>,
+    Query(params): Query<TenantQuery>,
 ) -> Result<Json<CedarEntitiesResponse>> {
-    tracing::debug!("Fetching all entities");
+    let tenant_id = params.tenant;
+    let tenant_text = tenant_id.to_string();
+    tracing::debug!(%tenant_id, "Fetching all entities (tenant-scoped)");
 
     // Fetch all entity types in parallel
-    let (hierarchy_rows, user_rows, agent_rows, assignment_rows, codesearch_repo_rows, codesearch_req_rows, codesearch_id_rows) = tokio::try_join!(
+    let (
+        hierarchy_rows,
+        user_rows,
+        agent_rows,
+        assignment_rows,
+        codesearch_repo_rows,
+        codesearch_req_rows,
+        codesearch_id_rows,
+    ) = tokio::try_join!(
         sqlx::query_as::<_, HierarchyRow>(
-            r"SELECT company_id, company_slug, company_name, org_id, org_slug, org_name, team_id, team_slug, team_name, project_id, project_slug, project_name, git_remote FROM v_hierarchy"
-        ).fetch_all(&state.pool),
+            r"SELECT tenant_id, company_id, company_slug, company_name, org_id, org_slug, org_name, team_id, team_slug, team_name, project_id, project_slug, project_name, git_remote FROM v_hierarchy WHERE tenant_id = $1"
+        )
+        .bind(tenant_id)
+        .fetch_all(&state.pool),
         sqlx::query_as::<_, UserPermissionRow>(
-            r"SELECT user_id, email, user_name, user_status, team_id, role, permissions, org_id, company_id, company_slug, org_slug, team_slug FROM v_user_permissions"
-        ).fetch_all(&state.pool),
+            r"SELECT tenant_id, user_id, email, user_name, user_status, team_id, role, permissions, org_id, company_id, company_slug, org_slug, team_slug FROM v_user_permissions WHERE tenant_id = $1"
+        )
+        .bind(tenant_id)
+        .fetch_all(&state.pool),
+        // NOTE: agents unfiltered — tracked in #130, see get_agents docstring.
         sqlx::query_as::<_, AgentPermissionRow>(
             r"SELECT agent_id, agent_name, agent_type, delegated_by_user_id, delegated_by_agent_id, delegation_depth, capabilities, allowed_company_ids, allowed_org_ids, allowed_team_ids, allowed_project_ids, agent_status, delegating_user_email, delegating_user_name FROM v_agent_permissions"
-        ).fetch_all(&state.pool),
+        )
+        .fetch_all(&state.pool),
         sqlx::query_as::<_, ProjectTeamAssignmentRow>(
-            r"SELECT project_id, team_id, tenant_id, assignment_type FROM project_team_assignments"
-        ).fetch_all(&state.pool),
+            r"SELECT project_id, team_id, tenant_id, assignment_type FROM project_team_assignments WHERE tenant_id = $1"
+        )
+        .bind(&tenant_text)
+        .fetch_all(&state.pool),
         sqlx::query_as::<_, crate::entities::CodeSearchRepositoryRow>(
-            r"SELECT id, tenant_id, name, status, sync_strategy, current_branch FROM v_code_search_repositories"
-        ).fetch_all(&state.pool),
+            r"SELECT id, tenant_id, name, status, sync_strategy, current_branch FROM v_code_search_repositories WHERE tenant_id = $1"
+        )
+        .bind(&tenant_text)
+        .fetch_all(&state.pool),
         sqlx::query_as::<_, crate::entities::CodeSearchRequestRow>(
-            r"SELECT id, repository_id, requester_id, status, tenant_id FROM v_code_search_requests"
-        ).fetch_all(&state.pool),
+            r"SELECT id, repository_id, requester_id, status, tenant_id FROM v_code_search_requests WHERE tenant_id = $1"
+        )
+        .bind(&tenant_text)
+        .fetch_all(&state.pool),
         sqlx::query_as::<_, crate::entities::CodeSearchIdentityRow>(
-            r"SELECT id, tenant_id, name, provider FROM v_code_search_identities"
-        ).fetch_all(&state.pool),
+            r"SELECT id, tenant_id, name, provider FROM v_code_search_identities WHERE tenant_id = $1"
+        )
+        .bind(&tenant_text)
+        .fetch_all(&state.pool),
     )?;
+
+    tracing::warn!(
+        %tenant_id,
+        agent_row_count = agent_rows.len(),
+        "agent rows returned unfiltered — tenant filtering pending (#130)"
+    );
 
     // Transform all entities
     let mut all_entities = transform_hierarchy(hierarchy_rows)?;
@@ -260,8 +378,9 @@ pub async fn get_all_entities(
     let response = CedarEntitiesResponse::new(all_entities);
 
     tracing::info!(
+        %tenant_id,
         entity_count = response.count,
-        "Returning all entities (including Code Search)"
+        "Returning all entities (tenant-scoped, excluding agents)"
     );
 
     Ok(Json(response))

--- a/opal-fetcher/tests/tenant_isolation_test.rs
+++ b/opal-fetcher/tests/tenant_isolation_test.rs
@@ -1,0 +1,269 @@
+//! Tenant-isolation contract tests for the opal-fetcher SQL layer.
+//!
+//! Validates the invariant PR #130 establishes: every entity-returning
+//! handler filters rows by `tenant_id = $1` at the SQL layer, not at a
+//! policy layer downstream. This test exercises the EXACT SQL the
+//! handlers issue (`opal-fetcher/src/handlers.rs`) against a live
+//! Postgres fixture seeded with two distinct tenants and asserts zero
+//! cross-tenant leakage.
+//!
+//! Covered invariants:
+//!
+//!   1. `v_hierarchy WHERE tenant_id = A` returns only tenant A's rows,
+//!      even when tenant B has a company with the identical slug
+//!      (post-028 uniqueness is per-tenant).
+//!   2. `v_user_permissions WHERE tenant_id = A` returns only tenant
+//!      A's user/role/team rows.
+//!   3. `project_team_assignments WHERE tenant_id = A` isolates per-
+//!      tenant assignments.
+//!   4. An unknown tenant UUID returns the empty set (no fallthrough
+//!      to a default/global set).
+//!
+//! Out of scope (tracked as follow-up to #130):
+//!
+//!   - Agent-permissions isolation. The `agents` table has no
+//!     `tenant_id` column today; see `handlers::get_agents` docstring.
+//!
+//! Docker-gated; no-op with stderr notice when Docker is unavailable,
+//! matching `storage/tests/migration_028_tenant_scoped_hierarchy_test.rs`.
+
+use sqlx::Row;
+use sqlx::postgres::PgPoolOptions;
+use storage::migrations::apply_all;
+use storage::postgres::PostgresBackend;
+use testing::postgres;
+use uuid::Uuid;
+
+async fn seed_tenant(pool: &sqlx::PgPool, slug_prefix: &str) -> (Uuid, Uuid) {
+    let tenant_id = Uuid::new_v4();
+    let tenant_slug = format!("{slug_prefix}-tenant");
+
+    sqlx::query(
+        "INSERT INTO tenants (id, slug, name, status, source_owner)
+         VALUES ($1, $2, $2, 'active', 'test')",
+    )
+    .bind(tenant_id)
+    .bind(&tenant_slug)
+    .execute(pool)
+    .await
+    .expect("insert tenant");
+
+    // Same bare slug across tenants on purpose: exercises the
+    // (tenant_id, slug) uniqueness from migration 028.
+    let company_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO companies (id, tenant_id, slug, name)
+         VALUES ($1, $2, 'acme', 'Acme')",
+    )
+    .bind(company_id)
+    .bind(tenant_id)
+    .execute(pool)
+    .await
+    .expect("insert company");
+
+    let org_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO organizations (id, company_id, slug, name)
+         VALUES ($1, $2, 'platform', 'Platform')",
+    )
+    .bind(org_id)
+    .bind(company_id)
+    .execute(pool)
+    .await
+    .expect("insert organization");
+
+    let team_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO teams (id, org_id, slug, name)
+         VALUES ($1, $2, 'api', 'API')",
+    )
+    .bind(team_id)
+    .bind(org_id)
+    .execute(pool)
+    .await
+    .expect("insert team");
+
+    let user_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO users (id, email, name, status)
+         VALUES ($1, $2, $3, 'active')",
+    )
+    .bind(user_id)
+    .bind(format!("alice+{slug_prefix}@acme.com"))
+    .bind(format!("Alice-{slug_prefix}"))
+    .execute(pool)
+    .await
+    .expect("insert user");
+
+    sqlx::query(
+        "INSERT INTO memberships (user_id, team_id, role, permissions, status)
+         VALUES ($1, $2, 'developer', '[]'::jsonb, 'active')",
+    )
+    .bind(user_id)
+    .bind(team_id)
+    .execute(pool)
+    .await
+    .expect("insert membership");
+
+    (tenant_id, team_id)
+}
+
+async fn fresh_pool() -> Option<sqlx::PgPool> {
+    let pg = postgres().await?;
+    let pool = PgPoolOptions::new()
+        .max_connections(3)
+        .connect(pg.url())
+        .await
+        .expect("pool connect");
+    let backend = PostgresBackend::new(pg.url())
+        .await
+        .expect("backend connect");
+    backend
+        .initialize_schema()
+        .await
+        .expect("initialize_schema");
+    apply_all(&pool).await.expect("apply_all");
+    // Hold the fixture alive by leaking it; test processes are short-lived
+    // and the PgEmbed-style harness cleans up on drop at process exit.
+    Box::leak(Box::new(pg));
+    Some(pool)
+}
+
+#[tokio::test]
+async fn v_hierarchy_tenant_filter_isolates_cross_tenant_rows() {
+    let Some(pool) = fresh_pool().await else {
+        eprintln!("Skipping opal-fetcher tenant isolation test: Docker unavailable");
+        return;
+    };
+
+    let (tenant_a, _) = seed_tenant(&pool, "alpha").await;
+    let (tenant_b, _) = seed_tenant(&pool, "beta").await;
+
+    let rows_a: Vec<(Uuid, Option<String>)> =
+        sqlx::query_as("SELECT tenant_id, company_slug FROM v_hierarchy WHERE tenant_id = $1")
+            .bind(tenant_a)
+            .fetch_all(&pool)
+            .await
+            .expect("query tenant A");
+
+    let rows_b: Vec<(Uuid, Option<String>)> =
+        sqlx::query_as("SELECT tenant_id, company_slug FROM v_hierarchy WHERE tenant_id = $1")
+            .bind(tenant_b)
+            .fetch_all(&pool)
+            .await
+            .expect("query tenant B");
+
+    assert!(!rows_a.is_empty(), "tenant A should see its own rows");
+    assert!(!rows_b.is_empty(), "tenant B should see its own rows");
+    assert!(
+        rows_a.iter().all(|(t, _)| *t == tenant_a),
+        "tenant A query returned cross-tenant rows: {rows_a:?}",
+    );
+    assert!(
+        rows_b.iter().all(|(t, _)| *t == tenant_b),
+        "tenant B query returned cross-tenant rows: {rows_b:?}",
+    );
+    assert!(rows_a.iter().any(|(_, s)| s.as_deref() == Some("acme")));
+    assert!(rows_b.iter().any(|(_, s)| s.as_deref() == Some("acme")));
+}
+
+#[tokio::test]
+async fn v_user_permissions_tenant_filter_isolates_cross_tenant_rows() {
+    let Some(pool) = fresh_pool().await else {
+        eprintln!("Skipping opal-fetcher tenant isolation test: Docker unavailable");
+        return;
+    };
+
+    let (tenant_a, _) = seed_tenant(&pool, "gamma").await;
+    let (tenant_b, _) = seed_tenant(&pool, "delta").await;
+
+    let emails_a: Vec<(Uuid, String)> =
+        sqlx::query_as("SELECT tenant_id, email FROM v_user_permissions WHERE tenant_id = $1")
+            .bind(tenant_a)
+            .fetch_all(&pool)
+            .await
+            .expect("query tenant A users");
+
+    let emails_b: Vec<(Uuid, String)> =
+        sqlx::query_as("SELECT tenant_id, email FROM v_user_permissions WHERE tenant_id = $1")
+            .bind(tenant_b)
+            .fetch_all(&pool)
+            .await
+            .expect("query tenant B users");
+
+    assert!(!emails_a.is_empty());
+    assert!(!emails_b.is_empty());
+    assert!(emails_a.iter().all(|(t, _)| *t == tenant_a));
+    assert!(emails_b.iter().all(|(t, _)| *t == tenant_b));
+    assert!(emails_a.iter().any(|(_, e)| e.contains("+gamma@")));
+    assert!(emails_b.iter().any(|(_, e)| e.contains("+delta@")));
+    assert!(emails_a.iter().all(|(_, e)| !e.contains("+delta@")));
+    assert!(emails_b.iter().all(|(_, e)| !e.contains("+gamma@")));
+}
+
+#[tokio::test]
+async fn project_team_assignments_tenant_filter_isolates_cross_tenant_rows() {
+    let Some(pool) = fresh_pool().await else {
+        eprintln!("Skipping opal-fetcher tenant isolation test: Docker unavailable");
+        return;
+    };
+
+    let (tenant_a, team_a) = seed_tenant(&pool, "epsilon").await;
+    let (tenant_b, team_b) = seed_tenant(&pool, "zeta").await;
+
+    sqlx::query(
+        "INSERT INTO project_team_assignments (project_id, team_id, tenant_id, assignment_type)
+         VALUES ($1, $2, $3, 'primary')",
+    )
+    .bind("proj-a")
+    .bind(team_a.to_string())
+    .bind(tenant_a.to_string())
+    .execute(&pool)
+    .await
+    .expect("insert assignment A");
+
+    sqlx::query(
+        "INSERT INTO project_team_assignments (project_id, team_id, tenant_id, assignment_type)
+         VALUES ($1, $2, $3, 'primary')",
+    )
+    .bind("proj-b")
+    .bind(team_b.to_string())
+    .bind(tenant_b.to_string())
+    .execute(&pool)
+    .await
+    .expect("insert assignment B");
+
+    let assignments_a =
+        sqlx::query("SELECT project_id FROM project_team_assignments WHERE tenant_id = $1")
+            .bind(tenant_a.to_string())
+            .fetch_all(&pool)
+            .await
+            .expect("query assignments A");
+
+    assert_eq!(assignments_a.len(), 1);
+    assert_eq!(assignments_a[0].get::<String, _>("project_id"), "proj-a");
+}
+
+#[tokio::test]
+async fn v_hierarchy_unknown_tenant_returns_empty_set_not_global_fallthrough() {
+    let Some(pool) = fresh_pool().await else {
+        eprintln!("Skipping opal-fetcher tenant isolation test: Docker unavailable");
+        return;
+    };
+
+    let _ = seed_tenant(&pool, "eta").await;
+    let unknown_tenant = Uuid::new_v4();
+
+    let rows: Vec<(Uuid,)> =
+        sqlx::query_as("SELECT tenant_id FROM v_hierarchy WHERE tenant_id = $1")
+            .bind(unknown_tenant)
+            .fetch_all(&pool)
+            .await
+            .expect("query unknown tenant");
+
+    assert!(
+        rows.is_empty(),
+        "unknown tenant must return empty set, got {} rows",
+        rows.len()
+    );
+}


### PR DESCRIPTION
Closes the hierarchy/users portion of #130 in one PR.

## What this PR does

**1. Stops idp-sync from redefining migration-owned views.**

`idp-sync::github::initialize_opal_views` previously issued `CREATE OR REPLACE VIEW` for five views. Two of them — `v_hierarchy` and `v_user_permissions` — raced migration `028_tenant_scoped_hierarchy.sql`. Whichever ran last won; any `aeterna admin sync github` silently reverted the migration’s tenant-scoped definitions and pointed the views back at the legacy `organizational_units` table with synthesized UUIDs.

Those two definitions are now deleted. Migration 028 is the sole definer. `initialize_opal_views` retains ownership of `v_agent_permissions` and the three Code Search stub views; the function’s doc-comment explains the surviving scope.

**2. Forces tenant-scope on every entity endpoint in opal-fetcher.**

- `GET /v1/hierarchy?tenant=<uuid>` — required, SQL-filtered
- `GET /v1/users?tenant=<uuid>` — required, SQL-filtered
- `GET /v1/all?tenant=<uuid>` — required, SQL-filtered (agents excepted, see below)
- `GET /v1/agents?tenant=<uuid>` — required but not yet filtering, logs WARN

Missing/invalid tenant param returns 400 via axum’s `Query` extractor. Filtering is SQL-layer (`WHERE tenant_id = $1`), not policy-layer — the wire contract is authoritative.

`HierarchyRow` and `UserPermissionRow` gain a strongly-typed `tenant_id: Uuid` field that mirrors migration 028’s new first column.

## Known gap (scoped out, tracked inside #130)

`/v1/agents` still returns cross-tenant rows. The `agents` table has no `tenant_id` column (migration 009); adding it + backfill + a filtered `v_agent_permissions` view is the follow-up work under #130. The handler accepts the tenant param and emits a WARN to make the gap grep-able in production logs. Cedar’s scope-check on `allowed_company_ids` continues to provide defense-in-depth until then.

## Tests

- `opal-fetcher/tests/tenant_isolation_test.rs` — Docker-gated integration tests seeding two tenants with overlapping slugs (`(tenant_id, slug)` uniqueness from migration 028) and asserting:
  1. `v_hierarchy WHERE tenant_id = A` returns only A’s rows
  2. `v_user_permissions WHERE tenant_id = A` returns only A’s users
  3. `project_team_assignments WHERE tenant_id = A` isolates assignments
  4. Unknown tenant UUID → empty set (no global fallthrough)
- Existing 35 opal-fetcher + 18 idp-sync unit tests remain green (spread-based row fixtures inherit the new `tenant_id` field automatically).
- `cargo fmt`, `cargo clippy -p opal-fetcher -p idp-sync --all-targets` both clean.

## What this PR does NOT do (follow-ups remain on #130)

- Relocate idp-sync writes from `organizational_units` to `companies/organizations/teams`.
- Remove `organizational_units` writes from `initialize_schema` (blocked on the above).
- Add `agents.tenant_id` + filter `/v1/agents`.

These are intentionally separate PRs because each has a non-trivial migration or write-path refactor.