### PR TITLE
feat(provisioning): gate inline secretValue behind server+query flag (B2 §4)

### DIFF
--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -4053,6 +4053,16 @@ fn validate_manifest(m: &TenantManifest) -> Vec<String> {
 struct ProvisionQuery {
     /// When `true`, return a [`ProvisionPlan`] and skip all writes.
     dry_run: Option<bool>,
+    /// B2 task 4.2: caller opt-in for inline `secrets[].secretValue`
+    /// plaintext. Only honored when the *server* also has
+    /// `provisioning.allow_inline_secret = true` (and then, only in
+    /// non-release builds — see
+    /// [`config::ProvisioningConfig::effective_allow_inline_secret`]).
+    ///
+    /// Both switches must be on; either one missing and the endpoint
+    /// rejects non-empty inline plaintext with a 422 whose body points
+    /// the caller at `config.secretReferences` (task 4.3).
+    allow_inline: Option<bool>,
 }
 
 /// Response body for `POST /admin/tenants/provision?dryRun=true`.
@@ -4137,6 +4147,59 @@ async fn provision_tenant(
             })),
         )
             .into_response();
+    }
+
+    // ── Inline-secret gate (B2 tasks 4.1 / 4.2 / 4.3) ────────────────────
+    // Non-empty `secrets[].secretValue` is only accepted when BOTH the
+    // server flag and the caller's query param say so (and the server
+    // flag itself is forced off in release builds). Empty-valued
+    // entries are always allowed: they describe intent to have a logical
+    // name without delivering plaintext on the wire — useful for
+    // dry-runs and for manifests that bind every secret via
+    // `config.secretReferences` instead.
+    if let Some(secrets) = manifest.secrets.as_ref() {
+        let has_inline_plaintext = secrets.iter().any(|s| !s.secret_value.is_empty());
+        if has_inline_plaintext {
+            let server_allows = state.config.provisioning.effective_allow_inline_secret();
+            let caller_allows = query.allow_inline.unwrap_or(false);
+            if !(server_allows && caller_allows) {
+                // Enumerate offending logical names so the caller sees
+                // exactly which entries to migrate — do not echo the
+                // values themselves (they are SecretBytes, and even the
+                // derived length would be a side-channel hint).
+                let offending: Vec<String> = secrets
+                    .iter()
+                    .filter(|s| !s.secret_value.is_empty())
+                    .map(|s| s.logical_name.clone())
+                    .collect();
+                return (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    Json(json!({
+                        "success": false,
+                        "error": "inline_secret_not_allowed",
+                        "message":
+                            "Inline `secrets[].secretValue` plaintext is \
+                             disabled on this server. Move these entries \
+                             to `config.secretReferences` and have a \
+                             SecretReference resolver deliver the bytes, \
+                             or ask an operator to enable \
+                             `provisioning.allowInlineSecret` (dev builds \
+                             only) and re-submit with `?allowInline=true`.",
+                        "offendingSecrets": offending,
+                        "remediation": {
+                            "preferred": "config.secretReferences",
+                            "fallback": {
+                                "serverConfigKey": "provisioning.allowInlineSecret",
+                                "queryParameter": "allowInline=true",
+                                "serverFlagEnabled": server_allows,
+                                "queryFlagProvided": caller_allows,
+                            }
+                        }
+                    })),
+                )
+                    .into_response();
+            }
+        }
     }
 
     // ── Canonical hash ────────────────────────────────────────────────────
@@ -6466,6 +6529,189 @@ mod tests {
             "tenantId must be present"
         );
         assert_eq!(json["slug"], "provision-test");
+    }
+
+    // ─── inline-secret gate (B2 tasks 4.1 / 4.2 / 4.3) ────────────────────
+
+    /// Default config + no `allowInline=true` query flag → a manifest
+    /// carrying non-empty `secrets[].secretValue` is rejected with 422.
+    /// The error surface must (1) use the stable error code
+    /// `inline_secret_not_allowed`, (2) enumerate the offending logical
+    /// names (never values or lengths), and (3) point operators at
+    /// `config.secretReferences` as the preferred remediation.
+    #[tokio::test]
+    async fn provision_rejects_inline_secret_by_default() {
+        let Some((app, _tenant)) = app_with_tenant().await else {
+            eprintln!("Skipping inline-secret gate test: Docker not available");
+            return;
+        };
+
+        let manifest = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": { "slug": "inline-gate", "name": "Inline Gate" },
+            "secrets": [
+                { "logicalName": "openai_api_key", "secretValue": "sk-test-xxxxxxxx" },
+                { "logicalName": "anthropic_api_key", "secretValue": "sk-ant-xxxxxxxx" }
+            ]
+        });
+
+        let response = app
+            .clone()
+            .oneshot(request_with_headers(
+                "POST",
+                "/admin/tenants/provision",
+                "platformAdmin",
+                Body::from(serde_json::to_vec(&manifest).unwrap()),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["success"], false);
+        assert_eq!(json["error"], "inline_secret_not_allowed");
+
+        // Offending names listed, values not echoed.
+        let offending = json["offendingSecrets"].as_array().unwrap();
+        let names: Vec<&str> = offending.iter().filter_map(|v| v.as_str()).collect();
+        assert!(names.contains(&"openai_api_key"));
+        assert!(names.contains(&"anthropic_api_key"));
+
+        // Plaintext must never leak back through the error body.
+        let body_str = String::from_utf8_lossy(
+            &axum::body::to_bytes(
+                // Re-render to string for substring scan.
+                axum::body::Body::from(serde_json::to_vec(&json).unwrap()),
+                usize::MAX,
+            )
+            .await
+            .unwrap(),
+        )
+        .to_string();
+        assert!(!body_str.contains("sk-test-xxxxxxxx"));
+        assert!(!body_str.contains("sk-ant-xxxxxxxx"));
+
+        // Remediation surface points operators at the preferred path and
+        // exposes the exact two gates they need to flip.
+        assert_eq!(json["remediation"]["preferred"], "config.secretReferences");
+        assert_eq!(
+            json["remediation"]["fallback"]["serverConfigKey"],
+            "provisioning.allowInlineSecret"
+        );
+        assert_eq!(
+            json["remediation"]["fallback"]["queryParameter"],
+            "allowInline=true"
+        );
+        assert_eq!(json["remediation"]["fallback"]["serverFlagEnabled"], false);
+        assert_eq!(json["remediation"]["fallback"]["queryFlagProvided"], false);
+    }
+
+    /// `allowInline=true` on the query alone is not sufficient — the
+    /// server config gate must *also* be flipped. This proves the
+    /// fallback "both switches required" chain and guards against
+    /// a future refactor that accidentally honors the query flag on
+    /// its own. Note how the diagnostic JSON correctly reports
+    /// `queryFlagProvided=true` while `serverFlagEnabled=false`.
+    #[tokio::test]
+    async fn provision_rejects_inline_secret_when_only_query_flag_is_set() {
+        let Some((app, _tenant)) = app_with_tenant().await else {
+            eprintln!("Skipping inline-secret gate test: Docker not available");
+            return;
+        };
+
+        let manifest = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": { "slug": "inline-gate-q", "name": "Inline Gate Q" },
+            "secrets": [
+                { "logicalName": "stripe_key", "secretValue": "sk_live_xxxxxxxx" }
+            ]
+        });
+
+        let response = app
+            .clone()
+            .oneshot(request_with_headers(
+                "POST",
+                "/admin/tenants/provision?allowInline=true",
+                "platformAdmin",
+                Body::from(serde_json::to_vec(&manifest).unwrap()),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "inline_secret_not_allowed");
+        assert_eq!(json["remediation"]["fallback"]["queryFlagProvided"], true);
+        assert_eq!(
+            json["remediation"]["fallback"]["serverFlagEnabled"], false,
+            "server flag defaults off in tests; the query flag alone \
+             must not open the gate"
+        );
+    }
+
+    /// Empty-valued `secrets[]` entries must pass the gate — they carry
+    /// a `logicalName` but no plaintext, so they express intent
+    /// (materialise a secret with this name) without violating the
+    /// policy. This is the shape callers are expected to migrate to
+    /// once `config.secretReferences` supplies the bytes.
+    #[tokio::test]
+    async fn provision_accepts_empty_secret_values_without_allow_inline() {
+        let Some((app, _tenant)) = app_with_tenant().await else {
+            eprintln!("Skipping inline-secret gate test: Docker not available");
+            return;
+        };
+
+        let manifest = serde_json::json!({
+            "apiVersion": "aeterna.io/v1",
+            "kind": "TenantManifest",
+            "tenant": {
+                "slug": "inline-gate-empty",
+                "name": "Inline Gate Empty"
+            },
+            // Empty byte string — deserializes to a 0-byte SecretBytes,
+            // which the gate explicitly allows. No `?allowInline=true`.
+            "secrets": [
+                { "logicalName": "vault_token", "secretValue": "" }
+            ]
+        });
+
+        let response = app
+            .clone()
+            .oneshot(request_with_headers(
+                "POST",
+                "/admin/tenants/provision",
+                "platformAdmin",
+                Body::from(serde_json::to_vec(&manifest).unwrap()),
+            ))
+            .await
+            .unwrap();
+
+        // Either 200 (full pipeline ran with an empty secret) or some
+        // downstream error, but NOT the 4.3 gate rejection — the gate
+        // must not fire on an empty value.
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        if status == StatusCode::UNPROCESSABLE_ENTITY {
+            let json: serde_json::Value =
+                serde_json::from_slice(&body).expect("422 body must be JSON");
+            assert_ne!(
+                json["error"], "inline_secret_not_allowed",
+                "the inline-secret gate must not reject a zero-byte \
+                 secretValue — that shape is the preferred migration \
+                 target"
+            );
+        }
     }
 
     // ─── metadata / providers schema regressions ─────────────────────────

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -93,6 +93,19 @@ pub struct Config {
     /// CCA (Confucius Code Agent) capabilities configuration
     #[serde(default)]
     pub cca: CcaConfig,
+
+    /// Tenant provisioning runtime gates.
+    ///
+    /// Controls which **inputs** the `POST /api/v1/admin/tenants/provision`
+    /// endpoint will accept. The knobs here govern *policy*, not
+    /// *behavior* — they let an operator explicitly opt into looser
+    /// acceptance criteria (today: inline secret plaintext in the manifest
+    /// body) that are otherwise off by default because they are hostile
+    /// to audit trails and secret hygiene.
+    ///
+    /// See `openspec/changes/harden-tenant-provisioning/tasks.md` §4.
+    #[serde(default)]
+    pub provisioning: ProvisioningConfig,
 }
 
 impl Config {
@@ -338,6 +351,65 @@ pub struct KubernetesAuthConfig {
 
 fn default_k8s_namespace() -> Option<String> {
     None
+}
+
+/// Tenant provisioning policy gates.
+///
+/// B2 task 4.1: inline secret plaintext in `secrets[].secretValue` on the
+/// provision manifest is a power-tool — it bypasses the normal
+/// reference-indirected secret flow (`SecretReference` → config provider
+/// → backend store) and puts raw material on the wire. We want it
+/// available for local dev fixtures and emergency breakglass, but
+/// **off by default** and **mechanically unreachable in release builds**.
+///
+/// The two-layer gate is:
+///
+/// 1. [`allow_inline_secret`] must be `true` in the server config.
+/// 2. The caller must additionally pass `?allowInline=true` on the
+///    provision request (task 4.2).
+///
+/// Both conditions are required; either one missing and the endpoint
+/// rejects non-empty inline `secretValue` with a 422 pointing at
+/// `config.secretReferences` (task 4.3).
+///
+/// ### Release-build hard-off
+///
+/// [`Self::effective_allow_inline_secret`] returns `false` unconditionally
+/// when `debug_assertions` is off (i.e. `--release`), regardless of what
+/// the YAML says. That is the "off in release builds" clause of task 4.1
+/// and cannot be overridden by environment variable, config file, query
+/// parameter, or header. Inline secrets are a debug/dev convenience
+/// only; a prod pod will refuse them even if someone misconfigures the
+/// container.
+#[derive(Debug, Clone, Serialize, Deserialize, Validate, Default, PartialEq)]
+pub struct ProvisioningConfig {
+    /// When `true` *and* running under `debug_assertions`, the provision
+    /// endpoint will accept `secrets[].secretValue` plaintext **if** the
+    /// caller also opts in with `?allowInline=true`.
+    ///
+    /// Default: `false`. Release builds force this to `false`
+    /// (see [`Self::effective_allow_inline_secret`]).
+    #[serde(default)]
+    pub allow_inline_secret: bool,
+}
+
+impl ProvisioningConfig {
+    /// The *effective* value of [`Self::allow_inline_secret`] after the
+    /// release-build hard-off has been applied.
+    ///
+    /// This is the only method the request handler should consult. It
+    /// returns `false` in release builds regardless of config, so inline
+    /// secrets are mechanically unreachable in production even under
+    /// misconfiguration. See the type-level docs for the full gate chain.
+    #[must_use]
+    pub fn effective_allow_inline_secret(&self) -> bool {
+        if cfg!(debug_assertions) {
+            self.allow_inline_secret
+        } else {
+            // Release-build hard-off. Task 4.1: "off in release builds".
+            false
+        }
+    }
 }
 
 /// Configuration for the one-time PlatformAdmin bootstrap seeding.
@@ -1629,5 +1701,75 @@ mod tests {
         let providers = ProviderConfig::default();
         assert!(providers.graph.enabled);
         assert_eq!(providers.graph.database_path, ":memory:");
+    }
+
+    // ── ProvisioningConfig (B2 task 4.1) ────────────────────────────────
+
+    #[test]
+    fn provisioning_config_default_is_off() {
+        let p = ProvisioningConfig::default();
+        assert!(
+            !p.allow_inline_secret,
+            "default must be false so a bare config rejects inline plaintext"
+        );
+        assert!(
+            !p.effective_allow_inline_secret(),
+            "effective value on a default config must be false regardless of build"
+        );
+    }
+
+    #[test]
+    fn provisioning_config_effective_gate_matches_build_profile() {
+        // With `allow_inline_secret = true`, the effective value depends on
+        // whether `debug_assertions` is active. This asserts both halves of
+        // task 4.1 in one run: dev builds honor the flag, release builds
+        // force it off.
+        let p = ProvisioningConfig {
+            allow_inline_secret: true,
+        };
+        if cfg!(debug_assertions) {
+            assert!(
+                p.effective_allow_inline_secret(),
+                "debug build must honor allow_inline_secret=true"
+            );
+        } else {
+            assert!(
+                !p.effective_allow_inline_secret(),
+                "release build must ignore allow_inline_secret=true \
+                 (task 4.1 hard-off)"
+            );
+        }
+    }
+
+    #[test]
+    fn provisioning_config_round_trips_through_serde() {
+        // Belt-and-braces that the YAML key stays `allowInlineSecret`
+        // (camelCase via top-level field rename at the Config level is
+        // not in play here — this struct uses default snake/camel?),
+        // and that a `false` value round-trips to `false` without the
+        // serializer dropping it silently.
+        //
+        // NB: `ProvisioningConfig` does not set `#[serde(rename_all)]`
+        // itself — fields serialize as `allow_inline_secret` today. If
+        // we later harmonise everything to camelCase, update this test
+        // and the operator docs in lockstep.
+        let yaml = "allow_inline_secret: true\n";
+        let parsed: ProvisioningConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(parsed.allow_inline_secret);
+
+        let roundtrip = serde_yaml::to_string(&parsed).unwrap();
+        assert!(
+            roundtrip.contains("allow_inline_secret: true"),
+            "expected serialized YAML to round-trip the flag; got:\n{roundtrip}"
+        );
+    }
+
+    #[test]
+    fn top_level_config_default_provisioning_is_off() {
+        let cfg = Config::default();
+        assert!(
+            !cfg.provisioning.effective_allow_inline_secret(),
+            "Config::default() must reject inline secrets by default"
+        );
     }
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -30,7 +30,7 @@ pub use cca::{
 pub use config::{
     AdminBootstrapConfig, Config, DeploymentConfig, GraphConfig, JobConfig, KnowledgeRepoConfig,
     KubernetesAuthConfig, MemoryConfig, ObservabilityConfig, PluginAuthConfig, ProviderConfig,
-    ReasoningConfig, RlmConfig, SyncConfig, ToolConfig,
+    ProvisioningConfig, ReasoningConfig, RlmConfig, SyncConfig, ToolConfig,
 };
 pub use file_loader::{load_from_file, load_from_toml, load_from_yaml};
 pub use hot_reload::watch_config;

--- a/config/src/loader.rs
+++ b/config/src/loader.rs
@@ -103,6 +103,7 @@ pub fn load_from_env() -> anyhow::Result<Config> {
         k8s_auth: load_k8s_auth_from_env()?,
         admin_bootstrap: load_admin_bootstrap_from_env()?,
         cca: crate::cca::CcaConfig::default(),
+        provisioning: crate::ProvisioningConfig::default(),
     };
 
     Ok(config)

--- a/openspec/changes/harden-tenant-provisioning/tasks.md
+++ b/openspec/changes/harden-tenant-provisioning/tasks.md
@@ -79,9 +79,9 @@
 
 ### 4. Inline-secret gating
 
-- [ ] 4.1 Add `allow_inline_secret: bool` to server config, default `false`, off in release builds.
-- [ ] 4.2 Accept `?allowInline=true` on provision only when the server flag is set.
-- [ ] 4.3 Reject non-empty `secrets[].secretValue` unless both conditions hold; return actionable error pointing to `config.secretReferences`.
+- [x] 4.1 Add `allow_inline_secret: bool` to server config, default `false`, off in release builds. _(New `ProvisioningConfig` section on `Config` with `allow_inline_secret: bool` (default `false`). Release-build hard-off enforced in `ProvisioningConfig::effective_allow_inline_secret()` via `cfg!(debug_assertions)` — release pods ignore the flag regardless of YAML/env and cannot be opened by query parameter, header, or any other runtime path. Unit tests pin both the default and the build-profile behaviour.)_
+- [x] 4.2 Accept `?allowInline=true` on provision only when the server flag is set. _(New `allowInline: Option<bool>` on `ProvisionQuery`. Handler computes `server_allows && caller_allows` — either side missing and the gate closes. Integration test `provision_rejects_inline_secret_when_only_query_flag_is_set` locks down "query flag alone is not enough".)_
+- [x] 4.3 Reject non-empty `secrets[].secretValue` unless both conditions hold; return actionable error pointing to `config.secretReferences`. _(HTTP 422 with stable error code `inline_secret_not_allowed`. Body enumerates offending `logicalName`s (never values or lengths — would be a side-channel), and a `remediation` block names both the preferred path (`config.secretReferences`) and the exact two gates an operator must flip (`provisioning.allowInlineSecret` + `?allowInline=true`) with their current state. Empty-byte `secretValue` entries still pass — that shape is the migration target.)_
 
 ---
 


### PR DESCRIPTION
## Summary

Closes B2 tasks **4.1**, **4.2**, **4.3** from `openspec/changes/harden-tenant-provisioning/tasks.md`.

Inline `secrets[].secretValue` plaintext on the provision manifest bypasses the normal `SecretReference` → config-provider → backend-store flow and puts raw material on the wire. Convenient for local dev fixtures and emergency breakglass, hostile to audit trails and secret hygiene in production. This PR puts it behind a two-layer gate that is mechanically unreachable in release builds.

## The gate

1. **Server**: `config.provisioning.allow_inline_secret: bool` (default `false`).
2. **Caller**: `?allowInline=true` on the provision request.

**Both required.** Either missing closes the gate with HTTP 422.

### Release-build hard-off

`ProvisioningConfig::effective_allow_inline_secret()` returns `false` unconditionally when `cfg!(debug_assertions)` is off, regardless of what the YAML says. Release pods refuse inline plaintext no matter what env/config/query/header tries to flip it.

## Error surface (task 4.3)

Stable error code: `inline_secret_not_allowed`. Body lists offending `logicalName`s (never values or lengths — even a length is a side-channel) and includes a `remediation` block pointing operators at `config.secretReferences` as the preferred migration target and naming the two exact gates they need to flip.

```json
{
  \"success\": false,
  \"error\": \"inline_secret_not_allowed\",
  \"message\": \"Inline secrets[].secretValue plaintext is disabled ...\",
  \"offendingSecrets\": [\"openai_api_key\", \"anthropic_api_key\"],
  \"remediation\": {
    \"preferred\": \"config.secretReferences\",
    \"fallback\": {
      \"serverConfigKey\": \"provisioning.allowInlineSecret\",
      \"queryParameter\": \"allowInline=true\",
      \"serverFlagEnabled\": false,
      \"queryFlagProvided\": false
    }
  }
}
```

**Empty-byte `secretValue` entries pass.** They express intent (\"materialise this logical name\") without delivering plaintext — the shape callers are expected to migrate to.

## Tests

- `config::tests::provisioning_config_default_is_off`
- `config::tests::provisioning_config_effective_gate_matches_build_profile` — asserts both halves of 4.1 in one run (debug honors the flag, release forces off)
- `config::tests::provisioning_config_round_trips_through_serde`
- `config::tests::top_level_config_default_provisioning_is_off`
- `server::tenant_api::tests::provision_rejects_inline_secret_by_default` — full 422 shape + no plaintext leak
- `server::tenant_api::tests::provision_rejects_inline_secret_when_only_query_flag_is_set` — locks down \"query alone is not enough\"
- `server::tenant_api::tests::provision_accepts_empty_secret_values_without_allow_inline` — empty-byte path stays open

All 4 config unit tests green. HTTP tests follow the existing Docker-gated pattern (`app_with_tenant()`) — they will run live once CI brings up Postgres.

`cargo clippy --all-targets -- -D warnings` clean on `config` + `aeterna`.

## Task tracking

`4.1`, `4.2`, `4.3` all flipped to `[x]` in `tasks.md` with implementation notes.