### PR TITLE
fix(opal): close agent-permissions tenant leak (#130)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8030,6 +8030,8 @@ dependencies = [
  "sha2 0.10.9",
  "sqlx 0.9.0-alpha.1",
  "statig",
+ "testcontainers",
+ "testcontainers-modules",
  "testing",
  "thiserror 2.0.18",
  "tokio",

--- a/idp-sync/src/github.rs
+++ b/idp-sync/src/github.rs
@@ -630,57 +630,36 @@ pub async fn initialize_github_sync_schema(pool: &PgPool) -> IdpSyncResult<()> {
     Ok(())
 }
 
-/// Initializes OPAL views that are NOT owned by the storage migration tree.
+/// Initializes Code Search stub views (`v_code_search_repositories`,
+/// `v_code_search_requests`, `v_code_search_identities`) that the Code
+/// Search feature has not yet populated with its own schema.
 ///
 /// # History
 ///
-/// Up to PR #129 this function also defined `v_hierarchy` and
-/// `v_user_permissions` against the legacy `organizational_units` table
-/// (with UUIDs synthesized via `uuid_generate_v5`). Those definitions
-/// raced migration `009_organizational_referential.sql` /
-/// `028_tenant_scoped_hierarchy.sql` via `CREATE OR REPLACE VIEW` —
-/// whichever ran last won, and any `aeterna admin sync github` call
-/// silently reverted the migration's tenant-scoped definition and
-/// pointed the view at synthesized UUIDs that didn't match the real
-/// `companies.id` values.
+/// Up to PR #129 this function defined five views, including
+/// `v_hierarchy`, `v_user_permissions`, and `v_agent_permissions`. All
+/// three raced the storage migrations via `CREATE OR REPLACE VIEW`;
+/// whichever ran last won, and `aeterna admin sync github` could
+/// silently revert migration-owned definitions. The relocation was done
+/// in two steps:
 ///
-/// That race is resolved by PR #130: the migration is now the single
-/// canonical definer of `v_hierarchy` and `v_user_permissions`. This
-/// function retains ownership of views whose definitions are still
-/// idp-sync-specific:
+/// - PR #131 moved `v_hierarchy` and `v_user_permissions` ownership to
+///   migration `028_tenant_scoped_hierarchy.sql`, and additionally
+///   fixed a latent bug where the idp-sync definitions pointed at the
+///   legacy `organizational_units` table with `uuid_generate_v5`-
+///   synthesized IDs that didn't match real `companies.id` values.
+/// - PR #132 (this PR) moves `v_agent_permissions` ownership to
+///   migration `029_agents_tenant_scope.sql`, which also adds
+///   `agents.tenant_id` (backfilled + enforced) so that the view can
+///   surface a tenant column for opal-fetcher's isolation filter. The
+///   idp-sync definition additionally had `u.display_name` referenced,
+///   which never existed on the `users` table — the migration uses
+///   `u.name` correctly.
 ///
-/// - `v_agent_permissions` — joined across `agents` + `users`; no
-///   migration owns this yet. Tracked for relocation in #130.
-/// - `v_code_search_repositories` / `v_code_search_requests` /
-///   `v_code_search_identities` — empty-result stubs held here until
-///   the Code Search schema lands in its own migration.
+/// This function now owns only the Code Search stubs, which are
+/// empty-result placeholders until the Code Search schema lands in its
+/// own migration.
 async fn initialize_opal_views(pool: &PgPool) -> IdpSyncResult<()> {
-    sqlx::query(
-        r"
-        CREATE OR REPLACE VIEW v_agent_permissions AS
-        SELECT
-            a.id AS agent_id,
-            a.name AS agent_name,
-            a.agent_type,
-            a.delegated_by_user_id,
-            a.delegated_by_agent_id,
-            a.delegation_depth,
-            a.capabilities,
-            a.allowed_company_ids,
-            a.allowed_org_ids,
-            a.allowed_team_ids,
-            a.allowed_project_ids,
-            a.status AS agent_status,
-            u.email AS delegating_user_email,
-            u.display_name AS delegating_user_name
-        FROM agents a
-        LEFT JOIN users u ON u.id = a.delegated_by_user_id
-        ",
-    )
-    .execute(pool)
-    .await
-    .map_err(IdpSyncError::DatabaseError)?;
-
     sqlx::query(
         r"
         CREATE OR REPLACE VIEW v_code_search_repositories AS

--- a/opal-fetcher/src/entities.rs
+++ b/opal-fetcher/src/entities.rs
@@ -62,8 +62,21 @@ pub struct UserPermissionRow {
 }
 
 /// Row from the `v_agent_permissions` view.
+/// Row from the `v_agent_permissions` view.
+///
+/// `tenant_id` is surfaced by migration `029_agents_tenant_scope.sql`
+/// as the first column of the view, mirroring the pattern established
+/// by migration 028 for `v_hierarchy` and `v_user_permissions`. The
+/// column is nullable on the view because soft-deleted / revoked
+/// agents retain `NULL` tenant_id (they are historical rows kept for
+/// audit). Active agents always have a tenant — the migration's CHECK
+/// constraint enforces this.
+///
+/// Handlers MUST filter by this column before returning rows to OPAL.
+/// See `handlers::get_agents`.
 #[derive(Debug, Clone, FromRow)]
 pub struct AgentPermissionRow {
+    pub tenant_id: Option<Uuid>,
     pub agent_id: Uuid,
     pub agent_name: String,
     pub agent_type: String,
@@ -811,6 +824,7 @@ mod tests {
         let team_id = Uuid::new_v4();
 
         let row = AgentPermissionRow {
+            tenant_id: Some(Uuid::new_v4()),
             agent_id,
             agent_name: "OpenCode Assistant".to_string(),
             agent_type: "opencode".to_string(),
@@ -854,6 +868,7 @@ mod tests {
         let delegating_agent_id = Uuid::new_v4();
 
         let row = AgentPermissionRow {
+            tenant_id: Some(Uuid::new_v4()),
             agent_id,
             agent_name: "Sub-Agent".to_string(),
             agent_type: "custom".to_string(),

--- a/opal-fetcher/src/handlers.rs
+++ b/opal-fetcher/src/handlers.rs
@@ -216,35 +216,25 @@ pub async fn get_users(
 /// GET /v1/agents?tenant=<uuid>
 ///
 /// Returns agents with their delegation chains and capabilities as Cedar
-/// entities.
+/// entities, scoped to a single tenant. The `tenant` query parameter is
+/// **required**.
 ///
-/// # ⚠️ Known gap — tracked in issue #130 / follow-up
-///
-/// The `agents` table (migration `009_organizational_referential.sql`)
-/// has NO `tenant_id` column today. An agent's tenant is only knowable
-/// transitively via `agents.allowed_company_ids → companies.tenant_id`,
-/// and that set can in principle span multiple tenants. This handler
-/// therefore **requires** a `tenant` query param to match the contract
-/// of its siblings (so OPAL can be configured uniformly across all
-/// fetcher endpoints) but the current implementation still returns the
-/// full agent set and emits a WARN. The follow-up work to this PR adds
-/// `agents.tenant_id` + backfill + a filtered `v_agent_permissions`
-/// view; at that point this handler becomes a SQL-layer filter like
-/// `get_hierarchy` / `get_users` above and the WARN is removed.
+/// Isolation contract: rows are filtered by `v_agent_permissions.tenant_id
+/// = $1` (column exposed by migration `029_agents_tenant_scope.sql`,
+/// backed by a backfilled+NOT-NULL-for-active `agents.tenant_id` column).
+/// Revoked / soft-deleted agents with `NULL` tenant_id are never
+/// returned because the equality filter excludes `NULL`.
 pub async fn get_agents(
     State(state): State<Arc<AppState>>,
     Query(params): Query<TenantQuery>,
 ) -> Result<Json<CedarEntitiesResponse>> {
     let tenant_id = params.tenant;
-    tracing::warn!(
-        %tenant_id,
-        "agent-permissions endpoint currently returns cross-tenant rows; \
-         tenant filtering pending agents.tenant_id schema work (see #130)"
-    );
+    tracing::debug!(%tenant_id, "Fetching agent permissions");
 
     let rows: Vec<AgentPermissionRow> = sqlx::query_as(
         r"
         SELECT
+            tenant_id,
             agent_id,
             agent_name,
             agent_type,
@@ -260,17 +250,15 @@ pub async fn get_agents(
             delegating_user_email,
             delegating_user_name
         FROM v_agent_permissions
+        WHERE tenant_id = $1
         ",
     )
+    .bind(tenant_id)
     .fetch_all(&state.pool)
     .await?;
 
     let count = rows.len();
-    tracing::debug!(
-        %tenant_id,
-        row_count = count,
-        "Fetched agent permission rows (unfiltered — see handler docs)"
-    );
+    tracing::debug!(%tenant_id, row_count = count, "Fetched agent permission rows");
 
     let entities = transform_agents(rows)?;
     let response = CedarEntitiesResponse::new(entities);
@@ -278,7 +266,7 @@ pub async fn get_agents(
     tracing::info!(
         %tenant_id,
         entity_count = response.count,
-        "Returning agent entities (unfiltered — see handler docs)"
+        "Returning agent entities"
     );
 
     Ok(Json(response))
@@ -291,9 +279,10 @@ pub async fn get_agents(
 /// sync of one tenant's OPAL data-source. The `tenant` query parameter
 /// is **required**.
 ///
-/// Tenant-filtering applied: hierarchy, users, code-search repositories
-/// / requests / identities, and project-team assignments. Agents are
-/// NOT filtered — see `get_agents` docstring for the tracked gap.
+/// Tenant-filtering applied uniformly to every entity source: hierarchy,
+/// users, agents, code-search repositories / requests / identities, and
+/// project-team assignments. There are no remaining cross-tenant gaps
+/// in this endpoint after migration `029_agents_tenant_scope.sql`.
 pub async fn get_all_entities(
     State(state): State<Arc<AppState>>,
     Query(params): Query<TenantQuery>,
@@ -322,10 +311,10 @@ pub async fn get_all_entities(
         )
         .bind(tenant_id)
         .fetch_all(&state.pool),
-        // NOTE: agents unfiltered — tracked in #130, see get_agents docstring.
         sqlx::query_as::<_, AgentPermissionRow>(
-            r"SELECT agent_id, agent_name, agent_type, delegated_by_user_id, delegated_by_agent_id, delegation_depth, capabilities, allowed_company_ids, allowed_org_ids, allowed_team_ids, allowed_project_ids, agent_status, delegating_user_email, delegating_user_name FROM v_agent_permissions"
+            r"SELECT tenant_id, agent_id, agent_name, agent_type, delegated_by_user_id, delegated_by_agent_id, delegation_depth, capabilities, allowed_company_ids, allowed_org_ids, allowed_team_ids, allowed_project_ids, agent_status, delegating_user_email, delegating_user_name FROM v_agent_permissions WHERE tenant_id = $1"
         )
+        .bind(tenant_id)
         .fetch_all(&state.pool),
         sqlx::query_as::<_, ProjectTeamAssignmentRow>(
             r"SELECT project_id, team_id, tenant_id, assignment_type FROM project_team_assignments WHERE tenant_id = $1"
@@ -348,12 +337,6 @@ pub async fn get_all_entities(
         .bind(&tenant_text)
         .fetch_all(&state.pool),
     )?;
-
-    tracing::warn!(
-        %tenant_id,
-        agent_row_count = agent_rows.len(),
-        "agent rows returned unfiltered — tenant filtering pending (#130)"
-    );
 
     // Transform all entities
     let mut all_entities = transform_hierarchy(hierarchy_rows)?;
@@ -380,7 +363,7 @@ pub async fn get_all_entities(
     tracing::info!(
         %tenant_id,
         entity_count = response.count,
-        "Returning all entities (tenant-scoped, excluding agents)"
+        "Returning all entities (tenant-scoped)"
     );
 
     Ok(Json(response))

--- a/opal-fetcher/tests/tenant_isolation_test.rs
+++ b/opal-fetcher/tests/tenant_isolation_test.rs
@@ -19,10 +19,8 @@
 //!   4. An unknown tenant UUID returns the empty set (no fallthrough
 //!      to a default/global set).
 //!
-//! Out of scope (tracked as follow-up to #130):
-//!
-//!   - Agent-permissions isolation. The `agents` table has no
-//!     `tenant_id` column today; see `handlers::get_agents` docstring.
+//! Agent isolation (migration 029) is covered by the dedicated cases at
+//! the bottom of this file: backfill uniqueness + view tenant_id filter.
 //!
 //! Docker-gated; no-op with stderr notice when Docker is unavailable,
 //! matching `storage/tests/migration_028_tenant_scoped_hierarchy_test.rs`.
@@ -266,4 +264,140 @@ async fn v_hierarchy_unknown_tenant_returns_empty_set_not_global_fallthrough() {
         "unknown tenant must return empty set, got {} rows",
         rows.len()
     );
+}
+
+// ---------------------------------------------------------------------
+// Agent-permissions isolation (migration 029 — added in this PR)
+// ---------------------------------------------------------------------
+
+async fn first_user_and_company_for_tenant(
+    pool: &sqlx::PgPool,
+    tenant_id: Uuid,
+) -> (Uuid, Uuid) {
+    let row = sqlx::query(
+        "SELECT u.id AS user_id, c.id AS company_id
+         FROM users u
+         JOIN memberships m ON m.user_id = u.id
+         JOIN teams t ON t.id = m.team_id
+         JOIN organizations o ON o.id = t.org_id
+         JOIN companies c ON c.id = o.company_id
+         WHERE c.tenant_id = $1
+         LIMIT 1",
+    )
+    .bind(tenant_id)
+    .fetch_one(pool)
+    .await
+    .expect("lookup seed user/company");
+    (
+        row.get::<Uuid, _>("user_id"),
+        row.get::<Uuid, _>("company_id"),
+    )
+}
+
+#[tokio::test]
+async fn v_agent_permissions_tenant_filter_isolates_cross_tenant_rows() {
+    let Some(pool) = fresh_pool().await else {
+        eprintln!("Skipping opal-fetcher tenant isolation test: Docker unavailable");
+        return;
+    };
+
+    // Note: seed the hierarchy BEFORE inserting agents, because
+    // migration 029 has already run during fresh_pool() — it added the
+    // tenant_id column and installed the CHECK constraint. Fresh agent
+    // inserts here therefore set tenant_id inline.
+    let (tenant_a, _) = seed_tenant(&pool, "theta").await;
+    let (tenant_b, _) = seed_tenant(&pool, "iota").await;
+
+    let (user_a, company_a) = first_user_and_company_for_tenant(&pool, tenant_a).await;
+    let (user_b, company_b) = first_user_and_company_for_tenant(&pool, tenant_b).await;
+
+    // Insert with tenant_id set explicitly (post-migration path).
+    let agent_a = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO agents (id, name, agent_type, delegated_by_user_id, delegation_depth, capabilities, allowed_company_ids, status, tenant_id)
+         VALUES ($1, 'agent-a', 'opencode', $2, 1, '[]'::jsonb, ARRAY[$3]::uuid[], 'active', $4)",
+    )
+    .bind(agent_a).bind(user_a).bind(company_a).bind(tenant_a)
+    .execute(&pool).await.expect("insert agent A");
+
+    let agent_b = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO agents (id, name, agent_type, delegated_by_user_id, delegation_depth, capabilities, allowed_company_ids, status, tenant_id)
+         VALUES ($1, 'agent-b', 'opencode', $2, 1, '[]'::jsonb, ARRAY[$3]::uuid[], 'active', $4)",
+    )
+    .bind(agent_b).bind(user_b).bind(company_b).bind(tenant_b)
+    .execute(&pool).await.expect("insert agent B");
+
+    let rows_a: Vec<(Option<Uuid>, Uuid, String)> = sqlx::query_as(
+        "SELECT tenant_id, agent_id, agent_name FROM v_agent_permissions WHERE tenant_id = $1",
+    )
+    .bind(tenant_a)
+    .fetch_all(&pool)
+    .await
+    .expect("query tenant A agents");
+
+    let rows_b: Vec<(Option<Uuid>, Uuid, String)> = sqlx::query_as(
+        "SELECT tenant_id, agent_id, agent_name FROM v_agent_permissions WHERE tenant_id = $1",
+    )
+    .bind(tenant_b)
+    .fetch_all(&pool)
+    .await
+    .expect("query tenant B agents");
+
+    assert_eq!(rows_a.len(), 1, "tenant A should see exactly its one agent, got {rows_a:?}");
+    assert_eq!(rows_b.len(), 1, "tenant B should see exactly its one agent, got {rows_b:?}");
+    assert_eq!(rows_a[0].1, agent_a);
+    assert_eq!(rows_b[0].1, agent_b);
+    assert_eq!(rows_a[0].0, Some(tenant_a));
+    assert_eq!(rows_b[0].0, Some(tenant_b));
+}
+
+#[tokio::test]
+async fn agents_check_constraint_rejects_active_agent_with_null_tenant() {
+    let Some(pool) = fresh_pool().await else {
+        eprintln!("Skipping opal-fetcher tenant isolation test: Docker unavailable");
+        return;
+    };
+
+    let (tenant, _) = seed_tenant(&pool, "kappa").await;
+    let (user, _) = first_user_and_company_for_tenant(&pool, tenant).await;
+
+    let result = sqlx::query(
+        "INSERT INTO agents (id, name, agent_type, delegated_by_user_id, delegation_depth, capabilities, status, tenant_id)
+         VALUES (gen_random_uuid(), 'bad-agent', 'opencode', $1, 1, '[]'::jsonb, 'active', NULL)",
+    )
+    .bind(user)
+    .execute(&pool)
+    .await;
+
+    let err = result.expect_err("expected CHECK constraint violation");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("agents_tenant_id_required_when_active"),
+        "unexpected error (want CHECK constraint name): {msg}"
+    );
+}
+
+#[tokio::test]
+async fn agents_check_constraint_allows_revoked_agent_with_null_tenant() {
+    let Some(pool) = fresh_pool().await else {
+        eprintln!("Skipping opal-fetcher tenant isolation test: Docker unavailable");
+        return;
+    };
+
+    let (tenant, _) = seed_tenant(&pool, "lambda").await;
+    let (user, _) = first_user_and_company_for_tenant(&pool, tenant).await;
+
+    // Revoked/soft-deleted agents are permitted to retain NULL tenant_id:
+    // they are historical rows, never surfaced by the fetcher (the view
+    // filter is tenant_id = $1 which excludes NULL), and forcing a tenant
+    // during revocation would require backfill gymnastics.
+    sqlx::query(
+        "INSERT INTO agents (id, name, agent_type, delegated_by_user_id, delegation_depth, capabilities, status, tenant_id)
+         VALUES (gen_random_uuid(), 'historical-agent', 'opencode', $1, 1, '[]'::jsonb, 'revoked', NULL)",
+    )
+    .bind(user)
+    .execute(&pool)
+    .await
+    .expect("revoked agent with NULL tenant_id should be allowed");
 }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -60,6 +60,12 @@ metrics-util.workspace = true
 wiremock.workspace = true
 anyhow.workspace = true
 url = "2"
+# Migration 029 backfill/audit tests need a dedicated container per case
+# (shared `testing::postgres()` fixture has already applied 029, making
+# a pre-029 seeding path impossible). Kept dev-only — production code
+# never touches testcontainers.
+testcontainers.workspace = true
+testcontainers-modules = { workspace = true, features = ["postgres"] }
 
 [lints]
 workspace = true

--- a/storage/migrations/029_agents_tenant_scope.sql
+++ b/storage/migrations/029_agents_tenant_scope.sql
@@ -1,0 +1,215 @@
+-- Migration 029: agents.tenant_id + v_agent_permissions relocation
+--
+-- Closes the second half of issue #130: agent-permissions isolation.
+--
+-- PR #131 added tenant-filtering to hierarchy and users endpoints in
+-- opal-fetcher, but /v1/agents still returned the globally-merged agent
+-- set across every tenant — because the `agents` table (migration 009)
+-- has no `tenant_id` column. An agent's tenant was only knowable
+-- transitively via `agents.allowed_company_ids -> companies.tenant_id`,
+-- and that set can in principle span multiple tenants.
+--
+-- This migration establishes the invariant **one agent = one tenant**:
+--
+--   1. ADDs a nullable `agents.tenant_id UUID` column (FK -> tenants.id).
+--   2. AUDITs existing agents for cross-tenant scope; ABORTs with a
+--      loud RAISE if any agent's allowed_company_ids span multiple
+--      tenants or if any active agent has no derivable tenant. This is
+--      deliberate: we do not want to pick a tenant for you, because a
+--      silent wrong choice would be a durable authz bug.
+--   3. BACKFILLs tenant_id from the distinct tenant of
+--      allowed_company_ids (plus fallback derivations through orgs /
+--      teams / projects for agents scoped at finer granularities).
+--   4. SETs NOT NULL once the backfill is complete.
+--   5. RELOCATEs the `v_agent_permissions` view from
+--      `idp-sync::github::initialize_opal_views` into this migration
+--      (same pattern as migration 028 for v_hierarchy and
+--      v_user_permissions), surfacing tenant_id as the first column.
+--      Fixes a latent bug: the idp-sync definition referenced
+--      `u.display_name`, which does not exist in the users table
+--      (migration 009 defines `users.name`). The relocated view uses
+--      `u.name` correctly.
+--
+-- Operational note: if step 2 aborts in staging/prod, the offending
+-- agents need to be manually split or re-scoped before retrying. The
+-- error message lists every problem agent id so the fix is mechanical.
+--
+-- Follow-up #130 subtask remaining after this migration: relocate
+-- idp-sync writes from `organizational_units` to
+-- `companies/organizations/teams`, then remove the legacy OU writes
+-- from `PostgresBackend::initialize_schema`.
+
+-- ---------------------------------------------------------------------
+-- 1. Add column (nullable initially for backfill)
+-- ---------------------------------------------------------------------
+
+ALTER TABLE agents
+    ADD COLUMN IF NOT EXISTS tenant_id UUID REFERENCES tenants(id);
+
+-- ---------------------------------------------------------------------
+-- 2. Audit: fail loud on cross-tenant agents
+-- ---------------------------------------------------------------------
+
+DO $$
+DECLARE
+    offenders TEXT;
+BEGIN
+    -- For each not-yet-backfilled active agent, compute the set of
+    -- distinct tenants implied by its entire scope (companies + the
+    -- companies reachable through orgs / teams / projects). An agent
+    -- is an offender if that set has more than one element.
+    SELECT string_agg(agent_id::text, ', ')
+      INTO offenders
+      FROM (
+        SELECT a.id AS agent_id
+        FROM agents a
+        LEFT JOIN LATERAL (
+            SELECT DISTINCT c.tenant_id
+            FROM companies c
+            WHERE c.deleted_at IS NULL
+              AND (
+                c.id = ANY(a.allowed_company_ids)
+                OR c.id IN (
+                    SELECT o.company_id FROM organizations o
+                    WHERE o.deleted_at IS NULL
+                      AND o.id = ANY(a.allowed_org_ids)
+                )
+                OR c.id IN (
+                    SELECT o.company_id FROM organizations o
+                    JOIN teams t ON t.org_id = o.id
+                    WHERE o.deleted_at IS NULL
+                      AND t.deleted_at IS NULL
+                      AND t.id = ANY(a.allowed_team_ids)
+                )
+                OR c.id IN (
+                    SELECT o.company_id FROM organizations o
+                    JOIN teams t ON t.org_id = o.id
+                    JOIN projects p ON p.team_id = t.id
+                    WHERE o.deleted_at IS NULL
+                      AND t.deleted_at IS NULL
+                      AND p.deleted_at IS NULL
+                      AND p.id = ANY(a.allowed_project_ids)
+                )
+              )
+        ) tenants ON TRUE
+        WHERE a.deleted_at IS NULL
+          AND a.status <> 'revoked'
+          AND a.tenant_id IS NULL
+        GROUP BY a.id
+        HAVING COUNT(DISTINCT tenants.tenant_id) > 1
+      ) bad;
+
+    IF offenders IS NOT NULL THEN
+        RAISE EXCEPTION
+            'Migration 029 abort: agents % have allowed_* scope spanning multiple tenants. Split or re-scope them to a single tenant before retrying (see docs/issue #130).',
+            offenders;
+    END IF;
+END $$;
+
+-- ---------------------------------------------------------------------
+-- 3. Backfill tenant_id from the (now-verified-single) tenant of scope
+-- ---------------------------------------------------------------------
+
+UPDATE agents a SET tenant_id = sub.tenant_id
+FROM (
+    SELECT a.id AS agent_id, MIN(c.tenant_id) AS tenant_id
+    FROM agents a
+    JOIN companies c ON c.deleted_at IS NULL AND (
+        c.id = ANY(a.allowed_company_ids)
+        OR c.id IN (
+            SELECT o.company_id FROM organizations o
+            WHERE o.deleted_at IS NULL
+              AND o.id = ANY(a.allowed_org_ids)
+        )
+        OR c.id IN (
+            SELECT o.company_id FROM organizations o
+            JOIN teams t ON t.org_id = o.id
+            WHERE o.deleted_at IS NULL
+              AND t.deleted_at IS NULL
+              AND t.id = ANY(a.allowed_team_ids)
+        )
+        OR c.id IN (
+            SELECT o.company_id FROM organizations o
+            JOIN teams t ON t.org_id = o.id
+            JOIN projects p ON p.team_id = t.id
+            WHERE o.deleted_at IS NULL
+              AND t.deleted_at IS NULL
+              AND p.deleted_at IS NULL
+              AND p.id = ANY(a.allowed_project_ids)
+        )
+    )
+    WHERE a.deleted_at IS NULL
+      AND a.tenant_id IS NULL
+    GROUP BY a.id
+) sub
+WHERE a.id = sub.agent_id;
+
+-- ---------------------------------------------------------------------
+-- 4. Fail loud if any active agent still lacks a tenant after backfill
+--    (e.g. agents with empty allowed_* arrays — truly-global agents
+--    cannot exist under the one-agent-one-tenant invariant).
+-- ---------------------------------------------------------------------
+
+DO $$
+DECLARE
+    unscoped TEXT;
+BEGIN
+    SELECT string_agg(id::text, ', ') INTO unscoped
+    FROM agents
+    WHERE tenant_id IS NULL
+      AND deleted_at IS NULL
+      AND status <> 'revoked';
+
+    IF unscoped IS NOT NULL THEN
+        RAISE EXCEPTION
+            'Migration 029 abort: agents % have no derivable tenant (empty allowed_* scopes). Assign tenant_id manually or revoke them before retrying.',
+            unscoped;
+    END IF;
+END $$;
+
+-- ---------------------------------------------------------------------
+-- 5. Enforce NOT NULL going forward
+-- ---------------------------------------------------------------------
+
+-- Soft-deleted / revoked agents may retain NULL tenant_id (they are
+-- harmless historical rows). New inserts and updates of active agents
+-- must provide tenant_id.
+ALTER TABLE agents
+    ADD CONSTRAINT agents_tenant_id_required_when_active
+    CHECK (
+        tenant_id IS NOT NULL
+        OR status = 'revoked'
+        OR deleted_at IS NOT NULL
+    );
+
+CREATE INDEX IF NOT EXISTS idx_agents_tenant_id
+    ON agents(tenant_id)
+    WHERE deleted_at IS NULL;
+
+-- ---------------------------------------------------------------------
+-- 6. Relocate v_agent_permissions into the migration (was defined by
+--    idp-sync::github::initialize_opal_views; see PR #131 for the
+--    v_hierarchy / v_user_permissions relocation that preceded this).
+--    Fixes u.display_name -> u.name (display_name never existed).
+-- ---------------------------------------------------------------------
+
+DROP VIEW IF EXISTS v_agent_permissions;
+CREATE VIEW v_agent_permissions AS
+SELECT
+    a.tenant_id,
+    a.id AS agent_id,
+    a.name AS agent_name,
+    a.agent_type,
+    a.delegated_by_user_id,
+    a.delegated_by_agent_id,
+    a.delegation_depth,
+    a.capabilities,
+    a.allowed_company_ids,
+    a.allowed_org_ids,
+    a.allowed_team_ids,
+    a.allowed_project_ids,
+    a.status AS agent_status,
+    u.email AS delegating_user_email,
+    u.name AS delegating_user_name
+FROM agents a
+LEFT JOIN users u ON u.id = a.delegated_by_user_id;

--- a/storage/src/migrations.rs
+++ b/storage/src/migrations.rs
@@ -177,6 +177,11 @@ pub const MIGRATIONS: &[EmbeddedMigration] = &[
         name: "028_tenant_scoped_hierarchy",
         sql: include_str!("../migrations/028_tenant_scoped_hierarchy.sql"),
     },
+    EmbeddedMigration {
+        version: 29,
+        name: "029_agents_tenant_scope",
+        sql: include_str!("../migrations/029_agents_tenant_scope.sql"),
+    },
 ];
 
 /// Apply every embedded migration in order, transactionally.

--- a/storage/tests/migration_029_agents_tenant_scope_test.rs
+++ b/storage/tests/migration_029_agents_tenant_scope_test.rs
@@ -1,0 +1,208 @@
+//! Migration 029 backfill and audit tests.
+//!
+//! Migration 029 adds `agents.tenant_id` with these guarantees:
+//!
+//!   1. Cross-tenant agents (allowed_* spanning >1 tenant) abort the
+//!      migration with a loud RAISE.
+//!   2. Active agents with no derivable tenant abort the migration.
+//!   3. Otherwise, tenant_id is backfilled from the single tenant
+//!      implied by allowed_company_ids / allowed_org_ids /
+//!      allowed_team_ids / allowed_project_ids.
+//!   4. Revoked / soft-deleted agents may retain NULL tenant_id.
+//!
+//! The fetcher's isolation tests (`opal-fetcher/tests/tenant_isolation_test.rs`)
+//! verify steady-state behavior on a post-migration schema. These tests
+//! simulate the PRE-migration world by running migrations 001-028,
+//! seeding raw agent rows without tenant_id, then running migration 029
+//! and asserting each outcome path.
+//!
+//! Docker-gated.
+
+use sqlx::Row;
+use sqlx::postgres::PgPoolOptions;
+use storage::migrations::MIGRATIONS;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use uuid::Uuid;
+
+// These tests need a fresh container per case: they simulate the
+// pre-029 world by seeding agents WITHOUT `tenant_id`, which is
+// incompatible with the steady-state schema the shared
+// `testing::postgres()` fixture installs (that fixture has already
+// applied migration 029 and its CHECK constraint is active).
+//
+// A per-test container costs ~5-10s of Docker startup; acceptable for
+// a ring-fenced migration-backfill test.
+async fn fresh_container() -> Option<(ContainerAsync<Postgres>, String)> {
+    let container = Postgres::default()
+        .with_db_name("testdb")
+        .with_user("testuser")
+        .with_password("testpass")
+        .start()
+        .await
+        .ok()?;
+    let port = container.get_host_port_ipv4(5432).await.ok()?;
+    let url = format!("postgres://testuser:testpass@localhost:{}/testdb", port);
+    Some((container, url))
+}
+
+/// Applies every migration up to (but not including) `target_version`.
+/// Used to reach a schema state just before the migration under test.
+async fn apply_up_to(pool: &sqlx::PgPool, exclusive_upper: i32) {
+    for migration in MIGRATIONS.iter().filter(|m| m.version < exclusive_upper) {
+        let mut tx = pool.begin().await.expect("begin tx");
+        sqlx::raw_sql(migration.sql)
+            .execute(&mut *tx)
+            .await
+            .unwrap_or_else(|e| {
+                panic!("apply migration {} failed: {e}", migration.name)
+            });
+        tx.commit().await.expect("commit");
+    }
+}
+
+async fn apply_migration_029(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
+    let m = MIGRATIONS
+        .iter()
+        .find(|m| m.version == 29)
+        .expect("migration 029 registered");
+    let mut tx = pool.begin().await?;
+    sqlx::raw_sql(m.sql).execute(&mut *tx).await?;
+    tx.commit().await
+}
+
+async fn seed_tenant_with_company(
+    pool: &sqlx::PgPool,
+    slug: &str,
+) -> (Uuid, Uuid, Uuid) {
+    let tenant_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO tenants (id, slug, name, status, source_owner)
+         VALUES ($1, $2, $2, 'active', 'test')",
+    )
+    .bind(tenant_id)
+    .bind(slug)
+    .execute(pool).await.expect("insert tenant");
+
+    let company_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO companies (id, tenant_id, slug, name)
+         VALUES ($1, $2, 'acme', 'Acme')",
+    )
+    .bind(company_id).bind(tenant_id).execute(pool).await.expect("insert company");
+
+    let user_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO users (id, email, name, status)
+         VALUES ($1, $2, 'User', 'active')",
+    )
+    .bind(user_id).bind(format!("u+{slug}@acme.com")).execute(pool).await.expect("insert user");
+
+    (tenant_id, company_id, user_id)
+}
+
+async fn fresh_pre_029_pool() -> Option<(ContainerAsync<Postgres>, sqlx::PgPool)> {
+    let (container, url) = fresh_container().await?;
+    let pool = PgPoolOptions::new()
+        .max_connections(3)
+        .connect(&url)
+        .await
+        .expect("pool");
+    // Apply migrations 001..=28; agents table exists without tenant_id,
+    // ready for the migration 029 scenario under test to run on top.
+    apply_up_to(&pool, 29).await;
+    Some((container, pool))
+}
+
+async fn insert_pre_migration_agent(
+    pool: &sqlx::PgPool,
+    user_id: Uuid,
+    allowed_company_ids: &[Uuid],
+    status: &str,
+) -> Uuid {
+    let agent_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO agents (id, name, agent_type, delegated_by_user_id, delegation_depth, capabilities, allowed_company_ids, status)
+         VALUES ($1, 'test-agent', 'opencode', $2, 1, '[]'::jsonb, $3::uuid[], $4)",
+    )
+    .bind(agent_id).bind(user_id).bind(allowed_company_ids).bind(status)
+    .execute(pool).await.expect("insert pre-migration agent");
+    agent_id
+}
+
+#[tokio::test]
+async fn migration_029_backfills_single_tenant_agent() {
+    let Some((_container, pool)) = fresh_pre_029_pool().await else {
+        eprintln!("Skipping migration 029 test: Docker unavailable");
+        return;
+    };
+    let (tenant, company, user) = seed_tenant_with_company(&pool, "single").await;
+    let agent = insert_pre_migration_agent(&pool, user, &[company], "active").await;
+
+    apply_migration_029(&pool).await.expect("migration should succeed");
+
+    let row = sqlx::query("SELECT tenant_id FROM agents WHERE id = $1")
+        .bind(agent).fetch_one(&pool).await.expect("fetch agent");
+    let actual: Uuid = row.get("tenant_id");
+    assert_eq!(actual, tenant, "backfill should assign the company's tenant");
+}
+
+#[tokio::test]
+async fn migration_029_aborts_on_cross_tenant_agent() {
+    let Some((_container, pool)) = fresh_pre_029_pool().await else {
+        eprintln!("Skipping migration 029 test: Docker unavailable");
+        return;
+    };
+    let (_, company_a, user) = seed_tenant_with_company(&pool, "mu").await;
+    let (_, company_b, _) = seed_tenant_with_company(&pool, "nu").await;
+    let _agent = insert_pre_migration_agent(&pool, user, &[company_a, company_b], "active").await;
+
+    let err = apply_migration_029(&pool).await.expect_err(
+        "cross-tenant agent must abort migration",
+    );
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("spanning multiple tenants"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn migration_029_aborts_on_unscoped_active_agent() {
+    let Some((_container, pool)) = fresh_pre_029_pool().await else {
+        eprintln!("Skipping migration 029 test: Docker unavailable");
+        return;
+    };
+    let (_, _, user) = seed_tenant_with_company(&pool, "xi").await;
+    // Agent with empty allowed_* arrays — no derivable tenant.
+    let _agent = insert_pre_migration_agent(&pool, user, &[], "active").await;
+
+    let err = apply_migration_029(&pool).await.expect_err(
+        "unscoped active agent must abort migration",
+    );
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("no derivable tenant"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn migration_029_leaves_revoked_agents_null() {
+    let Some((_container, pool)) = fresh_pre_029_pool().await else {
+        eprintln!("Skipping migration 029 test: Docker unavailable");
+        return;
+    };
+    let (_, _, user) = seed_tenant_with_company(&pool, "omicron").await;
+    // Revoked agent with empty scope — should NOT abort the migration
+    // and should retain NULL tenant_id afterward.
+    let agent = insert_pre_migration_agent(&pool, user, &[], "revoked").await;
+
+    apply_migration_029(&pool).await.expect("revoked unscoped agent should not abort");
+
+    let row = sqlx::query("SELECT tenant_id FROM agents WHERE id = $1")
+        .bind(agent).fetch_one(&pool).await.expect("fetch revoked");
+    let actual: Option<Uuid> = row.get("tenant_id");
+    assert!(actual.is_none(), "revoked agent should retain NULL tenant_id, got {actual:?}");
+}


### PR DESCRIPTION
Replaces #132 (auto-closed when its stacked base branch was deleted post-merge of #131).

Original content: tenant-scope migration 029 + agent permissions fetcher hardening + isolation tests. Rebased onto current master after #131 landed.