### PR TITLE
feat(cli): standardise exit-code table + HTTP→exit mapping (B2 §9.3/9.4)

### DIFF
--- a/cli/src/commands/admin.rs
+++ b/cli/src/commands/admin.rs
@@ -450,7 +450,7 @@ async fn run_validate(args: AdminValidateArgs) -> anyhow::Result<()> {
     }
 
     if has_errors {
-        std::process::exit(1);
+        crate::exit_code::ExitCode::Usage.exit();
     }
 
     Ok(())
@@ -516,7 +516,7 @@ async fn run_migrate(args: AdminMigrateArgs) -> anyhow::Result<()> {
                             .suggest("aeterna admin migrate up --dry-run")
                             .display();
                     }
-                    std::process::exit(1);
+                    crate::exit_code::ExitCode::Usage.exit();
                 }
             };
             ensure_migration_table(&pool).await?;
@@ -550,7 +550,7 @@ async fn run_migrate(args: AdminMigrateArgs) -> anyhow::Result<()> {
                     .fix("Add --force if you're sure you want to rollback")
                     .suggest("aeterna admin migrate down --force")
                     .display();
-                std::process::exit(1);
+                crate::exit_code::ExitCode::Usage.exit();
             }
 
             if args.json {
@@ -569,14 +569,14 @@ async fn run_migrate(args: AdminMigrateArgs) -> anyhow::Result<()> {
                     .fix("Restore from backup if rollback is required")
                     .display();
             }
-            std::process::exit(1);
+            crate::exit_code::ExitCode::Usage.exit();
         }
         _ => {
             ux_error::UxError::new(format!("Invalid migration direction: {}", args.direction))
                 .fix("Use one of: up, down, status")
                 .suggest("aeterna admin migrate status")
                 .display();
-            std::process::exit(1);
+            crate::exit_code::ExitCode::Usage.exit();
         }
     }
 
@@ -1073,7 +1073,7 @@ async fn run_import(args: AdminImportArgs) -> anyhow::Result<()> {
             .fix("Check the file path is correct")
             .fix("Ensure the file exists and is readable")
             .display();
-        std::process::exit(1);
+        crate::exit_code::ExitCode::Usage.exit();
     }
 
     // Open and validate the archive using the backup crate.
@@ -1284,7 +1284,7 @@ async fn run_backup_validate(args: AdminBackupValidateArgs) -> anyhow::Result<()
             .why("The specified archive file does not exist")
             .fix("Check the file path is correct")
             .display();
-        std::process::exit(1);
+        crate::exit_code::ExitCode::Usage.exit();
     }
 
     let report = validate_archive(&args.archive)?;

--- a/cli/src/commands/check.rs
+++ b/cli/src/commands/check.rs
@@ -178,7 +178,7 @@ pub async fn run(args: CheckArgs) -> Result<()> {
         } else {
             output::error("Validation failed with errors");
         }
-        std::process::exit(1);
+        crate::exit_code::ExitCode::Usage.exit();
     } else {
         output::success("All checks passed");
     }
@@ -238,7 +238,7 @@ async fn run_json(args: CheckArgs, ctx: &context::ResolvedContext) -> Result<()>
     println!("{}", serde_json::to_string_pretty(&output)?);
 
     if has_violations {
-        std::process::exit(1);
+        crate::exit_code::ExitCode::Usage.exit();
     }
 
     Ok(())

--- a/cli/src/commands/govern.rs
+++ b/cli/src/commands/govern.rs
@@ -575,7 +575,7 @@ async fn run_reject(args: GovernRejectArgs) -> anyhow::Result<()> {
                 args.request_id
             ))
             .display();
-        std::process::exit(1);
+        crate::exit_code::ExitCode::Usage.exit();
     }
 
     if !args.yes {
@@ -1093,7 +1093,7 @@ async fn run_roles(args: GovernRolesArgs) -> anyhow::Result<()> {
                 .fix("Use one of: list, assign, revoke")
                 .suggest("aeterna govern roles list")
                 .display();
-            std::process::exit(1);
+            crate::exit_code::ExitCode::Usage.exit();
         }
     }
 

--- a/cli/src/commands/knowledge.rs
+++ b/cli/src/commands/knowledge.rs
@@ -1216,7 +1216,7 @@ async fn run_reject(args: KnowledgeRejectArgs) -> anyhow::Result<()> {
                 args.promotion_id
             ))
             .display();
-        std::process::exit(1);
+        crate::exit_code::ExitCode::Usage.exit();
     }
 
     if !args.yes {

--- a/cli/src/exit_code.rs
+++ b/cli/src/exit_code.rs
@@ -1,0 +1,259 @@
+//! Standard CLI exit-code table for `aeterna`.
+//!
+//! B2 tasks 9.3 + 9.4 of `harden-tenant-provisioning`: before this module
+//! landed, every failing command called `std::process::exit(1)` by hand
+//! and callers could not distinguish "your manifest is bad" from "the
+//! server is down" from "you have no permission". Scripts around the
+//! CLI (CI jobs, GitOps reconcilers, bash wrappers) had nothing to
+//! branch on.
+//!
+//! ### The table
+//!
+//! | Code | Variant                       | Meaning                                                     |
+//! |------|-------------------------------|-------------------------------------------------------------|
+//! | 0    | [`ExitCode::Success`]         | Command completed as requested.                             |
+//! | 1    | [`ExitCode::Usage`]           | Client-side error: bad flags, local validation, schema mismatch, not-found. Retrying with the same input will fail the same way. |
+//! | 2    | [`ExitCode::AuthDenied`]      | Authentication or authorization failed (HTTP 401 / 403). The caller must re-authenticate or be granted access. |
+//! | 3    | [`ExitCode::Conflict`]        | Resource-state conflict (HTTP 409) — the caller's view of the resource is stale. Refresh and retry. |
+//! | 4    | [`ExitCode::ServerTransient`] | Retryable server error (HTTP 502 / 503 / 504 or network-layer transport failure). Safe to retry with backoff. |
+//! | 5    | [`ExitCode::ServerFatal`]     | Non-retryable server error (HTTP 500 / 501 or any other 5xx). Retrying will not help; the server itself is broken. |
+//!
+//! All 4xx codes not in the explicit table above collapse to
+//! [`ExitCode::Usage`] — from the CLI's perspective a 422 validation
+//! failure, a 400 parse failure, and a 404 not-found are all "the
+//! request was rejected, fix the input".
+//!
+//! ### How to exit
+//!
+//! Commands that need to terminate the process with a specific code
+//! should call [`ExitCode::exit`], which converts the enum into its
+//! `u8` discriminant and hands it to `std::process::exit`. This keeps
+//! the integer values out of call sites and makes `grep 'exit(' cli/`
+//! a reliable audit surface.
+//!
+//! ```no_run
+//! use aeterna::exit_code::ExitCode;
+//! // Bad user input — tell the shell it was a usage error, not a crash.
+//! ExitCode::Usage.exit();
+//! ```
+
+use std::process;
+
+/// The complete set of exit codes the `aeterna` CLI emits.
+///
+/// See the module-level documentation for the full table and semantics.
+/// The `u8` discriminant is the exit code itself — do not renumber.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum ExitCode {
+    /// `0` — success.
+    Success = 0,
+    /// `1` — client-side error (bad flags, schema, not-found, local
+    /// validation, unclassified 4xx).
+    Usage = 1,
+    /// `2` — authentication or authorization failure (HTTP 401 / 403).
+    AuthDenied = 2,
+    /// `3` — resource-state conflict (HTTP 409).
+    Conflict = 3,
+    /// `4` — retryable server error (HTTP 502 / 503 / 504 or transport
+    /// failure).
+    ServerTransient = 4,
+    /// `5` — non-retryable server error (HTTP 500 / 501 or other 5xx).
+    ServerFatal = 5,
+}
+
+impl ExitCode {
+    /// Numeric value of this exit code, suitable for handing to
+    /// [`std::process::exit`] or a shell's `$?`.
+    #[must_use]
+    pub const fn code(self) -> i32 {
+        self as i32
+    }
+
+    /// Terminate the current process with this exit code.
+    ///
+    /// Never returns. Prefer this over `std::process::exit(N)` in the
+    /// CLI so the code number stays in one place.
+    pub fn exit(self) -> ! {
+        process::exit(self.code())
+    }
+
+    /// Map an HTTP status code (as a `u16` so callers do not need to
+    /// pull in `reqwest` / `http` here) to the CLI exit code a
+    /// well-behaved consumer should surface.
+    ///
+    /// ### Mapping (B2 task 9.4)
+    ///
+    /// - `1xx` / `2xx` / `3xx` → [`ExitCode::Success`].  Redirects are
+    ///   the HTTP layer's job; by the time a CLI sees one, the request
+    ///   has already been followed or surfaced as an error on its own.
+    /// - `401`, `403` → [`ExitCode::AuthDenied`].
+    /// - `409` → [`ExitCode::Conflict`].
+    /// - any other `4xx` → [`ExitCode::Usage`] (schema, parse, validation,
+    ///   not-found, rate-limit, etc.).
+    /// - `500`, `501` → [`ExitCode::ServerFatal`] — the server cannot
+    ///   fulfil the request; retrying will not help.
+    /// - `502`, `503`, `504` → [`ExitCode::ServerTransient`] — upstream
+    ///   or overload; safe to retry with backoff.
+    /// - any other `5xx` → [`ExitCode::ServerFatal`] — conservative
+    ///   default for unknown server errors so scripts do not
+    ///   hot-loop against a broken backend.
+    /// - anything < 100 or >= 600 → [`ExitCode::ServerFatal`] — a
+    ///   non-HTTP number reaching this function is itself a bug; fail
+    ///   loudly rather than pretend it's fine.
+    #[must_use]
+    pub fn from_http_status(status: u16) -> Self {
+        match status {
+            100..=399 => Self::Success,
+            401 | 403 => Self::AuthDenied,
+            409 => Self::Conflict,
+            400..=499 => Self::Usage,
+            500 | 501 => Self::ServerFatal,
+            502..=504 => Self::ServerTransient,
+            505..=599 => Self::ServerFatal,
+            _ => Self::ServerFatal,
+        }
+    }
+}
+
+impl From<ExitCode> for i32 {
+    fn from(value: ExitCode) -> Self {
+        value.code()
+    }
+}
+
+impl std::fmt::Display for ExitCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.code())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- discriminant stability -----------------------------------------
+
+    #[test]
+    fn discriminants_match_documented_table() {
+        // These values are a public contract with every script that
+        // branches on `$?`. Renumbering silently would break CI
+        // pipelines downstream. Pin every variant.
+        assert_eq!(ExitCode::Success as u8, 0);
+        assert_eq!(ExitCode::Usage as u8, 1);
+        assert_eq!(ExitCode::AuthDenied as u8, 2);
+        assert_eq!(ExitCode::Conflict as u8, 3);
+        assert_eq!(ExitCode::ServerTransient as u8, 4);
+        assert_eq!(ExitCode::ServerFatal as u8, 5);
+    }
+
+    #[test]
+    fn code_matches_discriminant() {
+        for code in [
+            ExitCode::Success,
+            ExitCode::Usage,
+            ExitCode::AuthDenied,
+            ExitCode::Conflict,
+            ExitCode::ServerTransient,
+            ExitCode::ServerFatal,
+        ] {
+            assert_eq!(code.code(), code as i32);
+        }
+    }
+
+    #[test]
+    fn display_renders_as_number() {
+        assert_eq!(format!("{}", ExitCode::Success), "0");
+        assert_eq!(format!("{}", ExitCode::ServerFatal), "5");
+    }
+
+    #[test]
+    fn converts_into_i32() {
+        let n: i32 = ExitCode::Conflict.into();
+        assert_eq!(n, 3);
+    }
+
+    // ---- HTTP status mapping (task 9.4) ---------------------------------
+
+    #[test]
+    fn success_range_maps_to_success() {
+        for s in [100, 101, 200, 201, 204, 301, 302, 304, 399] {
+            assert_eq!(
+                ExitCode::from_http_status(s),
+                ExitCode::Success,
+                "status {s} must map to Success"
+            );
+        }
+    }
+
+    #[test]
+    fn auth_denied_covers_401_and_403_only() {
+        assert_eq!(ExitCode::from_http_status(401), ExitCode::AuthDenied);
+        assert_eq!(ExitCode::from_http_status(403), ExitCode::AuthDenied);
+        // 402 Payment Required and 407 Proxy Authentication Required
+        // are NOT our auth flow; they fall into the general 4xx bucket.
+        assert_eq!(ExitCode::from_http_status(402), ExitCode::Usage);
+        assert_eq!(ExitCode::from_http_status(407), ExitCode::Usage);
+    }
+
+    #[test]
+    fn conflict_maps_only_409() {
+        assert_eq!(ExitCode::from_http_status(409), ExitCode::Conflict);
+        // 410 Gone and 412 Precondition Failed are closely related but
+        // distinct; lumping them into Conflict would lie to scripts
+        // that specifically retry on `$? == 3`.
+        assert_eq!(ExitCode::from_http_status(410), ExitCode::Usage);
+        assert_eq!(ExitCode::from_http_status(412), ExitCode::Usage);
+    }
+
+    #[test]
+    fn other_4xx_maps_to_usage() {
+        for s in [400, 404, 405, 406, 408, 411, 413, 415, 418, 422, 429, 499] {
+            assert_eq!(
+                ExitCode::from_http_status(s),
+                ExitCode::Usage,
+                "status {s} must map to Usage"
+            );
+        }
+    }
+
+    #[test]
+    fn fatal_5xx_and_transient_5xx_split_by_retry_semantics() {
+        // Non-retryable: the server itself rejected the request.
+        assert_eq!(ExitCode::from_http_status(500), ExitCode::ServerFatal);
+        assert_eq!(ExitCode::from_http_status(501), ExitCode::ServerFatal);
+        // Retryable: upstream/overload. A well-behaved script can loop
+        // with backoff on these.
+        assert_eq!(ExitCode::from_http_status(502), ExitCode::ServerTransient);
+        assert_eq!(ExitCode::from_http_status(503), ExitCode::ServerTransient);
+        assert_eq!(ExitCode::from_http_status(504), ExitCode::ServerTransient);
+        // Unknown 5xx: conservative default is Fatal so scripts do not
+        // hot-loop against a broken backend.
+        assert_eq!(ExitCode::from_http_status(505), ExitCode::ServerFatal);
+        assert_eq!(ExitCode::from_http_status(511), ExitCode::ServerFatal);
+        assert_eq!(ExitCode::from_http_status(599), ExitCode::ServerFatal);
+    }
+
+    #[test]
+    fn out_of_range_maps_to_server_fatal() {
+        // A non-HTTP number reaching this function is itself a bug —
+        // fail loudly rather than silently return Success.
+        assert_eq!(ExitCode::from_http_status(0), ExitCode::ServerFatal);
+        assert_eq!(ExitCode::from_http_status(99), ExitCode::ServerFatal);
+        assert_eq!(ExitCode::from_http_status(600), ExitCode::ServerFatal);
+        assert_eq!(ExitCode::from_http_status(u16::MAX), ExitCode::ServerFatal);
+    }
+
+    #[test]
+    fn boundaries_match_the_documented_comment_table() {
+        // One assertion per row of the doc-comment table so a reviewer
+        // can eyeball parity at a glance.
+        assert_eq!(ExitCode::from_http_status(200), ExitCode::Success);
+        assert_eq!(ExitCode::from_http_status(401), ExitCode::AuthDenied);
+        assert_eq!(ExitCode::from_http_status(403), ExitCode::AuthDenied);
+        assert_eq!(ExitCode::from_http_status(409), ExitCode::Conflict);
+        assert_eq!(ExitCode::from_http_status(422), ExitCode::Usage);
+        assert_eq!(ExitCode::from_http_status(500), ExitCode::ServerFatal);
+        assert_eq!(ExitCode::from_http_status(503), ExitCode::ServerTransient);
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3,6 +3,7 @@ mod client;
 pub mod commands;
 mod credentials;
 pub mod env_vars;
+pub mod exit_code;
 mod offline;
 pub mod output;
 mod profile;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,7 @@ mod client;
 mod commands;
 mod credentials;
 pub mod env_vars;
+pub mod exit_code;
 mod offline;
 mod output;
 mod profile;

--- a/openspec/changes/harden-tenant-provisioning/tasks.md
+++ b/openspec/changes/harden-tenant-provisioning/tasks.md
@@ -109,8 +109,8 @@
 
 - [ ] 9.1 Extract `output::Renderer` supporting `table`, `json`, `yaml`, `name`, `jsonpath=<expr>`.
 - [ ] 9.2 Default to `table` on TTY, `json` otherwise, unless `-o` specified.
-- [ ] 9.3 Replace ad-hoc exit codes with a standard table (0/1/2/3/4/5); add `ExitCode` enum + unit tests.
-- [ ] 9.4 Map HTTP status codes to CLI exit codes consistently (401/403 → 2, 409 → 3, 5xx → 4/5, 4xx schema → 1).
+- [x] 9.3 Replace ad-hoc exit codes with a standard table (0/1/2/3/4/5); add `ExitCode` enum + unit tests. _(New `cli::exit_code::ExitCode` with `#[repr(u8)]` discriminants frozen to the documented table: `Success=0`, `Usage=1`, `AuthDenied=2`, `Conflict=3`, `ServerTransient=4`, `ServerFatal=5`. `ExitCode::exit()` centralises the `std::process::exit` call so `grep 'process::exit' cli/` stays a reliable audit surface. All 12 pre-existing `std::process::exit(1)` call sites in `commands/{check,govern,knowledge,admin}.rs` migrated to `ExitCode::Usage.exit()` — semantics preserved, the numbers now live in one place.)_
+- [x] 9.4 Map HTTP status codes to CLI exit codes consistently (401/403 → 2, 409 → 3, 5xx → 4/5, 4xx schema → 1). _(`ExitCode::from_http_status(u16)` takes a raw `u16` so callers do not need to drag `reqwest`/`http` into the exit-code module. Splits 5xx by retry semantics: `500/501` and unknown 5xx → `ServerFatal` (do not hot-loop), `502/503/504` → `ServerTransient` (safe to back off and retry). Explicit negative assertions pin `402`/`407`/`410`/`412` to `Usage` — close relatives of auth/conflict that scripts specifically must NOT confuse. 11 unit tests cover discriminant stability, every documented row of the table, and out-of-range defensive handling.)_
 
 ---
 


### PR DESCRIPTION
## Summary

Closes B2 tasks **9.3** and **9.4** from `openspec/changes/harden-tenant-provisioning/tasks.md`.

Before this PR, every failing command called `std::process::exit(1)` by hand. Scripts around the CLI (CI jobs, GitOps reconcilers, bash wrappers) had nothing to branch on — they couldn't tell \"your manifest is bad\" from \"the server is down\" from \"you have no permission\".

## The table

| Code | Variant | Meaning |
|------|---------|---------|
| 0 | `Success` | Command completed as requested. |
| 1 | `Usage` | Client-side error: bad flags, local validation, schema mismatch, not-found, unclassified 4xx. |
| 2 | `AuthDenied` | HTTP 401 / 403. |
| 3 | `Conflict` | HTTP 409 — refresh and retry. |
| 4 | `ServerTransient` | HTTP 502 / 503 / 504 — retryable. |
| 5 | `ServerFatal` | HTTP 500 / 501 + unknown 5xx — non-retryable. |

**5xx split by retry semantics**, not by number: `500/501` and any unknown 5xx land in `ServerFatal` (do not hot-loop), `502/503/504` land in `ServerTransient` (safe to back off with jitter and retry).

## Key design choices

- **`#[repr(u8)]` + frozen discriminants**: the variant numbers are a public contract with every downstream script that branches on `$?`. A dedicated test pins all six. Renumbering silently would break CI pipelines in consumer repos.
- **`from_http_status` takes `u16`, not `reqwest::StatusCode`**: the exit-code module must stay dependency-free — any caller hands in `.as_u16()`.
- **Negative assertions** on `402` / `407` / `410` / `412`: close relatives of auth/conflict that a naive mapping would confuse. They must route to `Usage`, not AuthDenied or Conflict, so retry scripts stay honest.
- **Out-of-range defensive handling**: status numbers `< 100` or `>= 600` collapse to `ServerFatal`. A non-HTTP number reaching this function is itself a bug; fail loudly rather than pretend it's `Success`.
- **Single point of exit**: `ExitCode::exit()` wraps `std::process::exit`, so `grep 'process::exit' cli/` remains a reliable audit surface after this PR. All 12 existing `std::process::exit(1)` call sites in `commands/{check,govern,knowledge,admin}.rs` migrated to `ExitCode::Usage.exit()` — semantics preserved, integers now in one place.

## Tests

11 unit tests in `cli::exit_code::tests`:

- `discriminants_match_documented_table` — pins all six `as u8` values
- `code_matches_discriminant`
- `display_renders_as_number`
- `converts_into_i32`
- `success_range_maps_to_success` — 1xx/2xx/3xx sweep
- `auth_denied_covers_401_and_403_only` — with 402/407 negative assertions
- `conflict_maps_only_409` — with 410/412 negative assertions
- `other_4xx_maps_to_usage` — 400/404/405/418/422/429 sweep
- `fatal_5xx_and_transient_5xx_split_by_retry_semantics`
- `out_of_range_maps_to_server_fatal`
- `boundaries_match_the_documented_comment_table` — one assert per table row

All green. `cargo clippy --all-targets -- -D warnings` clean on `aeterna`.

## Not in scope

- 9.1 (`output::Renderer` for `table`/`json`/`yaml`/`name`/`jsonpath`) and 9.2 (TTY-aware default) stay for a follow-up PR — they touch a much broader command surface.
- Propagating exit codes through every HTTP call site will come incrementally as individual commands migrate to the new `from_http_status` mapping; the plumbing lands here, the fan-out is deliberate churn deferred.

## Task tracking

`9.3` and `9.4` both flipped to `[x]` in `tasks.md` with implementation notes.