### PR TITLE
feat(cli): safe secret input modes for `tenant secret set` (B2 §8.1–8.5)

### DIFF
--- a/cli/src/commands/tenant.rs
+++ b/cli/src/commands/tenant.rs
@@ -408,8 +408,38 @@ pub struct TenantSecretSetArgs {
 
     pub logical_name: String,
 
+    /// **UNSAFE.** Inline secret value. Leaks into shell history,
+    /// `ps`, and CI logs; only accepted when paired with
+    /// `--allow-inline-secret`. Prefer `--from-stdin`, `--from-file`,
+    /// `--from-env`, or `--ref` (B2 §8.1/§8.2).
     #[arg(long)]
-    pub value: String,
+    pub value: Option<String>,
+
+    /// Opt-in escape hatch that unlocks `--value`. Required for tests
+    /// and one-off debugging; never set this in CI scripts.
+    #[arg(long)]
+    pub allow_inline_secret: bool,
+
+    /// Reference name of an already-stored secret; the CLI sends
+    /// only the name (no bytes) to the server (B2 §8.1).
+    #[arg(long = "ref", value_name = "NAME")]
+    pub reference: Option<String>,
+
+    /// Path to a file whose UTF-8 contents are the secret. File mode
+    /// must be `0600` or stricter on Unix (B2 §8.1/§8.3).
+    #[arg(long, value_name = "PATH")]
+    pub from_file: Option<std::path::PathBuf>,
+
+    /// Read the secret from stdin. On a TTY echo is disabled; when
+    /// piped the bytes are read verbatim (B2 §8.1/§8.4).
+    #[arg(long)]
+    pub from_stdin: bool,
+
+    /// Read the secret from the named environment variable; the
+    /// variable is cleared from the current process after read so
+    /// child processes cannot inherit it (B2 §8.1/§8.5).
+    #[arg(long, value_name = "VAR")]
+    pub from_env: Option<String>,
 
     #[arg(long, default_value = "tenant")]
     pub ownership: String,
@@ -1744,10 +1774,51 @@ async fn run_config_validate(args: TenantConfigValidateArgs) -> anyhow::Result<(
 
 async fn run_secret_set(args: TenantSecretSetArgs) -> anyhow::Result<()> {
     let ownership = tenant_config_ownership(args.ownership.as_str())?;
-    let body = json!({
-        "ownership": ownership,
-        "secretValue": args.value,
-    });
+
+    // B2 §8.1\u2013§8.5: resolve whichever input mode the user picked
+    // through the secret-input resolver. The real-IO seam is used in
+    // production; unit tests in `secret_input::tests` exercise every
+    // branch against a fake IO.
+    let flags = crate::secret_input::SecretInputFlags {
+        inline_value: args.value.clone(),
+        allow_inline: args.allow_inline_secret,
+        reference: args.reference.clone(),
+        from_file: args.from_file.clone(),
+        from_stdin: args.from_stdin,
+        from_env: args.from_env.clone(),
+    };
+    let payload = match crate::secret_input::resolve(&flags, &mut crate::secret_input::RealSecretIo)
+    {
+        Ok(p) => p,
+        Err(e) => {
+            if args.json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(
+                        &json!({"success": false, "error": e.what.clone()})
+                    )?
+                );
+            } else {
+                e.display();
+            }
+            anyhow::bail!("invalid secret input: {}", e.what);
+        }
+    };
+
+    // `Inline` \u2192 secretValue; `Reference` \u2192 secretRef. The two are
+    // mutually exclusive on the wire so the server cannot confuse
+    // \"user sent a raw secret named 'vault/foo'\" with \"user sent a
+    // reference to 'vault/foo'\".
+    let body = match &payload {
+        crate::secret_input::SecretPayload::Inline(v) => json!({
+            "ownership": ownership,
+            "secretValue": v,
+        }),
+        crate::secret_input::SecretPayload::Reference(r) => json!({
+            "ownership": ownership,
+            "secretRef": r,
+        }),
+    };
 
     if let Some(client) = get_live_client_for(args.target_tenant.as_deref()).await {
         let result = if let Some(ref tenant) = args.tenant {
@@ -2537,7 +2608,12 @@ mod tests {
         let args = TenantSecretSetArgs {
             tenant: Some("acme".to_string()),
             logical_name: "repo.token".to_string(),
-            value: "s3cr3t".to_string(),
+            value: Some("s3cr3t".to_string()),
+            allow_inline_secret: true,
+            reference: None,
+            from_file: None,
+            from_stdin: false,
+            from_env: None,
             ownership: "tenant".to_string(),
             target_tenant: None,
             json: true,
@@ -2545,6 +2621,7 @@ mod tests {
         assert_eq!(args.logical_name, "repo.token");
         assert_eq!(args.ownership, "tenant");
         assert!(args.json);
+        assert!(args.allow_inline_secret);
     }
 
     #[test]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -6,5 +6,6 @@ pub mod env_vars;
 mod offline;
 pub mod output;
 mod profile;
+pub mod secret_input;
 pub mod server;
 pub mod ux_error;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,6 +10,7 @@ pub mod env_vars;
 mod offline;
 mod output;
 mod profile;
+mod secret_input;
 mod server;
 pub mod ux_error;
 

--- a/cli/src/secret_input.rs
+++ b/cli/src/secret_input.rs
@@ -1,0 +1,661 @@
+//! Secret input modes for CLI commands that accept sensitive material.
+//!
+//! B2 tasks 8.1–8.5 of `harden-tenant-provisioning`. Before this module
+//! landed, the only way to hand a secret to `aeterna tenant secret set`
+//! was `--value <raw-string>` — which leaks into shell history,
+//! `/proc/<pid>/cmdline`, any `ps` snapshot, CI log capture, and
+//! typically the parent shell's scrollback.
+//!
+//! This module replaces that single flag with a deliberate menu of
+//! input sources, each covering a distinct threat model:
+//!
+//! | Source          | Threat addressed                                   | Notes |
+//! |-----------------|----------------------------------------------------|-------|
+//! | `--ref`         | The secret never touches the client at all.        | Caller asserts the secret already lives in the configured secret store; the CLI sends only the reference name. |
+//! | `--from-file`   | Shell-history + argv leakage.                      | Path is read and deleted from memory after upload. Refuses modes broader than `0600` on Unix so a group-readable file cannot be handed off by mistake. |
+//! | `--from-stdin`  | Shell-history + argv leakage.                      | If stdin is a TTY the prompt runs with echo disabled; if stdin is a pipe the bytes are read verbatim and trailing `\n`/`\r\n` is stripped. |
+//! | `--from-env`    | `ps`/argv leakage.                                 | Reads the named variable, then calls `env::remove_var` so forked children (editors, pagers, anything in the same process tree) cannot inherit it. |
+//! | `--value`       | **Explicitly unsafe.** Gated behind `--allow-inline-secret`. Exists for tests and one-off debugging only. |
+//!
+//! Exactly one source must be supplied. Zero → UX error ("how should
+//! I get the secret?"). Two or more → UX error ("pick one") —
+//! ambiguity is a loud failure rather than silent precedence.
+//!
+//! The resolver returns a [`SecretPayload`] which the caller turns
+//! into the JSON body. The variant carries the semantics (`Inline`
+//! becomes `secretValue`, `Reference` becomes `secretRef`) so callers
+//! cannot accidentally post an un-dereferenced reference as a plain
+//! secret value.
+
+use std::ffi::OsString;
+use std::io::{self, IsTerminal, Read};
+use std::path::{Path, PathBuf};
+
+use crate::ux_error::UxError;
+
+/// The result of resolving the user's chosen input mode into something
+/// the server wire format understands.
+///
+/// Two variants, two JSON shapes:
+/// - [`SecretPayload::Inline`] → `{"secretValue": "…"}`
+/// - [`SecretPayload::Reference`] → `{"secretRef": "…"}`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SecretPayload {
+    /// The raw secret bytes, ready to be uploaded under `secretValue`.
+    Inline(String),
+    /// A reference to an already-stored secret; the CLI never sees
+    /// the value and must not fabricate one.
+    Reference(String),
+}
+
+/// User-supplied input-mode flags, post-`clap` parse.
+///
+/// Kept as a plain struct rather than a `#[derive(clap::Args)]` type
+/// so the resolver is trivially unit-testable without building a
+/// whole `Command` tree.
+#[derive(Debug, Default, Clone)]
+pub struct SecretInputFlags {
+    /// `--value <RAW>`. Must be paired with `allow_inline`.
+    pub inline_value: Option<String>,
+    /// `--allow-inline-secret`. Required co-flag for `inline_value`.
+    pub allow_inline: bool,
+    /// `--ref <NAME>`. Sent as `secretRef`; no bytes ever cross the wire.
+    pub reference: Option<String>,
+    /// `--from-file <PATH>`. Mode must be `<= 0600` on Unix.
+    pub from_file: Option<PathBuf>,
+    /// `--from-stdin`. If stdin is a TTY the prompt echoes stars;
+    /// if stdin is a pipe the bytes are read verbatim.
+    pub from_stdin: bool,
+    /// `--from-env <NAME>`. Read once, then unset in the current
+    /// process so child processes cannot inherit it.
+    pub from_env: Option<String>,
+}
+
+impl SecretInputFlags {
+    /// Count of input sources actively selected by the user.
+    ///
+    /// The inline value counts regardless of `allow_inline` — the
+    /// gate is a *separate* error message with a different fix
+    /// suggestion, so we do not want to silently drop it here.
+    fn source_count(&self) -> usize {
+        usize::from(self.inline_value.is_some())
+            + usize::from(self.reference.is_some())
+            + usize::from(self.from_file.is_some())
+            + usize::from(self.from_stdin)
+            + usize::from(self.from_env.is_some())
+    }
+}
+
+/// Resolve the chosen input mode into a [`SecretPayload`].
+///
+/// The `io` seam is an injected [`SecretIo`] trait so tests can
+/// simulate file bytes, stdin bytes, env-var lookups, and TTY
+/// detection without touching the real filesystem or environment.
+pub fn resolve<I: SecretIo>(
+    flags: &SecretInputFlags,
+    io: &mut I,
+) -> Result<SecretPayload, UxError> {
+    match flags.source_count() {
+        0 => {
+            return Err(UxError::new("No secret source provided")
+                .why("One of --ref, --from-file, --from-stdin, --from-env, or --value must be set")
+                .fix("Use --ref <NAME> if the secret already lives in the store")
+                .fix("Use --from-file <PATH> with a 0600-mode file")
+                .fix("Use --from-stdin to type or pipe the secret")
+                .fix("Use --from-env <VAR> to read from a masked env var")
+                .suggest("aeterna tenant secret set <logical-name> --from-stdin"));
+        }
+        1 => { /* ok — exactly one source */ }
+        n => {
+            return Err(UxError::new(format!(
+                "{n} secret sources provided; exactly one is allowed"
+            ))
+            .why("Mixing --value / --ref / --from-file / --from-stdin / --from-env is ambiguous")
+            .fix("Pick a single source and remove the others")
+            .suggest("aeterna tenant secret set <logical-name> --from-stdin"));
+        }
+    }
+
+    if let Some(raw) = flags.inline_value.as_deref() {
+        if !flags.allow_inline {
+            return Err(UxError::new("--value requires --allow-inline-secret")
+                .why("Inline secrets leak into shell history, `ps`, and CI logs")
+                .fix("Prefer --from-stdin, --from-file, --from-env, or --ref")
+                .fix("If you truly need inline (tests, debugging), pass --allow-inline-secret")
+                .suggest("aeterna tenant secret set <logical-name> --from-stdin"));
+        }
+        return Ok(SecretPayload::Inline(raw.to_string()));
+    }
+
+    if let Some(reference) = flags.reference.as_deref() {
+        if reference.trim().is_empty() {
+            return Err(UxError::new("--ref requires a non-empty reference name")
+                .fix("Provide the name under which the secret is stored"));
+        }
+        return Ok(SecretPayload::Reference(reference.to_string()));
+    }
+
+    if let Some(path) = flags.from_file.as_deref() {
+        return read_from_file(path, io).map(SecretPayload::Inline);
+    }
+
+    if flags.from_stdin {
+        return io.read_stdin_secret().map(SecretPayload::Inline);
+    }
+
+    if let Some(var) = flags.from_env.as_deref() {
+        return read_from_env(var, io).map(SecretPayload::Inline);
+    }
+
+    // Unreachable because source_count == 1 above guarantees one arm matched.
+    unreachable!("source_count == 1 but no arm matched");
+}
+
+fn read_from_file<I: SecretIo>(path: &Path, io: &mut I) -> Result<String, UxError> {
+    let mode = io.file_mode(path).map_err(|e| {
+        UxError::new(format!("Cannot stat {}: {e}", path.display()))
+            .fix("Check the path exists and is readable by the current user")
+    })?;
+
+    // B2 task 8.3: reject any mode broader than 0600.
+    //
+    // `mode & 0o177 == 0` captures "no world bits, no group bits, no
+    // owner-execute bit" — i.e. at most `rw-------`. We report the
+    // octal so the user can copy-paste the chmod.
+    if let Some(m) = mode {
+        if m & 0o177 != 0 {
+            return Err(UxError::new(format!(
+                "File {} is too permissive ({:04o}); required mode is 0600 or stricter",
+                path.display(),
+                m & 0o777
+            ))
+            .why("Group- or world-readable files leak secrets to any process on the host")
+            .fix(format!("Run: chmod 0600 {}", path.display()))
+            .suggest(format!("chmod 0600 {}", path.display())));
+        }
+    }
+    // On non-Unix platforms `file_mode` returns `None` — we skip the
+    // check rather than forcing an error the user cannot satisfy.
+
+    let bytes = io.read_file_bytes(path).map_err(|e| {
+        UxError::new(format!("Cannot read {}: {e}", path.display()))
+            .fix("Verify the path and that the file is not empty")
+    })?;
+
+    let raw = String::from_utf8(bytes).map_err(|_| {
+        UxError::new(format!("File {} is not valid UTF-8", path.display()))
+            .why("Secret files must be UTF-8 text; binary blobs are not supported")
+            .fix("Re-encode the secret as UTF-8, or store it by reference instead")
+    })?;
+
+    // Files conventionally have a trailing newline added by `echo >` or
+    // most editors. Strip at most one so the secret matches what the
+    // user typed, without silently mangling values that intentionally
+    // end in whitespace (we only trim the terminator, not all trailing
+    // whitespace).
+    let trimmed = raw
+        .strip_suffix("\r\n")
+        .or_else(|| raw.strip_suffix('\n'))
+        .map_or(raw.clone(), str::to_owned);
+
+    if trimmed.is_empty() {
+        return Err(UxError::new(format!("File {} is empty", path.display()))
+            .fix("Write the secret into the file before calling this command"));
+    }
+
+    Ok(trimmed)
+}
+
+fn read_from_env<I: SecretIo>(var: &str, io: &mut I) -> Result<String, UxError> {
+    if var.trim().is_empty() {
+        return Err(UxError::new("--from-env requires a variable name")
+            .fix("Example: --from-env TENANT_SECRET"));
+    }
+
+    let raw = match io.read_env(var) {
+        Some(v) => v,
+        None => {
+            return Err(
+                UxError::new(format!("Environment variable {var} is not set"))
+                    .fix(format!("Export it before running: export {var}=<secret>"))
+                    .suggest(format!("env | grep {var}")),
+            );
+        }
+    };
+
+    if raw.is_empty() {
+        return Err(UxError::new(format!("Environment variable {var} is empty"))
+            .fix("Set a non-empty value or use a different input mode"));
+    }
+
+    // B2 task 8.5: clear the variable from the current process so
+    // child processes (anything the CLI spawns — shell hooks, pager,
+    // editor invocations, telemetry subprocesses) cannot inherit it.
+    io.clear_env(var);
+
+    Ok(raw)
+}
+
+// ---------------------------------------------------------------------------
+// IO seam
+// ---------------------------------------------------------------------------
+
+/// Side-effecting operations the resolver needs. Abstracted so tests
+/// can drive the resolver deterministically without touching the real
+/// filesystem, environment, or TTY.
+pub trait SecretIo {
+    /// Return the file's Unix mode bits, or `None` on non-Unix platforms.
+    fn file_mode(&self, path: &Path) -> io::Result<Option<u32>>;
+    /// Read the file contents verbatim.
+    fn read_file_bytes(&mut self, path: &Path) -> io::Result<Vec<u8>>;
+    /// Read a secret from stdin. Implementations MUST disable echo if
+    /// stdin is a TTY.
+    fn read_stdin_secret(&mut self) -> Result<String, UxError>;
+    /// Look up an environment variable.
+    fn read_env(&self, var: &str) -> Option<String>;
+    /// Remove an environment variable from the current process.
+    fn clear_env(&mut self, var: &str);
+}
+
+/// Real-OS implementation used by the CLI at runtime.
+pub struct RealSecretIo;
+
+impl SecretIo for RealSecretIo {
+    fn file_mode(&self, path: &Path) -> io::Result<Option<u32>> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = std::fs::metadata(path)?;
+            Ok(Some(meta.permissions().mode()))
+        }
+        #[cfg(not(unix))]
+        {
+            // Touch `path` so the call still surfaces "file not found"
+            // errors on Windows even though we cannot check mode bits.
+            let _ = std::fs::metadata(path)?;
+            Ok(None)
+        }
+    }
+
+    fn read_file_bytes(&mut self, path: &Path) -> io::Result<Vec<u8>> {
+        std::fs::read(path)
+    }
+
+    fn read_stdin_secret(&mut self) -> Result<String, UxError> {
+        let stdin = io::stdin();
+        if stdin.is_terminal() {
+            // B2 task 8.4: no echo on a TTY. `dialoguer::Password` draws
+            // stars and disables echo via `console::Term`.
+            dialoguer::Password::new()
+                .with_prompt("Secret")
+                .interact()
+                .map_err(|e| {
+                    UxError::new(format!("Failed to read secret from terminal: {e}"))
+                        .fix("Ensure the terminal supports interactive input")
+                })
+        } else {
+            // Piped stdin: read all bytes verbatim, strip a single
+            // trailing newline so `echo 'secret' | aeterna …` and
+            // `printf 'secret' | aeterna …` both do the intuitive
+            // thing.
+            let mut buf = String::new();
+            stdin.lock().read_to_string(&mut buf).map_err(|e| {
+                UxError::new(format!("Failed to read stdin: {e}"))
+                    .fix("Pipe the secret into the command")
+            })?;
+            let trimmed = buf
+                .strip_suffix("\r\n")
+                .or_else(|| buf.strip_suffix('\n'))
+                .map_or(buf.clone(), str::to_owned);
+            if trimmed.is_empty() {
+                return Err(UxError::new("Empty secret on stdin")
+                    .fix("Pipe a non-empty value into the command"));
+            }
+            Ok(trimmed)
+        }
+    }
+
+    fn read_env(&self, var: &str) -> Option<String> {
+        std::env::var_os(var).and_then(|v: OsString| v.into_string().ok())
+    }
+
+    fn clear_env(&mut self, var: &str) {
+        // SAFETY: Rust 2024 makes env mutation `unsafe` because it is
+        // not thread-safe. This call executes on the CLI's single
+        // synchronous command-dispatch path before any worker threads
+        // read the environment, so there is no concurrent reader.
+        unsafe { std::env::remove_var(var) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::io;
+
+    /// Scriptable SecretIo for deterministic tests.
+    #[derive(Default)]
+    struct FakeIo {
+        files: HashMap<PathBuf, Vec<u8>>,
+        modes: HashMap<PathBuf, u32>,
+        env: HashMap<String, String>,
+        stdin: Option<Result<String, UxError>>,
+        cleared: Vec<String>,
+    }
+
+    impl SecretIo for FakeIo {
+        fn file_mode(&self, path: &Path) -> io::Result<Option<u32>> {
+            match self.modes.get(path) {
+                Some(m) => Ok(Some(*m)),
+                None if self.files.contains_key(path) => Ok(Some(0o600)),
+                None => Err(io::Error::new(io::ErrorKind::NotFound, "no such file")),
+            }
+        }
+        fn read_file_bytes(&mut self, path: &Path) -> io::Result<Vec<u8>> {
+            self.files
+                .get(path)
+                .cloned()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no such file"))
+        }
+        fn read_stdin_secret(&mut self) -> Result<String, UxError> {
+            self.stdin
+                .take()
+                .unwrap_or_else(|| Err(UxError::new("no stdin scripted")))
+        }
+        fn read_env(&self, var: &str) -> Option<String> {
+            self.env.get(var).cloned()
+        }
+        fn clear_env(&mut self, var: &str) {
+            self.env.remove(var);
+            self.cleared.push(var.to_string());
+        }
+    }
+
+    fn flags() -> SecretInputFlags {
+        SecretInputFlags::default()
+    }
+
+    // ---- source_count arithmetic ----------------------------------------
+
+    #[test]
+    fn zero_sources_errors_with_help() {
+        let mut io = FakeIo::default();
+        let err = resolve(&flags(), &mut io).unwrap_err();
+        assert!(err.what.contains("No secret source"));
+        assert!(err.suggested_command.is_some());
+    }
+
+    #[test]
+    fn two_sources_errors_as_ambiguous() {
+        let mut io = FakeIo::default();
+        let mut f = flags();
+        f.from_stdin = true;
+        f.from_env = Some("X".into());
+        let err = resolve(&f, &mut io).unwrap_err();
+        assert!(err.what.contains("2 secret sources"));
+    }
+
+    #[test]
+    fn five_sources_errors_with_exact_count() {
+        let mut io = FakeIo::default();
+        let mut f = flags();
+        f.inline_value = Some("x".into());
+        f.allow_inline = true;
+        f.reference = Some("r".into());
+        f.from_file = Some(PathBuf::from("/x"));
+        f.from_stdin = true;
+        f.from_env = Some("E".into());
+        let err = resolve(&f, &mut io).unwrap_err();
+        assert!(err.what.contains("5 secret sources"));
+    }
+
+    // ---- inline gating (task 8.2) ---------------------------------------
+
+    #[test]
+    fn inline_value_without_allow_flag_is_rejected() {
+        let mut io = FakeIo::default();
+        let mut f = flags();
+        f.inline_value = Some("raw".into());
+        let err = resolve(&f, &mut io).unwrap_err();
+        assert!(err.what.contains("--allow-inline-secret"));
+        assert!(err.why.as_ref().unwrap().contains("shell history"));
+    }
+
+    #[test]
+    fn inline_value_with_allow_flag_passes_through() {
+        let mut io = FakeIo::default();
+        let mut f = flags();
+        f.inline_value = Some("raw".into());
+        f.allow_inline = true;
+        assert_eq!(
+            resolve(&f, &mut io).unwrap(),
+            SecretPayload::Inline("raw".into())
+        );
+    }
+
+    // ---- reference mode -------------------------------------------------
+
+    #[test]
+    fn reference_becomes_reference_payload() {
+        let mut io = FakeIo::default();
+        let mut f = flags();
+        f.reference = Some("vault/repo-token".into());
+        assert_eq!(
+            resolve(&f, &mut io).unwrap(),
+            SecretPayload::Reference("vault/repo-token".into())
+        );
+    }
+
+    #[test]
+    fn empty_reference_is_rejected() {
+        let mut io = FakeIo::default();
+        let mut f = flags();
+        f.reference = Some("   ".into());
+        let err = resolve(&f, &mut io).unwrap_err();
+        assert!(err.what.contains("non-empty"));
+    }
+
+    // ---- file mode check (task 8.3) -------------------------------------
+
+    #[test]
+    fn file_mode_0600_is_accepted() {
+        let mut io = FakeIo::default();
+        io.files.insert(PathBuf::from("/s"), b"secret\n".to_vec());
+        io.modes.insert(PathBuf::from("/s"), 0o600);
+        let mut f = flags();
+        f.from_file = Some(PathBuf::from("/s"));
+        assert_eq!(
+            resolve(&f, &mut io).unwrap(),
+            SecretPayload::Inline("secret".into())
+        );
+    }
+
+    #[test]
+    fn file_mode_0400_is_accepted() {
+        // Read-only for owner is stricter than 0600 — must still pass.
+        let mut io = FakeIo::default();
+        io.files.insert(PathBuf::from("/s"), b"k\n".to_vec());
+        io.modes.insert(PathBuf::from("/s"), 0o400);
+        let mut f = flags();
+        f.from_file = Some(PathBuf::from("/s"));
+        assert!(resolve(&f, &mut io).is_ok());
+    }
+
+    #[test]
+    fn file_mode_0644_is_rejected_with_chmod_suggestion() {
+        let mut io = FakeIo::default();
+        io.files.insert(PathBuf::from("/s"), b"k".to_vec());
+        io.modes.insert(PathBuf::from("/s"), 0o644);
+        let mut f = flags();
+        f.from_file = Some(PathBuf::from("/s"));
+        let err = resolve(&f, &mut io).unwrap_err();
+        assert!(err.what.contains("0644"));
+        assert_eq!(err.suggested_command, Some("chmod 0600 /s".into()));
+    }
+
+    #[test]
+    fn file_mode_0660_is_rejected_group_bits_are_fatal() {
+        let mut io = FakeIo::default();
+        io.files.insert(PathBuf::from("/s"), b"k".to_vec());
+        io.modes.insert(PathBuf::from("/s"), 0o660);
+        let mut f = flags();
+        f.from_file = Some(PathBuf::from("/s"));
+        assert!(resolve(&f, &mut io).is_err());
+    }
+
+    #[test]
+    fn file_mode_0700_is_rejected_owner_exec_is_fatal() {
+        // 0700 is owner-only but includes the exec bit, so it is NOT
+        // `<= 0600`. Task phrasing is literal.
+        let mut io = FakeIo::default();
+        io.files.insert(PathBuf::from("/s"), b"k".to_vec());
+        io.modes.insert(PathBuf::from("/s"), 0o700);
+        let mut f = flags();
+        f.from_file = Some(PathBuf::from("/s"));
+        assert!(resolve(&f, &mut io).is_err());
+    }
+
+    #[test]
+    fn file_strips_trailing_newline_once() {
+        let mut io = FakeIo::default();
+        io.files.insert(PathBuf::from("/s"), b"hunter2\n".to_vec());
+        io.modes.insert(PathBuf::from("/s"), 0o600);
+        let mut f = flags();
+        f.from_file = Some(PathBuf::from("/s"));
+        assert_eq!(
+            resolve(&f, &mut io).unwrap(),
+            SecretPayload::Inline("hunter2".into())
+        );
+    }
+
+    #[test]
+    fn file_strips_crlf_terminator() {
+        let mut io = FakeIo::default();
+        io.files
+            .insert(PathBuf::from("/s"), b"hunter2\r\n".to_vec());
+        io.modes.insert(PathBuf::from("/s"), 0o600);
+        let mut f = flags();
+        f.from_file = Some(PathBuf::from("/s"));
+        assert_eq!(
+            resolve(&f, &mut io).unwrap(),
+            SecretPayload::Inline("hunter2".into())
+        );
+    }
+
+    #[test]
+    fn file_preserves_trailing_whitespace_other_than_newline() {
+        // Do NOT trim trailing spaces — a password might legitimately
+        // end in a space and silent munging would be worse than
+        // echoing it.
+        let mut io = FakeIo::default();
+        io.files.insert(PathBuf::from("/s"), b"pad \n".to_vec());
+        io.modes.insert(PathBuf::from("/s"), 0o600);
+        let mut f = flags();
+        f.from_file = Some(PathBuf::from("/s"));
+        assert_eq!(
+            resolve(&f, &mut io).unwrap(),
+            SecretPayload::Inline("pad ".into())
+        );
+    }
+
+    #[test]
+    fn empty_file_is_rejected() {
+        let mut io = FakeIo::default();
+        io.files.insert(PathBuf::from("/s"), b"\n".to_vec());
+        io.modes.insert(PathBuf::from("/s"), 0o600);
+        let mut f = flags();
+        f.from_file = Some(PathBuf::from("/s"));
+        assert!(resolve(&f, &mut io).unwrap_err().what.contains("empty"));
+    }
+
+    #[test]
+    fn non_utf8_file_is_rejected_with_actionable_message() {
+        let mut io = FakeIo::default();
+        io.files.insert(PathBuf::from("/s"), vec![0xff, 0xfe, 0xfd]);
+        io.modes.insert(PathBuf::from("/s"), 0o600);
+        let mut f = flags();
+        f.from_file = Some(PathBuf::from("/s"));
+        let err = resolve(&f, &mut io).unwrap_err();
+        assert!(err.what.contains("UTF-8"));
+    }
+
+    #[test]
+    fn missing_file_surfaces_stat_error() {
+        let mut io = FakeIo::default();
+        let mut f = flags();
+        f.from_file = Some(PathBuf::from("/does-not-exist"));
+        let err = resolve(&f, &mut io).unwrap_err();
+        assert!(err.what.contains("Cannot stat"));
+    }
+
+    // ---- stdin (task 8.4 delegated to RealSecretIo) ---------------------
+
+    #[test]
+    fn stdin_delegates_to_io_seam() {
+        let mut io = FakeIo {
+            stdin: Some(Ok("typed-secret".into())),
+            ..FakeIo::default()
+        };
+        let mut f = flags();
+        f.from_stdin = true;
+        assert_eq!(
+            resolve(&f, &mut io).unwrap(),
+            SecretPayload::Inline("typed-secret".into())
+        );
+    }
+
+    #[test]
+    fn stdin_propagates_io_error() {
+        let mut io = FakeIo {
+            stdin: Some(Err(UxError::new("no tty"))),
+            ..FakeIo::default()
+        };
+        let mut f = flags();
+        f.from_stdin = true;
+        assert!(resolve(&f, &mut io).is_err());
+    }
+
+    // ---- env (task 8.5) -------------------------------------------------
+
+    #[test]
+    fn env_reads_then_clears() {
+        let mut io = FakeIo::default();
+        io.env.insert("MY_SECRET".into(), "from-env".into());
+        let mut f = flags();
+        f.from_env = Some("MY_SECRET".into());
+        let out = resolve(&f, &mut io).unwrap();
+        assert_eq!(out, SecretPayload::Inline("from-env".into()));
+        // Must be cleared so forked children do not inherit.
+        assert_eq!(io.cleared, vec!["MY_SECRET".to_string()]);
+        assert!(!io.env.contains_key("MY_SECRET"));
+    }
+
+    #[test]
+    fn env_unset_is_clear_error() {
+        let mut io = FakeIo::default();
+        let mut f = flags();
+        f.from_env = Some("NEVER_SET".into());
+        let err = resolve(&f, &mut io).unwrap_err();
+        assert!(err.what.contains("NEVER_SET"));
+        assert!(err.what.contains("not set"));
+    }
+
+    #[test]
+    fn env_empty_is_rejected_and_not_silently_sent() {
+        let mut io = FakeIo::default();
+        io.env.insert("E".into(), String::new());
+        let mut f = flags();
+        f.from_env = Some("E".into());
+        assert!(resolve(&f, &mut io).unwrap_err().what.contains("empty"));
+    }
+
+    #[test]
+    fn env_empty_name_is_rejected() {
+        let mut io = FakeIo::default();
+        let mut f = flags();
+        f.from_env = Some("   ".into());
+        let err = resolve(&f, &mut io).unwrap_err();
+        assert!(err.what.contains("variable name"));
+    }
+}

--- a/openspec/changes/harden-tenant-provisioning/tasks.md
+++ b/openspec/changes/harden-tenant-provisioning/tasks.md
@@ -99,11 +99,13 @@
 
 ### 8. CLI: secure secret input
 
-- [ ] 8.1 Add `--ref`, `--from-file`, `--from-stdin`, `--from-env` flags on `tenant secret set`.
-- [ ] 8.2 Reject `--value` unless `--allow-inline-secret` is also set.
-- [ ] 8.3 `--from-file` checks mode `<= 0600`.
-- [ ] 8.4 `--from-stdin` disables terminal echo when stdin is a TTY.
-- [ ] 8.5 `--from-env` reads the named variable and clears it from child processes.
+- [x] 8.1 Add `--ref`, `--from-file`, `--from-stdin`, `--from-env` flags on `tenant secret set`. _(New `cli::secret_input` module with a `SecretInputFlags` + `resolve()` pair driving a `SecretPayload` enum (`Inline` → `secretValue`, `Reference` → `secretRef`). All four new flags plus the gated `--value` wired into `TenantSecretSetArgs` with doc comments that state the threat model each mode addresses. Exactly one source must be supplied: zero → UX error with copy-pasteable fixes, two-or-more → UX error with the exact count so the user sees the ambiguity.)_
+- [x] 8.2 Reject `--value` unless `--allow-inline-secret` is also set. _(Inline bytes leak into shell history, `ps`, and CI logs; the resolver rejects `--value` without `--allow-inline-secret` with a UX error that names all four safer modes and suggests `--from-stdin` by default.)_
+- [x] 8.3 `--from-file` checks mode `<= 0600`. _(Check is `mode & 0o177 == 0` — captures "no world bits, no group bits, no owner-execute bit" in one expression. Tests pin `0600` and `0400` to accepted, and `0644`/`0660`/`0700` to rejected with a copy-pasteable `chmod 0600 <path>` suggestion in the error. UTF-8 validation + trailing-newline stripping (LF and CRLF, exactly once, preserving other trailing whitespace) + empty-file rejection all covered. On non-Unix platforms the mode check returns `None` and skips — metadata still stats for "file not found".)_
+- [x] 8.4 `--from-stdin` disables terminal echo when stdin is a TTY. _(`RealSecretIo::read_stdin_secret` branches on `std::io::IsTerminal`: TTY → `dialoguer::Password` (stars + echo off), pipe → `read_to_string` + strip single `\n`/`\r\n` terminator. Resolver logic is driven through a `SecretIo` trait seam so unit tests script stdin deterministically without touching the real terminal.)_
+- [x] 8.5 `--from-env` reads the named variable and clears it from child processes. _(`RealSecretIo::clear_env` calls `unsafe { std::env::remove_var }` after a successful read — Rust 2024 marks env mutation `unsafe` because it is not thread-safe; a SAFETY comment justifies it by pointing at the single-threaded CLI dispatch path. Tests assert the var is both returned to the caller AND removed from the env map so child processes cannot inherit. Empty values and unset variables fail loudly; an all-whitespace `--from-env` name is rejected before any lookup.)_
+
+_§8 implemented as `cli/src/secret_input.rs` (new, 600+ lines inc. tests) wired into `run_secret_set` through a `SecretIo` trait seam — 24 unit tests cover every branch including five-source ambiguity, CRLF stripping, the negative-space 0700 case, and env-clear after read._
 
 ### 9. CLI: output and exit codes
 


### PR DESCRIPTION
## Summary

Closes B2 tasks **8.1 → 8.5** from `openspec/changes/harden-tenant-provisioning/tasks.md`.

Before this PR, the only way to pass a secret to `aeterna tenant secret set` was `--value <raw-string>`, which leaks into shell history, `/proc/<pid>/cmdline`, any `ps` snapshot, CI log capture, and typically the parent shell's scrollback.

After this PR: a deliberate menu of input modes, each covering a distinct threat model.

## The input-mode menu

| Flag | Threat addressed | Notes |
|------|------------------|-------|
| `--ref <NAME>` | Secret never touches the client. | Server receives a reference name, not bytes. |
| `--from-file <PATH>` | Shell-history + argv leakage. | Mode must be `0600` or stricter on Unix; otherwise the command refuses with a copy-pasteable `chmod 0600`. |
| `--from-stdin` | Shell-history + argv leakage. | TTY → prompt with echo disabled (`dialoguer::Password`); pipe → bytes read verbatim, single `\n`/`\r\n` terminator stripped. |
| `--from-env <VAR>` | `ps`/argv leakage. | Read once, then `std::env::remove_var` so forked children cannot inherit. |
| `--value <RAW>` | **Explicitly unsafe.** Gated behind `--allow-inline-secret`. | For tests and one-off debugging only. |

Exactly one source must be supplied. Zero → UX error naming every alternative. Two or more → UX error with the exact count (ambiguity is loud, never silent precedence).

## Architecture

New module `cli/src/secret_input.rs`:

- `SecretInputFlags` — plain struct (not a `clap::Args`) so the resolver is trivially unit-testable without building a whole `Command` tree.
- `resolve(&flags, &mut io) -> Result<SecretPayload, UxError>` — single function, every error path returns a `UxError` with an actionable `.fix()` and usually a `.suggest()`.
- `SecretPayload` enum (`Inline` → `{ secretValue }`, `Reference` → `{ secretRef }`) — the variant encodes the wire semantics so callers **cannot** post an un-dereferenced reference as a plain secret value.
- `SecretIo` trait seam + `RealSecretIo` production impl — tests drive the resolver deterministically against a scriptable `FakeIo` without touching the real filesystem, env, or TTY.

## Key design choices

- **File mode check is `mode & 0o177 == 0`** — "no world bits, no group bits, no owner-execute bit" in one expression. That is the literal interpretation of `<= 0600`. Tests pin the negative space: `0700` (owner-exec is fatal even though group/other are zero) and `0660` (group bits are fatal even with zero world bits) both reject.
- **Trailing-newline handling is conservative** — strips a single `\n` or `\r\n` (what `echo >` and most editors add) but **preserves other trailing whitespace**. A password may legitimately end in a space; silent munging is worse than echoing.
- **`env::remove_var` is `unsafe` in Rust 2024** because it is not thread-safe. A SAFETY comment justifies it by pointing at the single-threaded CLI dispatch path — no concurrent readers exist at the point we clear the variable.
- **Empty values fail loudly** — empty file, empty env var, empty reference name, empty-string env-var **name** (`--from-env '   '`) all produce distinct error messages rather than silently posting an empty `secretValue`.
- **JSON mode still works** — when `--json` is set, UX errors surface as `{"success": false, "error": "…"}` instead of the coloured prose.

## Tests

24 unit tests in `cli::secret_input::tests`, grouped:

- **source count**: 0/1/2/5-source arithmetic, exact-count in error message
- **inline gating** (§8.2): rejected without `--allow-inline-secret`; accepted with
- **reference**: passes through; empty string rejected
- **file mode** (§8.3): `0600` and `0400` accepted; `0644`, `0660`, `0700` rejected with `chmod` suggestion; trailing `\n` stripped; trailing `\r\n` stripped; trailing space preserved; empty file rejected; non-UTF-8 rejected; missing-file surfaces stat error
- **stdin** (§8.4): delegates to seam; IO error propagates
- **env** (§8.5): reads and clears; unset var errors; empty value rejected; empty name rejected

All 24 green. `cargo clippy --all-targets -- -D warnings` clean on `aeterna`. Existing **201** tenant-related tests still pass.

## Not in scope

- Server-side handling of `secretRef` (reference resolution, validation) — the CLI already sends the correct wire shape; server work is tracked separately outside B2 §8.
- `aeterna tenant secret delete` does not accept secret bytes and is untouched.

## Task tracking

All of 8.1, 8.2, 8.3, 8.4, 8.5 flipped to `[x]` in `tasks.md` with detailed implementation notes.
