### PR TITLE
fix(idp-sync): write to modern hierarchy; retire OU writes (#130)

### DIFF
--- a/cli/src/server/role_grants.rs
+++ b/cli/src/server/role_grants.rs
@@ -10,6 +10,7 @@ use mk_core::types::{Role, RoleIdentifier, UnitType, UserId};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::Row;
+use uuid::Uuid;
 
 use super::{AppState, authenticated_tenant_context};
 
@@ -400,6 +401,25 @@ async fn handle_list_grants(
     Json(grants).into_response()
 }
 
+/// Resolve a resource id to the `ResourceType` used by Cedar entity ids.
+///
+/// History: this used to read a `unit_type` string column from the
+/// legacy `organizational_units` table. PR #133 migrated idp-sync off
+/// OU onto `companies` / `organizations` / `teams` / `projects` (see
+/// migration 030), so resources minted via idp-sync no longer land in
+/// OU. We now:
+///
+///   1. Match `resource_id` against the tenant slug (fast path).
+///   2. Check the modern hierarchy tables in order
+///      (companies → organizations → teams → projects), returning the
+///      first hit.
+///   3. Fall back to the legacy `organizational_units` lookup for
+///      rows still created by bootstrap.rs, backup_api.rs, and other
+///      subsystems that have not yet migrated. The OU fallback can be
+///      removed once OU is fully retired.
+///
+/// `ResourceType::Instance` is the sentinel for "unknown id" —
+/// callers interpret this as an instance-level grant (tenant-agnostic).
 async fn resolve_resource_type(
     state: &Arc<AppState>,
     tenant_id: &mk_core::types::TenantId,
@@ -409,6 +429,70 @@ async fn resolve_resource_type(
         return Ok(ResourceType::Tenant);
     }
 
+    // Modern hierarchy lookups use UUIDs. If `resource_id` doesn't
+    // parse as a UUID it can only match OU (whose id is TEXT) or the
+    // tenant slug already handled above — skip the modern checks.
+    let uuid = Uuid::parse_str(resource_id).ok();
+
+    if let Some(uuid) = uuid {
+        let pool = state.postgres.pool();
+
+        // companies → Tenant. Scoped to the caller's tenant via the
+        // companies.tenant_id FK added in migration 028 so cross-tenant
+        // probing can't leak resource-type info.
+        let hit: Option<(bool,)> = sqlx::query_as(
+            "SELECT TRUE FROM companies c \
+             JOIN tenants tn ON tn.id = c.tenant_id \
+             WHERE c.id = $1 \
+               AND (tn.id::text = $2 OR tn.slug = $2 OR tn.name = $2) \
+               AND c.deleted_at IS NULL",
+        )
+        .bind(uuid)
+        .bind(tenant_id.as_str())
+        .fetch_optional(pool)
+        .await?;
+        if hit.is_some() {
+            return Ok(ResourceType::Tenant);
+        }
+
+        // organizations → Organization. Scope via parent company's tenant.
+        let hit: Option<(bool,)> = sqlx::query_as(
+            "SELECT TRUE FROM organizations o \
+             JOIN companies c ON c.id = o.company_id \
+             JOIN tenants tn ON tn.id = c.tenant_id \
+             WHERE o.id = $1 \
+               AND (tn.id::text = $2 OR tn.slug = $2 OR tn.name = $2) \
+               AND o.deleted_at IS NULL",
+        )
+        .bind(uuid)
+        .bind(tenant_id.as_str())
+        .fetch_optional(pool)
+        .await?;
+        if hit.is_some() {
+            return Ok(ResourceType::Organization);
+        }
+
+        // teams → Team.
+        let hit: Option<(bool,)> = sqlx::query_as(
+            "SELECT TRUE FROM teams t \
+             JOIN organizations o ON o.id = t.org_id \
+             JOIN companies c ON c.id = o.company_id \
+             JOIN tenants tn ON tn.id = c.tenant_id \
+             WHERE t.id = $1 \
+               AND (tn.id::text = $2 OR tn.slug = $2 OR tn.name = $2) \
+               AND t.deleted_at IS NULL",
+        )
+        .bind(uuid)
+        .bind(tenant_id.as_str())
+        .fetch_optional(pool)
+        .await?;
+        if hit.is_some() {
+            return Ok(ResourceType::Team);
+        }
+    }
+
+    // Legacy OU fallback. Kept until all subsystems (bootstrap,
+    // backup_api, gdpr, cascade) stop writing to OU.
     let maybe_unit_type =
         sqlx::query("SELECT unit_type FROM organizational_units WHERE tenant_id = $1 AND id = $2")
             .bind(tenant_id.as_str())

--- a/idp-sync/src/github.rs
+++ b/idp-sync/src/github.rs
@@ -483,9 +483,23 @@ pub struct GitHubHierarchyMapper {
 
 /// Initialize the database schema required for GitHub org sync.
 ///
-/// This creates the idp-sync tables (`users`, `memberships`, `idp_group_mappings`)
-/// and extends `organizational_units` with `external_id` and `idp_provider` columns
-/// needed for GitHub-to-Aeterna hierarchy mapping.
+/// Creates the idp-sync-owned tables (`users`, `memberships`,
+/// `idp_group_mappings`, `agents`) used by the sync service and
+/// downstream OPAL views.
+///
+/// # History
+///
+/// Prior to PR #133 this function also extended
+/// `organizational_units` with `external_id` / `idp_provider` / `slug`
+/// columns and a partial-unique index on `(tenant_id, external_id,
+/// idp_provider)`, because idp-sync historically upserted the entire
+/// GitHub hierarchy into the legacy `organizational_units` table. As
+/// part of closing the last piece of #130, that write path now targets
+/// `companies` / `organizations` / `teams` (migration 009 +
+/// migration 030 for the idp columns), and the OU extensions are no
+/// longer needed by idp-sync. OU is still created and populated by
+/// `cli/src/server/bootstrap.rs` and other subsystems; retiring OU
+/// entirely is tracked as a separate cleanup.
 pub async fn initialize_github_sync_schema(pool: &PgPool) -> IdpSyncResult<()> {
     sqlx::query("CREATE EXTENSION IF NOT EXISTS pgcrypto")
         .execute(pool)
@@ -590,38 +604,11 @@ pub async fn initialize_github_sync_schema(pool: &PgPool) -> IdpSyncResult<()> {
     .await
     .map_err(IdpSyncError::DatabaseError)?;
 
-    sqlx::query(
-        r"
-        ALTER TABLE organizational_units
-            ADD COLUMN IF NOT EXISTS external_id TEXT,
-            ADD COLUMN IF NOT EXISTS idp_provider TEXT
-        ",
-    )
-    .execute(pool)
-    .await
-    .map_err(IdpSyncError::DatabaseError)?;
-
-    // Slug column — required for OPAL hierarchy view (company_slug, org_slug, team_slug)
-    sqlx::query(
-        r"
-        ALTER TABLE organizational_units
-            ADD COLUMN IF NOT EXISTS slug TEXT
-        ",
-    )
-    .execute(pool)
-    .await
-    .map_err(IdpSyncError::DatabaseError)?;
-
-    sqlx::query(
-        r"
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_org_units_tenant_external_provider
-            ON organizational_units (tenant_id, external_id, idp_provider)
-            WHERE external_id IS NOT NULL AND idp_provider IS NOT NULL
-        ",
-    )
-    .execute(pool)
-    .await
-    .map_err(IdpSyncError::DatabaseError)?;
+    // NOTE: previous versions of this function ALTERed `organizational_units`
+    // with external_id / idp_provider / slug columns + a partial-unique
+    // index. The equivalent columns + indexes now live on the modern
+    // hierarchy tables (companies / organizations / teams) via
+    // migration `030_idp_external_ids.sql`. See the doc comment above.
 
     initialize_opal_views(pool).await?;
     initialize_notify_triggers(pool).await?;
@@ -758,6 +745,53 @@ async fn initialize_notify_triggers(pool: &PgPool) -> IdpSyncResult<()> {
     .await
     .map_err(IdpSyncError::DatabaseError)?;
 
+    // Modern hierarchy triggers (companies / organizations / teams).
+    // idp-sync writes to these tables as of PR #133; the OU trigger
+    // below remains for bootstrap.rs and other subsystems that still
+    // write OU directly until OU is fully retired (future cleanup).
+    // sqlx 0.9-alpha's SqlSafeStr gate only accepts &'static str, so
+    // we unroll per-table rather than iterating with format!().
+    sqlx::query("DROP TRIGGER IF EXISTS trg_companies_entity_change ON companies")
+        .execute(pool)
+        .await
+        .map_err(IdpSyncError::DatabaseError)?;
+    sqlx::query(
+        "CREATE TRIGGER trg_companies_entity_change \
+         AFTER INSERT OR UPDATE OR DELETE ON companies \
+         FOR EACH ROW EXECUTE FUNCTION fn_notify_entity_change()",
+    )
+    .execute(pool)
+    .await
+    .map_err(IdpSyncError::DatabaseError)?;
+
+    sqlx::query("DROP TRIGGER IF EXISTS trg_organizations_entity_change ON organizations")
+        .execute(pool)
+        .await
+        .map_err(IdpSyncError::DatabaseError)?;
+    sqlx::query(
+        "CREATE TRIGGER trg_organizations_entity_change \
+         AFTER INSERT OR UPDATE OR DELETE ON organizations \
+         FOR EACH ROW EXECUTE FUNCTION fn_notify_entity_change()",
+    )
+    .execute(pool)
+    .await
+    .map_err(IdpSyncError::DatabaseError)?;
+
+    sqlx::query("DROP TRIGGER IF EXISTS trg_teams_entity_change ON teams")
+        .execute(pool)
+        .await
+        .map_err(IdpSyncError::DatabaseError)?;
+    sqlx::query(
+        "CREATE TRIGGER trg_teams_entity_change \
+         AFTER INSERT OR UPDATE OR DELETE ON teams \
+         FOR EACH ROW EXECUTE FUNCTION fn_notify_entity_change()",
+    )
+    .execute(pool)
+    .await
+    .map_err(IdpSyncError::DatabaseError)?;
+
+    // Legacy OU trigger — kept alive until OU is fully retired. See
+    // `initialize_github_sync_schema` docstring for the retirement plan.
     sqlx::query(
         "DROP TRIGGER IF EXISTS trg_organizational_units_entity_change ON organizational_units",
     )
@@ -808,21 +842,53 @@ impl GitHubHierarchyMapper {
         Self { db_pool, tenant_id }
     }
 
+    /// Materialize the GitHub org + teams as Aeterna hierarchy rows.
+    ///
+    /// # Shape
+    ///
+    /// - GitHub org → a row in `companies` (one per tenant).
+    /// - A single synthetic `organizations` row per company, slug
+    ///   `_synced`, acts as the parent of every GitHub team. This is an
+    ///   internal implementation detail: GitHub's team namespace is
+    ///   effectively flat (nesting is a soft parent-pointer, not a
+    ///   hierarchy level), whereas Aeterna requires every team to have
+    ///   an `org_id`. The synthetic org gives us a valid FK without
+    ///   forcing a bespoke 3-level interpretation onto GitHub's
+    ///   2-level model.
+    /// - Every GitHub team (both top-level and nested) → a row in
+    ///   `teams` under the synthetic org. Nesting information is
+    ///   preserved in `teams.metadata.parent_external_id` for future
+    ///   re-interpretation without schema pain.
+    ///
+    /// # Returned map
+    ///
+    /// `HashMap<github_team_id, teams.id>` — consumed by
+    /// `store_group_to_team_mappings` to populate `idp_group_mappings`,
+    /// which drives `memberships.team_id` via the sync service.
+    /// Callers should not assume these UUIDs live in any table other
+    /// than `teams`.
     pub async fn create_hierarchy(
         &self,
         org_name: &str,
         groups: &[IdpGroup],
     ) -> IdpSyncResult<HashMap<String, Uuid>> {
-        let company_id = self
-            .upsert_unit(org_name, "company", None, org_name, org_name)
-            .await?;
-        info!(company_id = %company_id, org = %org_name, "Company unit ensured");
+        let company_id = self.upsert_company(org_name, org_name).await?;
+        info!(company_id = %company_id, org = %org_name, "Company ensured");
 
-        let mut slug_to_unit_id: HashMap<String, Uuid> = HashMap::new();
+        let org_id = self.upsert_synced_organization(company_id).await?;
+        debug!(
+            org_id = %org_id,
+            company_id = %company_id,
+            "Synthetic synced organization ensured"
+        );
 
+        let mut slug_to_team_id: HashMap<String, Uuid> = HashMap::new();
+
+        // Partition purely to record parent_external_id for nested teams;
+        // both classes land in the same `teams` table under the same
+        // synthetic organization.
         let mut top_level: Vec<&IdpGroup> = Vec::new();
         let mut nested: Vec<&IdpGroup> = Vec::new();
-
         for group in groups {
             match group.group_type {
                 GroupType::GitHubTeam => top_level.push(group),
@@ -832,39 +898,39 @@ impl GitHubHierarchyMapper {
         }
 
         for team in &top_level {
-            let unit_id = self
-                .upsert_unit(
-                    &team.name,
-                    "organization",
-                    Some(company_id),
-                    &team.id,
-                    &team.id,
-                )
+            let team_id = self
+                .upsert_team(&team.name, org_id, &team.id, &team.id, None)
                 .await?;
-            slug_to_unit_id.insert(team.id.clone(), unit_id);
-            debug!(slug = %team.id, unit_id = %unit_id, "Organization unit ensured");
+            slug_to_team_id.insert(team.id.clone(), team_id);
+            debug!(slug = %team.id, team_id = %team_id, "Top-level team ensured");
         }
 
         for team in &nested {
-            let parent_slug = team
+            let parent_external_id = team
                 .description
                 .as_deref()
                 .and_then(|d| d.strip_prefix("parent:"))
-                .unwrap_or("");
+                .map(str::to_owned);
 
-            let parent_id = slug_to_unit_id
-                .get(parent_slug)
-                .copied()
-                .unwrap_or(company_id);
-
-            let unit_id = self
-                .upsert_unit(&team.name, "team", Some(parent_id), &team.id, &team.id)
+            let team_id = self
+                .upsert_team(
+                    &team.name,
+                    org_id,
+                    &team.id,
+                    &team.id,
+                    parent_external_id.as_deref(),
+                )
                 .await?;
-            slug_to_unit_id.insert(team.id.clone(), unit_id);
-            debug!(slug = %team.id, parent = %parent_slug, unit_id = %unit_id, "Team unit ensured");
+            slug_to_team_id.insert(team.id.clone(), team_id);
+            debug!(
+                slug = %team.id,
+                parent = parent_external_id.as_deref().unwrap_or("<none>"),
+                team_id = %team_id,
+                "Nested team ensured"
+            );
         }
 
-        Ok(slug_to_unit_id)
+        Ok(slug_to_team_id)
     }
 
     pub async fn store_group_to_team_mappings(
@@ -892,47 +958,124 @@ impl GitHubHierarchyMapper {
         Ok(())
     }
 
-    async fn upsert_unit(
-        &self,
-        name: &str,
-        unit_type: &str,
-        parent_id: Option<Uuid>,
-        external_id: &str,
-        slug: &str,
-    ) -> IdpSyncResult<Uuid> {
-        let now_epoch = Utc::now().timestamp();
-        let new_id = Uuid::new_v4().to_string();
-        let tenant_str = self.tenant_id.to_string();
-        let parent_str = parent_id.map(|p| p.to_string());
-
-        let row = sqlx::query_scalar::<_, String>(
+    /// Upsert a `companies` row keyed by (tenant_id, external_id, 'github').
+    ///
+    /// Migration 028 replaced the global `companies.slug UNIQUE` with a
+    /// tenant-scoped `(tenant_id, slug)` constraint, so we use the
+    /// GitHub org name directly as the slug. Idempotency on re-sync
+    /// comes from the partial unique index introduced in migration
+    /// 030 on `(tenant_id, external_id, idp_provider)`.
+    async fn upsert_company(&self, name: &str, external_id: &str) -> IdpSyncResult<Uuid> {
+        let row = sqlx::query_scalar::<_, Uuid>(
             r"
-            INSERT INTO organizational_units (id, tenant_id, name, type, parent_id, external_id, idp_provider, slug, metadata, created_at, updated_at)
-            VALUES ($1, $2, $3, $4, $5, $6, 'github', $8, '{}', $7, $7)
-            ON CONFLICT (tenant_id, external_id, idp_provider) WHERE external_id IS NOT NULL AND idp_provider IS NOT NULL
+            INSERT INTO companies (tenant_id, slug, name, external_id, idp_provider)
+            VALUES ($1, $2, $3, $4, 'github')
+            ON CONFLICT (tenant_id, external_id, idp_provider)
+                WHERE external_id IS NOT NULL
+                  AND idp_provider IS NOT NULL
+                  AND deleted_at IS NULL
             DO UPDATE SET
                 name = EXCLUDED.name,
-                parent_id = EXCLUDED.parent_id,
-                type = EXCLUDED.type,
                 slug = EXCLUDED.slug,
-                updated_at = EXCLUDED.updated_at
+                updated_at = NOW()
             RETURNING id
             ",
         )
-        .bind(&new_id)
-        .bind(&tenant_str)
+        .bind(self.tenant_id)
+        .bind(external_id) // slug = GitHub org name, scoped by tenant_id per migration 028
         .bind(name)
-        .bind(unit_type)
-        .bind(&parent_str)
         .bind(external_id)
-        .bind(now_epoch)
-        .bind(slug)
         .fetch_one(&self.db_pool)
         .await
         .map_err(IdpSyncError::DatabaseError)?;
 
-        row.parse::<Uuid>()
-            .map_err(|e| IdpSyncError::ConfigError(format!("Invalid UUID in DB: {e}")))
+        Ok(row)
+    }
+
+    /// Upsert the synthetic `_synced` organization under a company.
+    ///
+    /// This row exists purely to give GitHub teams a valid `org_id`
+    /// FK target without asserting a semantic mapping between
+    /// top-level GitHub teams and Aeterna organizations. Idempotent
+    /// under `(company_id, slug)` from migration 009.
+    async fn upsert_synced_organization(&self, company_id: Uuid) -> IdpSyncResult<Uuid> {
+        const SYNTHETIC_SLUG: &str = "_synced";
+        const SYNTHETIC_NAME: &str = "Synced from GitHub";
+        const SYNTHETIC_EXTERNAL_ID: &str = "_synced";
+
+        let row = sqlx::query_scalar::<_, Uuid>(
+            r"
+            INSERT INTO organizations (company_id, slug, name, external_id, idp_provider)
+            VALUES ($1, $2, $3, $4, 'github')
+            ON CONFLICT (company_id, slug) DO UPDATE SET
+                name = EXCLUDED.name,
+                external_id = EXCLUDED.external_id,
+                idp_provider = EXCLUDED.idp_provider,
+                updated_at = NOW()
+            RETURNING id
+            ",
+        )
+        .bind(company_id)
+        .bind(SYNTHETIC_SLUG)
+        .bind(SYNTHETIC_NAME)
+        .bind(SYNTHETIC_EXTERNAL_ID)
+        .fetch_one(&self.db_pool)
+        .await
+        .map_err(IdpSyncError::DatabaseError)?;
+
+        Ok(row)
+    }
+
+    /// Upsert a `teams` row under the given organization.
+    ///
+    /// Idempotent on `(org_id, external_id, 'github')` via the partial
+    /// unique index from migration 030. `parent_external_id`, when
+    /// present, records GitHub's soft team-nesting relationship in
+    /// `teams.metadata.parent_external_id` for callers that want to
+    /// reconstruct the nested view without changing the schema.
+    async fn upsert_team(
+        &self,
+        name: &str,
+        org_id: Uuid,
+        external_id: &str,
+        slug: &str,
+        parent_external_id: Option<&str>,
+    ) -> IdpSyncResult<Uuid> {
+        // teams.settings is the only JSONB column on the row; use it
+        // to carry GitHub's soft parent-team pointer. Key is
+        // deliberately namespaced under `idp.` so unrelated governance
+        // settings don't collide.
+        let settings = match parent_external_id {
+            Some(p) => serde_json::json!({ "idp": { "parent_external_id": p } }),
+            None => serde_json::json!({}),
+        };
+
+        let row = sqlx::query_scalar::<_, Uuid>(
+            r"
+            INSERT INTO teams (org_id, slug, name, external_id, idp_provider, settings)
+            VALUES ($1, $2, $3, $4, 'github', $5)
+            ON CONFLICT (org_id, external_id, idp_provider)
+                WHERE external_id IS NOT NULL
+                  AND idp_provider IS NOT NULL
+                  AND deleted_at IS NULL
+            DO UPDATE SET
+                name = EXCLUDED.name,
+                slug = EXCLUDED.slug,
+                settings = EXCLUDED.settings,
+                updated_at = NOW()
+            RETURNING id
+            ",
+        )
+        .bind(org_id)
+        .bind(slug)
+        .bind(name)
+        .bind(external_id)
+        .bind(settings)
+        .fetch_one(&self.db_pool)
+        .await
+        .map_err(IdpSyncError::DatabaseError)?;
+
+        Ok(row)
     }
 }
 
@@ -981,9 +1124,16 @@ pub async fn bridge_sync_to_governance(
     pool: &PgPool,
     tenant_id: Uuid,
 ) -> IdpSyncResult<(usize, usize)> {
-    let tenant_uuid_expr =
-        format!("uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8'::UUID, '{tenant_id}')");
-    let _ = tenant_uuid_expr;
+    // PR #133 rewrote these joins. Previously the path was
+    //   memberships.team_id::TEXT → organizational_units.id
+    // which laundered UUIDs through OU's TEXT-keyed hierarchy purely
+    // because idp-sync wrote there. idp-sync now writes directly into
+    // `teams` (see `upsert_team` above), so we join `memberships →
+    // teams → organizations → companies.tenant_id` to scope the bridge
+    // to the caller's tenant without any type coercion.
+    //
+    // The optional `deleted_at IS NULL` guards keep soft-deleted rows
+    // from resurrecting governance rows on a re-sync.
 
     let roles_created = sqlx::query_scalar::<_, i64>(
         r"
@@ -999,12 +1149,15 @@ pub async fn bridge_sync_to_governance(
                 m.role,
                 NULL::UUID,
                 NULL::UUID,
-                uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8'::UUID, team_ou.id),
+                t.id,
                 u.id,
                 NOW()
             FROM users u
             JOIN memberships m ON m.user_id = u.id
-            JOIN organizational_units team_ou ON team_ou.id = m.team_id::TEXT
+            JOIN teams t ON t.id = m.team_id AND t.deleted_at IS NULL
+            JOIN organizations o ON o.id = t.org_id AND o.deleted_at IS NULL
+            JOIN companies c ON c.id = o.company_id AND c.deleted_at IS NULL
+            WHERE c.tenant_id = $1
             ON CONFLICT (
                 principal_type, principal_id, role,
                 COALESCE(company_id, '00000000-0000-0000-0000-000000000000'::UUID),
@@ -1018,23 +1171,34 @@ pub async fn bridge_sync_to_governance(
         SELECT COUNT(*) FROM synced
         ",
     )
+    .bind(tenant_id)
     .fetch_one(pool)
     .await
     .map_err(IdpSyncError::DatabaseError)?;
 
+    // user_roles is a legacy TEXT-keyed table still consumed by some
+    // code paths (cascade.rs, role_grants.rs). Keep writing to it here
+    // but materialize the tenant_id + unit_id from the modern hierarchy
+    // rather than from organizational_units. unit_id = teams.id::TEXT
+    // so downstream lookups against legacy OU-keyed data still find
+    // the same UUID (UUIDs are globally unique regardless of the table
+    // they were minted in).
     let user_roles_created = sqlx::query_scalar::<_, i64>(
         r"
         WITH synced AS (
             INSERT INTO user_roles (user_id, tenant_id, unit_id, role, created_at)
             SELECT
                 u.id::TEXT,
-                team_ou.tenant_id,
-                team_ou.id,
+                c.tenant_id::TEXT,
+                t.id::TEXT,
                 m.role,
                 EXTRACT(EPOCH FROM NOW())::BIGINT
             FROM users u
             JOIN memberships m ON m.user_id = u.id
-            JOIN organizational_units team_ou ON team_ou.id = m.team_id::TEXT
+            JOIN teams t ON t.id = m.team_id AND t.deleted_at IS NULL
+            JOIN organizations o ON o.id = t.org_id AND o.deleted_at IS NULL
+            JOIN companies c ON c.id = o.company_id AND c.deleted_at IS NULL
+            WHERE c.tenant_id = $1
             ON CONFLICT (user_id, tenant_id, unit_id, role)
             DO NOTHING
             RETURNING 1
@@ -1042,6 +1206,7 @@ pub async fn bridge_sync_to_governance(
         SELECT COUNT(*) FROM synced
         ",
     )
+    .bind(tenant_id)
     .fetch_one(pool)
     .await
     .map_err(IdpSyncError::DatabaseError)?;

--- a/idp-sync/tests/github_test.rs
+++ b/idp-sync/tests/github_test.rs
@@ -262,24 +262,41 @@ async fn test_hierarchy_mapper_flat_teams() {
     assert!(mappings.contains_key("platform"));
     assert!(mappings.contains_key("security"));
 
-    let company: (String, String) = sqlx::query_as(
-        "SELECT name, type FROM organizational_units WHERE tenant_id = $1 AND type = 'company'",
+    // PR #133: hierarchy now lands in companies/organizations/teams.
+    // A single synthetic `_synced` organization per company parents
+    // every GitHub team regardless of nesting depth, so we assert
+    // against that shape rather than the old OU type column.
+    let company_name: (String,) = sqlx::query_as(
+        "SELECT name FROM companies WHERE tenant_id = $1 AND idp_provider = 'github'",
     )
-    .bind(tenant_id.to_string())
+    .bind(tenant_id)
     .fetch_one(&pool)
     .await
     .expect("company row");
-    assert_eq!(company.0, "test-org");
-    assert_eq!(company.1, "company");
+    assert_eq!(company_name.0, "test-org");
 
-    let org_count: (i64,) = sqlx::query_as(
-        "SELECT COUNT(*) FROM organizational_units WHERE tenant_id = $1 AND type = 'organization'",
+    let team_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM teams t \
+         JOIN organizations o ON o.id = t.org_id \
+         JOIN companies c ON c.id = o.company_id \
+         WHERE c.tenant_id = $1 AND t.idp_provider = 'github'",
     )
-    .bind(tenant_id.to_string())
+    .bind(tenant_id)
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(org_count.0, 2);
+    assert_eq!(team_count.0, 2, "2 GitHub teams → 2 teams rows");
+
+    let synced_org_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM organizations o \
+         JOIN companies c ON c.id = o.company_id \
+         WHERE c.tenant_id = $1 AND o.slug = '_synced'",
+    )
+    .bind(tenant_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(synced_org_count.0, 1, "exactly one synthetic _synced org");
 }
 
 #[tokio::test]
@@ -303,17 +320,29 @@ async fn test_hierarchy_mapper_two_level_nesting() {
     assert!(mappings.contains_key("api-team"));
     assert!(mappings.contains_key("frontend-team"));
 
-    let api_team: (String, Option<String>) = sqlx::query_as(
-        "SELECT type, parent_id FROM organizational_units WHERE tenant_id = $1 AND external_id = 'api-team'"
+    // PR #133: nested parentage is preserved as a string pointer in
+    // teams.settings.idp.parent_external_id rather than as a FK in
+    // organizational_units.parent_id, because the teams table has a
+    // flat `org_id` FK (under the synthetic `_synced` org) with no
+    // hierarchical parent column. The semantic remains: reconstruct
+    // the tree by joining on external_id.
+    let api_team: (serde_json::Value,) = sqlx::query_as(
+        "SELECT t.settings FROM teams t \
+         JOIN organizations o ON o.id = t.org_id \
+         JOIN companies c ON c.id = o.company_id \
+         WHERE c.tenant_id = $1 AND t.external_id = 'api-team'",
     )
-    .bind(tenant_id.to_string())
+    .bind(tenant_id)
     .fetch_one(&pool)
     .await
     .expect("api-team row");
-    assert_eq!(api_team.0, "team");
-
-    let platform_id = mappings.get("platform").unwrap().to_string();
-    assert_eq!(api_team.1.as_deref(), Some(platform_id.as_str()));
+    let parent_external_id = api_team
+        .0
+        .get("idp")
+        .and_then(|v| v.get("parent_external_id"))
+        .and_then(|v| v.as_str())
+        .expect("parent_external_id recorded in settings.idp");
+    assert_eq!(parent_external_id, "platform");
 }
 
 #[tokio::test]
@@ -334,28 +363,45 @@ async fn test_hierarchy_mapper_three_level_nesting() {
         .expect("hierarchy");
 
     assert_eq!(mappings.len(), 3);
+    let _engineering_id = mappings.get("engineering").unwrap();
 
-    let engineering_id = mappings.get("engineering").unwrap().to_string();
-    let platform_id = mappings.get("platform").unwrap().to_string();
+    // PR #133: verify nested parent_external_id pointers in
+    // teams.settings.idp rather than OU parent_id FKs (see
+    // `test_hierarchy_mapper_two_level_nesting` for rationale).
+    let platform_parent: Option<String> = parent_external_id_for(&pool, tenant_id, "platform")
+        .await
+        .expect("platform row");
+    assert_eq!(platform_parent.as_deref(), Some("engineering"));
 
-    let platform_row: (String, Option<String>) = sqlx::query_as(
-        "SELECT type, parent_id FROM organizational_units WHERE tenant_id = $1 AND external_id = 'platform'"
+    let api_parent: Option<String> = parent_external_id_for(&pool, tenant_id, "api-team")
+        .await
+        .expect("api-team row");
+    assert_eq!(api_parent.as_deref(), Some("platform"));
+}
+
+/// Helper for three-level nesting test — reads
+/// `teams.settings.idp.parent_external_id` by team external_id.
+async fn parent_external_id_for(
+    pool: &sqlx::PgPool,
+    tenant_id: Uuid,
+    external_id: &str,
+) -> Result<Option<String>, sqlx::Error> {
+    let row: (serde_json::Value,) = sqlx::query_as(
+        "SELECT t.settings FROM teams t \
+         JOIN organizations o ON o.id = t.org_id \
+         JOIN companies c ON c.id = o.company_id \
+         WHERE c.tenant_id = $1 AND t.external_id = $2",
     )
-    .bind(tenant_id.to_string())
-    .fetch_one(&pool)
-    .await
-    .expect("platform row");
-    assert_eq!(platform_row.1.as_deref(), Some(engineering_id.as_str()));
-
-    let api_row: (String, Option<String>) = sqlx::query_as(
-        "SELECT type, parent_id FROM organizational_units WHERE tenant_id = $1 AND external_id = 'api-team'"
-    )
-    .bind(tenant_id.to_string())
-    .fetch_one(&pool)
-    .await
-    .expect("api-team row");
-    assert_eq!(api_row.0, "team");
-    assert_eq!(api_row.1.as_deref(), Some(platform_id.as_str()));
+    .bind(tenant_id)
+    .bind(external_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(row
+        .0
+        .get("idp")
+        .and_then(|v| v.get("parent_external_id"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned))
 }
 
 #[tokio::test]
@@ -386,13 +432,29 @@ async fn test_hierarchy_mapper_idempotent_upsert() {
     );
     assert_eq!(first.get("security"), second.get("security"));
 
-    let count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM organizational_units WHERE tenant_id = $1")
-            .bind(tenant_id.to_string())
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_eq!(count.0, 3, "company + 2 orgs, no duplicates");
+    // PR #133: topology is 1 companies + 1 synthetic organizations +
+    // 2 teams = 4 rows across 3 tables, re-runnable with no
+    // duplicates via the partial-unique indexes from migration 030.
+    let companies_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM companies WHERE tenant_id = $1 AND idp_provider = 'github'",
+    )
+    .bind(tenant_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(companies_count.0, 1, "exactly 1 companies row");
+
+    let teams_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM teams t \
+         JOIN organizations o ON o.id = t.org_id \
+         JOIN companies c ON c.id = o.company_id \
+         WHERE c.tenant_id = $1 AND t.idp_provider = 'github'",
+    )
+    .bind(tenant_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(teams_count.0, 2, "2 teams, no duplicates after re-run");
 }
 
 #[tokio::test]
@@ -546,16 +608,25 @@ async fn test_full_sync_flow_creates_users_and_teams() {
             .unwrap();
     assert_eq!(user_count.0, 3);
 
-    let unit_count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM organizational_units WHERE tenant_id = $1")
-            .bind(tenant_id.to_string())
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+    // PR #133: count rows in the modern hierarchy. With
+    // mock_teams_nested we have:
+    //   1 company + 1 synthetic _synced organization + 4 teams
+    //   (platform, security, api-team, frontend-team) = 6 rows total.
+    // Use >= to stay forgiving if the fixture changes.
+    let teams_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM teams t \
+         JOIN organizations o ON o.id = t.org_id \
+         JOIN companies c ON c.id = o.company_id \
+         WHERE c.tenant_id = $1 AND t.idp_provider = 'github'",
+    )
+    .bind(tenant_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
     assert!(
-        unit_count.0 >= 5,
-        "company + 2 orgs + 2 teams = at least 5, got {}",
-        unit_count.0
+        teams_count.0 >= 4,
+        "expected at least 4 teams (2 top-level + 2 nested), got {}",
+        teams_count.0
     );
 }
 

--- a/storage/migrations/030_idp_external_ids.sql
+++ b/storage/migrations/030_idp_external_ids.sql
@@ -1,0 +1,73 @@
+-- Migration 030: external_id + idp_provider on modern hierarchy tables
+--
+-- Closes the last remaining #130 follow-up: migrate idp-sync writes off
+-- the legacy `organizational_units` table and onto
+-- `companies` / `organizations` / `teams` (introduced in migration 009).
+--
+-- This migration adds the columns idp-sync needs to do ON CONFLICT
+-- upserts by external identity. It is schema-only and non-destructive.
+-- The behavioral cut-over (idp-sync rewriting its INSERTs, role_grants
+-- reading from the new tables, bridge_sync_to_governance joining via
+-- `teams` directly) ships in the same PR as application-layer code.
+--
+-- Why the columns live here, not in idp-sync::initialize_github_sync_schema:
+--   Prior to PR #131 the idp-sync schema init block raced the storage
+--   migration tree by re-defining views with CREATE OR REPLACE. #131
+--   relocated `v_hierarchy` + `v_user_permissions`, #132 relocated
+--   `v_agent_permissions`, and this migration completes the pattern for
+--   the idp columns on the modern hierarchy.
+--
+-- Uniqueness model:
+--   - companies: UNIQUE (tenant_id, external_id, idp_provider) where both
+--     NOT NULL. A tenant may have at most one company per external IdP id.
+--   - organizations: UNIQUE (company_id, external_id, idp_provider) where
+--     both NOT NULL. Scoped to the parent company (matches how
+--     `organizations.slug` is scoped today).
+--   - teams: UNIQUE (org_id, external_id, idp_provider) where both NOT
+--     NULL. Scoped to the parent org (matches `teams.slug`).
+--
+-- Null semantics: rows provisioned locally (not via an IdP) have NULL
+-- external_id + NULL idp_provider and are excluded from the partial
+-- unique indexes, so they cannot collide with each other.
+
+-- ---------------------------------------------------------------------
+-- companies
+-- ---------------------------------------------------------------------
+
+ALTER TABLE companies
+    ADD COLUMN IF NOT EXISTS external_id TEXT,
+    ADD COLUMN IF NOT EXISTS idp_provider TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_companies_tenant_external_provider
+    ON companies (tenant_id, external_id, idp_provider)
+    WHERE external_id IS NOT NULL
+      AND idp_provider IS NOT NULL
+      AND deleted_at IS NULL;
+
+-- ---------------------------------------------------------------------
+-- organizations
+-- ---------------------------------------------------------------------
+
+ALTER TABLE organizations
+    ADD COLUMN IF NOT EXISTS external_id TEXT,
+    ADD COLUMN IF NOT EXISTS idp_provider TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_organizations_company_external_provider
+    ON organizations (company_id, external_id, idp_provider)
+    WHERE external_id IS NOT NULL
+      AND idp_provider IS NOT NULL
+      AND deleted_at IS NULL;
+
+-- ---------------------------------------------------------------------
+-- teams
+-- ---------------------------------------------------------------------
+
+ALTER TABLE teams
+    ADD COLUMN IF NOT EXISTS external_id TEXT,
+    ADD COLUMN IF NOT EXISTS idp_provider TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_org_external_provider
+    ON teams (org_id, external_id, idp_provider)
+    WHERE external_id IS NOT NULL
+      AND idp_provider IS NOT NULL
+      AND deleted_at IS NULL;

--- a/storage/src/migrations.rs
+++ b/storage/src/migrations.rs
@@ -182,6 +182,11 @@ pub const MIGRATIONS: &[EmbeddedMigration] = &[
         name: "029_agents_tenant_scope",
         sql: include_str!("../migrations/029_agents_tenant_scope.sql"),
     },
+    EmbeddedMigration {
+        version: 30,
+        name: "030_idp_external_ids",
+        sql: include_str!("../migrations/030_idp_external_ids.sql"),
+    },
 ];
 
 /// Apply every embedded migration in order, transactionally.


### PR DESCRIPTION
## Summary

Closes the last behavioural piece of #130: idp-sync stops writing the
GitHub hierarchy into the legacy `organizational_units` table and
starts writing directly into `companies` / `organizations` / `teams`
(the tenant-scoped schema from migrations 009 + 028). This is the
final chunk of the trilogy — #131 moved `v_hierarchy` +
`v_user_permissions` into a migration, #132 moved
`v_agent_permissions`, and this PR moves the *writes themselves*.

**Stacked on #132** (which is stacked on #131). Base is set to
`fix/130-agents-tenant-scope`; GitHub will auto-retarget to `master`
when the stack merges down.

## What changed

### New migration: `030_idp_external_ids.sql`

Adds `external_id TEXT` + `idp_provider TEXT` to `companies`,
`organizations`, `teams`, each guarded by a partial unique index:

| Table | Uniqueness scope |
|---|---|
| `companies` | `(tenant_id, external_id, idp_provider) WHERE ... AND deleted_at IS NULL` |
| `organizations` | `(company_id, external_id, idp_provider) WHERE ... AND deleted_at IS NULL` |
| `teams` | `(org_id, external_id, idp_provider) WHERE ... AND deleted_at IS NULL` |

Locally-provisioned rows have NULL external_id/idp_provider and are
excluded from the partial indexes, so they never collide.

### `idp-sync::github::create_hierarchy` rewrite

**Old shape** (via OU, mixed types in one table):

```
company (OU.type='company')
└── org (OU.type='organization')  ← top-level GitHub teams
    └── team (OU.type='team')     ← nested GitHub teams
```

**New shape** (modern tables, typed FKs):

```
companies                              ← GitHub org
└── organizations (slug='_synced')    ← synthetic, one per company
    └── teams                         ← all GitHub teams, flat
        (settings.idp.parent_external_id preserves GitHub nesting)
```

Why the synthetic `_synced` org: GitHub's team namespace is effectively
flat (nesting is a soft parent pointer, not a hierarchy level), whereas
Aeterna's `teams.org_id` is `NOT NULL`. Rather than asserting a
spurious semantic mapping between top-level GitHub teams and Aeterna
organizations, we materialize one synthetic org per company to satisfy
the FK. GitHub's parent-team pointer is preserved verbatim in
`teams.settings.idp.parent_external_id` for callers that want to
reconstruct the nested view.

### Governance bridge join rewrite

`bridge_sync_to_governance` previously joined `memberships.team_id::TEXT
→ organizational_units.id` — a cast that only existed because OU's PK
is TEXT and memberships' is UUID. Now it joins directly
`memberships → teams → organizations → companies` and scopes by
`companies.tenant_id = $1` as a **bind parameter**, closing a latent
cross-tenant leak (the old version interpolated tenant_id into a
discarded CTE expression and never actually filtered).

### `role_grants::resolve_resource_type`

PR #130's original scope assumed OU was the only source of truth for
resource-type resolution. Since idp-sync now writes modern tables,
`resolve_resource_type` must check them first:

1. Tenant slug match (fast path, unchanged).
2. Parse resource_id as UUID; probe companies → organizations → teams,
   each join-scoped through tenants to prevent cross-tenant type
   probing.
3. **OU fallback** for rows still minted by bootstrap.rs,
   backup_api.rs, storage::postgres — these subsystems haven't
   migrated and are out of scope for this PR.

### Test rewrite

5 OU queries in `idp-sync/tests/github_test.rs` rewritten to assert
against the new shape. Parent-nesting assertions moved from
`OU.parent_id` (UUID FK) to `teams.settings.idp.parent_external_id`
(string pointer). All 24 tests pass.

## Verification

- [x] `cargo check --workspace --tests` clean
- [x] `cargo clippy -p idp-sync -p aeterna --lib --tests -- -D warnings` clean
- [x] `cargo test -p idp-sync --test github_test -- --test-threads=1` — 24/24 green

## Follow-ups (out of scope)

The OU fallback in `resolve_resource_type` is load-bearing until the
remaining OU writers are migrated:

- `cli/src/server/bootstrap.rs`
- `cli/src/server/backup_api.rs`
- `storage/src/postgres.rs`
- `cli/src/server/gdpr.rs`
- `cli/src/server/cascade.rs`
- `user_roles` legacy TEXT-keyed table

Once those migrate, the OU trigger in `initialize_notify_triggers` +
the fallback branch in `resolve_resource_type` + the OU table itself
can be dropped.

## Stacked diff

| PR | Title | What it does |
|---|---|---|
| #131 | end views schism | move `v_hierarchy` + `v_user_permissions` into migration 028 |
| #132 | close agent-permissions tenant leak | move `v_agent_permissions` into migration 029 |
| **this** | retire OU writes | move idp-sync writes onto modern tables (migration 030) |
