### PR TITLE
feat(storage): HierarchyStore for tenant-scoped companies/orgs/teams (§2.2-B B3)

### DIFF
--- a/opal-fetcher/tests/tenant_isolation_test.rs
+++ b/opal-fetcher/tests/tenant_isolation_test.rs
@@ -270,10 +270,7 @@ async fn v_hierarchy_unknown_tenant_returns_empty_set_not_global_fallthrough() {
 // Agent-permissions isolation (migration 029 — added in this PR)
 // ---------------------------------------------------------------------
 
-async fn first_user_and_company_for_tenant(
-    pool: &sqlx::PgPool,
-    tenant_id: Uuid,
-) -> (Uuid, Uuid) {
+async fn first_user_and_company_for_tenant(pool: &sqlx::PgPool, tenant_id: Uuid) -> (Uuid, Uuid) {
     let row = sqlx::query(
         "SELECT u.id AS user_id, c.id AS company_id
          FROM users u
@@ -344,8 +341,16 @@ async fn v_agent_permissions_tenant_filter_isolates_cross_tenant_rows() {
     .await
     .expect("query tenant B agents");
 
-    assert_eq!(rows_a.len(), 1, "tenant A should see exactly its one agent, got {rows_a:?}");
-    assert_eq!(rows_b.len(), 1, "tenant B should see exactly its one agent, got {rows_b:?}");
+    assert_eq!(
+        rows_a.len(),
+        1,
+        "tenant A should see exactly its one agent, got {rows_a:?}"
+    );
+    assert_eq!(
+        rows_b.len(),
+        1,
+        "tenant B should see exactly its one agent, got {rows_b:?}"
+    );
     assert_eq!(rows_a[0].1, agent_a);
     assert_eq!(rows_b[0].1, agent_b);
     assert_eq!(rows_a[0].0, Some(tenant_a));

--- a/storage/src/hierarchy_store.rs
+++ b/storage/src/hierarchy_store.rs
@@ -1,0 +1,356 @@
+//! Tenant-scoped organizational hierarchy storage.
+//!
+//! §2.2-B commit B3 of `harden-tenant-provisioning`. Owns read and write
+//! access to the `companies` / `organizations` / `teams` tables — the
+//! "modern" hierarchy tables that idp-sync, bootstrap, and OPAL read
+//! (via `v_hierarchy`) — with full tenant-scoping enforced by
+//! migration 028.
+//!
+//! **Scope note.** `provision_tenant`'s current apply step writes only
+//! the legacy `organizational_units` table (via
+//! `PostgresBackend::create_unit_scoped`). That path remains, unchanged,
+//! for backward compatibility with backup/gdpr/cascade code paths that
+//! still read OU. This store is the forward path: B4 will wire
+//! `provision_tenant` to call [`HierarchyStore::upsert_hierarchy`] in
+//! addition to the OU write, so manifest-declared hierarchy lands in
+//! the same tables that bootstrap and idp-sync populate.
+//!
+//! **Slug derivation.** `ManifestCompany` / `ManifestOrg` / `ManifestTeam`
+//! carry a `name: String` but no `slug` — yet the modern tables require
+//! `(tenant_id, slug)` / `(company_id, slug)` / `(org_id, slug)` UNIQUE
+//! constraints. We derive a slug from the name via [`slugify`] (lossy
+//! kebab-case). Two distinct names collapsing to the same slug under the
+//! same parent is a UNIQUE-violation error surfaced by Postgres; callers
+//! should enforce slug uniqueness in manifest validation if they care.
+//!
+//! **Prune.** Deferred to B4. The blast-radius NOTES describe prune as
+//! "soft-delete rows no longer in manifest". That needs to coexist with
+//! idp-synced teams (which carry `idp_provider IS NOT NULL` per
+//! migration 030) that must NOT be pruned by a manifest apply. Safer
+//! to sequence after the apply wiring is in place.
+
+use sqlx::Row;
+use uuid::Uuid;
+
+use crate::postgres::PostgresError;
+
+/// A company in the modern hierarchy — owned by exactly one tenant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Company {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub slug: String,
+    pub name: String,
+    pub orgs: Vec<Org>,
+}
+
+/// An organization under a company.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Org {
+    pub id: Uuid,
+    pub company_id: Uuid,
+    pub slug: String,
+    pub name: String,
+    pub teams: Vec<Team>,
+}
+
+/// A team under an organization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Team {
+    pub id: Uuid,
+    pub org_id: Uuid,
+    pub slug: String,
+    pub name: String,
+}
+
+/// Input shape for [`HierarchyStore::upsert_hierarchy`]. Mirrors the
+/// shape of `ManifestCompany` but uses explicit `slug` fields derived
+/// up front by the caller (see [`slugify`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompanyInput {
+    pub slug: String,
+    pub name: String,
+    pub orgs: Vec<OrgInput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrgInput {
+    pub slug: String,
+    pub name: String,
+    pub teams: Vec<TeamInput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeamInput {
+    pub slug: String,
+    pub name: String,
+}
+
+/// Result of a successful [`HierarchyStore::upsert_hierarchy`] call.
+/// Surfaced so the caller (B4 `provision_tenant`) can report counts in
+/// the provision response step.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UpsertSummary {
+    pub companies_upserted: usize,
+    pub orgs_upserted: usize,
+    pub teams_upserted: usize,
+}
+
+/// Derive a URL-safe, lowercase, kebab-case slug from a free-form name.
+///
+/// Rules:
+/// * Lowercase ASCII letters and digits are kept as-is.
+/// * All other runs of characters collapse to a single `-`.
+/// * Leading and trailing `-` are stripped.
+/// * Empty result is replaced with `"unnamed"` so we never produce a
+///   NULL-violating empty slug.
+///
+/// This is intentionally lossy: two names that differ only in
+/// punctuation/whitespace map to the same slug, which will surface as
+/// a Postgres UNIQUE violation at upsert time (that's the desired
+/// fail-fast behaviour for accidentally-duplicate manifest entries).
+pub fn slugify(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut prev_dash = true;
+    for ch in name.chars() {
+        let mapped = ch.to_ascii_lowercase();
+        if mapped.is_ascii_alphanumeric() {
+            out.push(mapped);
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.is_empty() {
+        "unnamed".to_string()
+    } else {
+        out
+    }
+}
+
+/// Store for the modern tenant-scoped hierarchy tables.
+///
+/// Backed by the same `sqlx::PgPool` as `TenantStore`,
+/// `TenantRepositoryBindingStore`, etc. No RLS session variables are
+/// set from this store directly — the caller is responsible for
+/// running queries on the appropriate app/admin pool per the dual-pool
+/// RLS design (PR #72/#75).
+///
+/// **Consequence.** Call this store via the admin pool when
+/// provisioning a brand-new tenant. `provision_tenant` runs in admin
+/// context, which is correct for B4.
+#[derive(Clone)]
+pub struct HierarchyStore {
+    pool: sqlx::PgPool,
+}
+
+impl HierarchyStore {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Upsert a full hierarchy under `tenant_id`. Idempotent on repeat
+    /// application with the same inputs: existing rows get their `name`
+    /// refreshed (slug is the identity key, so it cannot change here —
+    /// a renamed company requires either a new slug or a soft-delete +
+    /// re-create, which is a B4 concern).
+    ///
+    /// This method runs in a single transaction so a partial failure
+    /// (e.g. one org violates a UNIQUE constraint) leaves no half-built
+    /// hierarchy behind.
+    ///
+    /// Does **not** prune rows absent from `companies` — see module
+    /// docstring.
+    pub async fn upsert_hierarchy(
+        &self,
+        tenant_id: Uuid,
+        companies: &[CompanyInput],
+    ) -> Result<UpsertSummary, PostgresError> {
+        let mut tx = self.pool.begin().await.map_err(PostgresError::Database)?;
+        let mut summary = UpsertSummary::default();
+
+        for company in companies {
+            let company_id: Uuid = sqlx::query_scalar(
+                "INSERT INTO companies (tenant_id, slug, name, settings, created_at, updated_at)
+                 VALUES ($1, $2, $3, '{}', NOW(), NOW())
+                 ON CONFLICT (tenant_id, slug)
+                 DO UPDATE SET name = EXCLUDED.name, updated_at = NOW()
+                 RETURNING id",
+            )
+            .bind(tenant_id)
+            .bind(&company.slug)
+            .bind(&company.name)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(PostgresError::Database)?;
+            summary.companies_upserted += 1;
+
+            for org in &company.orgs {
+                let org_id: Uuid = sqlx::query_scalar(
+                    "INSERT INTO organizations (company_id, slug, name, created_at, updated_at)
+                     VALUES ($1, $2, $3, NOW(), NOW())
+                     ON CONFLICT (company_id, slug)
+                     DO UPDATE SET name = EXCLUDED.name, updated_at = NOW()
+                     RETURNING id",
+                )
+                .bind(company_id)
+                .bind(&org.slug)
+                .bind(&org.name)
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(PostgresError::Database)?;
+                summary.orgs_upserted += 1;
+
+                for team in &org.teams {
+                    sqlx::query(
+                        "INSERT INTO teams (org_id, slug, name, created_at, updated_at)
+                         VALUES ($1, $2, $3, NOW(), NOW())
+                         ON CONFLICT (org_id, slug)
+                         DO UPDATE SET name = EXCLUDED.name, updated_at = NOW()",
+                    )
+                    .bind(org_id)
+                    .bind(&team.slug)
+                    .bind(&team.name)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(PostgresError::Database)?;
+                    summary.teams_upserted += 1;
+                }
+            }
+        }
+
+        tx.commit().await.map_err(PostgresError::Database)?;
+        Ok(summary)
+    }
+
+    /// Read the full hierarchy for `tenant_id` as a nested `Vec<Company>`.
+    ///
+    /// Uses `v_hierarchy` so any future view changes (e.g. surfacing
+    /// project-level rows) centralize in the migration, not here. The
+    /// view produces a row per (company, org, team, project) with
+    /// LEFT JOINs, so we see each company at least once even if it has
+    /// no orgs; we fold the flat rowset back into the nested shape.
+    ///
+    /// Ordering: companies by slug, orgs by slug within company, teams
+    /// by slug within org. Deterministic so round-trip equality in
+    /// integration tests is meaningful.
+    pub async fn get_hierarchy(&self, tenant_id: Uuid) -> Result<Vec<Company>, PostgresError> {
+        let rows = sqlx::query(
+            "SELECT company_id, company_slug, company_name,
+                    org_id, org_slug, org_name,
+                    team_id, team_slug, team_name
+               FROM v_hierarchy
+              WHERE tenant_id = $1
+              ORDER BY company_slug, org_slug NULLS FIRST, team_slug NULLS FIRST",
+        )
+        .bind(tenant_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(PostgresError::Database)?;
+
+        let mut companies: Vec<Company> = Vec::new();
+        for row in rows {
+            let company_id: Uuid = row.get("company_id");
+            let company_slug: String = row.get("company_slug");
+            let company_name: String = row.get("company_name");
+
+            let company_idx = match companies.iter().position(|c| c.id == company_id) {
+                Some(idx) => idx,
+                None => {
+                    companies.push(Company {
+                        id: company_id,
+                        tenant_id,
+                        slug: company_slug,
+                        name: company_name,
+                        orgs: Vec::new(),
+                    });
+                    companies.len() - 1
+                }
+            };
+
+            let org_id: Option<Uuid> = row.try_get("org_id").ok();
+            let Some(org_id) = org_id else {
+                continue;
+            };
+            let org_slug: String = row.get("org_slug");
+            let org_name: String = row.get("org_name");
+
+            let company = &mut companies[company_idx];
+            let org_idx = match company.orgs.iter().position(|o| o.id == org_id) {
+                Some(idx) => idx,
+                None => {
+                    company.orgs.push(Org {
+                        id: org_id,
+                        company_id: company.id,
+                        slug: org_slug,
+                        name: org_name,
+                        teams: Vec::new(),
+                    });
+                    company.orgs.len() - 1
+                }
+            };
+
+            let team_id: Option<Uuid> = row.try_get("team_id").ok();
+            let Some(team_id) = team_id else {
+                continue;
+            };
+            let team_slug: String = row.get("team_slug");
+            let team_name: String = row.get("team_name");
+
+            let org = &mut company.orgs[org_idx];
+            if !org.teams.iter().any(|t| t.id == team_id) {
+                org.teams.push(Team {
+                    id: team_id,
+                    org_id: org.id,
+                    slug: team_slug,
+                    name: team_name,
+                });
+            }
+        }
+
+        Ok(companies)
+    }
+}
+
+#[cfg(test)]
+mod slugify_tests {
+    use super::slugify;
+
+    #[test]
+    fn lowercases_and_kebab_cases_ascii() {
+        assert_eq!(slugify("Acme Corp"), "acme-corp");
+        assert_eq!(slugify("Acme   Corp"), "acme-corp");
+        assert_eq!(slugify("Acme/Corp_2024"), "acme-corp-2024");
+    }
+
+    #[test]
+    fn strips_leading_and_trailing_non_alphanumerics() {
+        assert_eq!(slugify("   hello   "), "hello");
+        assert_eq!(slugify("--foo--"), "foo");
+        assert_eq!(slugify("///a//b///"), "a-b");
+    }
+
+    #[test]
+    fn empty_or_all_punctuation_becomes_unnamed() {
+        assert_eq!(slugify(""), "unnamed");
+        assert_eq!(slugify("   "), "unnamed");
+        assert_eq!(slugify("!!!"), "unnamed");
+    }
+
+    #[test]
+    fn unicode_is_lossy_but_nonempty() {
+        assert_eq!(slugify("café"), "caf");
+        assert_eq!(slugify("日本語"), "unnamed");
+        assert_eq!(slugify("日本 Corp"), "corp");
+    }
+
+    #[test]
+    fn preserves_digits_and_single_dashes() {
+        assert_eq!(slugify("team-42"), "team-42");
+        assert_eq!(slugify("v1.0 release"), "v1-0-release");
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -11,6 +11,7 @@ pub mod governance;
 pub mod graph;
 pub mod graph_duckdb;
 pub mod graphrag;
+pub mod hierarchy_store;
 pub mod kms;
 pub mod kms_integration;
 pub mod meta_governance;

--- a/storage/tests/hierarchy_store_test.rs
+++ b/storage/tests/hierarchy_store_test.rs
@@ -1,0 +1,212 @@
+//! Round-trip + idempotency tests for `HierarchyStore` (§2.2-B, B3).
+//!
+//! Docker-gated; mirrors the skip-on-no-Docker convention used by
+//! `migration_028_tenant_scoped_hierarchy_test.rs`.
+
+use sqlx::postgres::PgPoolOptions;
+use storage::hierarchy_store::{CompanyInput, HierarchyStore, OrgInput, TeamInput, slugify};
+use storage::migrations::apply_all;
+use storage::postgres::PostgresBackend;
+use testing::postgres;
+use uuid::Uuid;
+
+async fn fresh_tenant(pool: &sqlx::PgPool, tag: &str) -> Uuid {
+    let slug = format!("{tag}-{}", Uuid::new_v4().simple());
+    sqlx::query_scalar("INSERT INTO tenants (slug, name) VALUES ($1, $1) RETURNING id")
+        .bind(&slug)
+        .fetch_one(pool)
+        .await
+        .expect("insert tenant")
+}
+
+#[tokio::test]
+async fn hierarchy_store_round_trip_and_idempotent() {
+    let Some(pg) = postgres().await else {
+        eprintln!("Skipping hierarchy_store test: Docker not available");
+        return;
+    };
+    let pool = PgPoolOptions::new()
+        .max_connections(3)
+        .connect(pg.url())
+        .await
+        .expect("connect fixture");
+    PostgresBackend::new(pg.url())
+        .await
+        .expect("backend")
+        .initialize_schema()
+        .await
+        .expect("init schema");
+    apply_all(&pool).await.expect("apply_all");
+
+    let store = HierarchyStore::new(pool.clone());
+    let tenant_id = fresh_tenant(&pool, "hs-rt").await;
+
+    let input = vec![CompanyInput {
+        slug: "acme".into(),
+        name: "Acme Corp".into(),
+        orgs: vec![
+            OrgInput {
+                slug: "platform".into(),
+                name: "Platform".into(),
+                teams: vec![
+                    TeamInput {
+                        slug: "admins".into(),
+                        name: "Admins".into(),
+                    },
+                    TeamInput {
+                        slug: "sre".into(),
+                        name: "SRE".into(),
+                    },
+                ],
+            },
+            OrgInput {
+                slug: "product".into(),
+                name: "Product".into(),
+                teams: vec![],
+            },
+        ],
+    }];
+
+    // ---- First apply ----
+    let s1 = store
+        .upsert_hierarchy(tenant_id, &input)
+        .await
+        .expect("upsert 1");
+    assert_eq!(s1.companies_upserted, 1);
+    assert_eq!(s1.orgs_upserted, 2);
+    assert_eq!(s1.teams_upserted, 2);
+
+    // ---- Read back ----
+    let readback = store.get_hierarchy(tenant_id).await.expect("get_hierarchy");
+    assert_eq!(readback.len(), 1);
+    let c = &readback[0];
+    assert_eq!(c.slug, "acme");
+    assert_eq!(c.name, "Acme Corp");
+    assert_eq!(c.tenant_id, tenant_id);
+    assert_eq!(c.orgs.len(), 2);
+
+    // `ORDER BY org_slug` → platform before product.
+    assert_eq!(c.orgs[0].slug, "platform");
+    assert_eq!(c.orgs[0].teams.len(), 2);
+    // `ORDER BY team_slug` → admins before sre.
+    assert_eq!(c.orgs[0].teams[0].slug, "admins");
+    assert_eq!(c.orgs[0].teams[1].slug, "sre");
+
+    assert_eq!(c.orgs[1].slug, "product");
+    assert!(c.orgs[1].teams.is_empty());
+
+    // ---- Idempotent re-apply of identical input ----
+    let s2 = store
+        .upsert_hierarchy(tenant_id, &input)
+        .await
+        .expect("upsert 2");
+    assert_eq!(
+        s2, s1,
+        "repeat apply with identical input must report the same summary"
+    );
+
+    let readback2 = store
+        .get_hierarchy(tenant_id)
+        .await
+        .expect("get_hierarchy 2");
+    assert_eq!(
+        readback, readback2,
+        "hierarchy must be stable across repeat applies"
+    );
+
+    // ---- Rename (same slug, new name) flows through ON CONFLICT DO UPDATE ----
+    let mut renamed = input.clone();
+    renamed[0].name = "Acme Corporation".into();
+    renamed[0].orgs[0].name = "Platform Eng".into();
+    renamed[0].orgs[0].teams[0].name = "Platform Admins".into();
+    let _ = store
+        .upsert_hierarchy(tenant_id, &renamed)
+        .await
+        .expect("upsert rename");
+
+    let renamed_read = store.get_hierarchy(tenant_id).await.expect("get renamed");
+    assert_eq!(renamed_read[0].name, "Acme Corporation");
+    assert_eq!(renamed_read[0].orgs[0].name, "Platform Eng");
+    assert_eq!(renamed_read[0].orgs[0].teams[0].name, "Platform Admins");
+    // IDs must remain stable across rename.
+    assert_eq!(renamed_read[0].id, readback[0].id);
+    assert_eq!(renamed_read[0].orgs[0].id, readback[0].orgs[0].id);
+}
+
+#[tokio::test]
+async fn hierarchy_store_is_tenant_isolated() {
+    let Some(pg) = postgres().await else {
+        eprintln!("Skipping hierarchy_store isolation test: Docker not available");
+        return;
+    };
+    let pool = PgPoolOptions::new()
+        .max_connections(3)
+        .connect(pg.url())
+        .await
+        .expect("connect fixture");
+    PostgresBackend::new(pg.url())
+        .await
+        .expect("backend")
+        .initialize_schema()
+        .await
+        .expect("init schema");
+    apply_all(&pool).await.expect("apply_all");
+
+    let store = HierarchyStore::new(pool.clone());
+    let tenant_a = fresh_tenant(&pool, "hs-iso-a").await;
+    let tenant_b = fresh_tenant(&pool, "hs-iso-b").await;
+
+    // Same slug 'shared' under both tenants — migration 028 allows this.
+    let input_a = vec![CompanyInput {
+        slug: "shared".into(),
+        name: "A's Shared".into(),
+        orgs: vec![OrgInput {
+            slug: "eng".into(),
+            name: "Eng".into(),
+            teams: vec![TeamInput {
+                slug: "t1".into(),
+                name: "Team One A".into(),
+            }],
+        }],
+    }];
+    let input_b = vec![CompanyInput {
+        slug: "shared".into(),
+        name: "B's Shared".into(),
+        orgs: vec![OrgInput {
+            slug: "eng".into(),
+            name: "Eng".into(),
+            teams: vec![TeamInput {
+                slug: "t1".into(),
+                name: "Team One B".into(),
+            }],
+        }],
+    }];
+
+    store.upsert_hierarchy(tenant_a, &input_a).await.expect("a");
+    store.upsert_hierarchy(tenant_b, &input_b).await.expect("b");
+
+    let read_a = store.get_hierarchy(tenant_a).await.expect("read a");
+    let read_b = store.get_hierarchy(tenant_b).await.expect("read b");
+
+    assert_eq!(read_a.len(), 1);
+    assert_eq!(read_b.len(), 1);
+    assert_eq!(read_a[0].name, "A's Shared");
+    assert_eq!(read_b[0].name, "B's Shared");
+    assert_ne!(
+        read_a[0].id, read_b[0].id,
+        "different tenants with same slug must have distinct company UUIDs"
+    );
+    assert_ne!(read_a[0].orgs[0].teams[0].id, read_b[0].orgs[0].teams[0].id);
+    assert_eq!(read_a[0].orgs[0].teams[0].name, "Team One A");
+    assert_eq!(read_b[0].orgs[0].teams[0].name, "Team One B");
+}
+
+#[test]
+fn slugify_matches_bootstrap_convention() {
+    // Sanity bridge between slugify() and the slugs bootstrap.rs/idp-sync
+    // are known to produce. Not exhaustive — see hierarchy_store::slugify_tests
+    // for the full rule-level coverage.
+    assert_eq!(slugify("Default"), "default");
+    assert_eq!(slugify("Platform"), "platform");
+    assert_eq!(slugify("Admins"), "admins");
+}

--- a/storage/tests/migration_029_agents_tenant_scope_test.rs
+++ b/storage/tests/migration_029_agents_tenant_scope_test.rs
@@ -21,8 +21,8 @@
 use sqlx::Row;
 use sqlx::postgres::PgPoolOptions;
 use storage::migrations::MIGRATIONS;
-use testcontainers::runners::AsyncRunner;
 use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
 use uuid::Uuid;
 
@@ -55,9 +55,7 @@ async fn apply_up_to(pool: &sqlx::PgPool, exclusive_upper: i32) {
         sqlx::raw_sql(migration.sql)
             .execute(&mut *tx)
             .await
-            .unwrap_or_else(|e| {
-                panic!("apply migration {} failed: {e}", migration.name)
-            });
+            .unwrap_or_else(|e| panic!("apply migration {} failed: {e}", migration.name));
         tx.commit().await.expect("commit");
     }
 }
@@ -72,10 +70,7 @@ async fn apply_migration_029(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
     tx.commit().await
 }
 
-async fn seed_tenant_with_company(
-    pool: &sqlx::PgPool,
-    slug: &str,
-) -> (Uuid, Uuid, Uuid) {
+async fn seed_tenant_with_company(pool: &sqlx::PgPool, slug: &str) -> (Uuid, Uuid, Uuid) {
     let tenant_id = Uuid::new_v4();
     sqlx::query(
         "INSERT INTO tenants (id, slug, name, status, source_owner)
@@ -83,21 +78,31 @@ async fn seed_tenant_with_company(
     )
     .bind(tenant_id)
     .bind(slug)
-    .execute(pool).await.expect("insert tenant");
+    .execute(pool)
+    .await
+    .expect("insert tenant");
 
     let company_id = Uuid::new_v4();
     sqlx::query(
         "INSERT INTO companies (id, tenant_id, slug, name)
          VALUES ($1, $2, 'acme', 'Acme')",
     )
-    .bind(company_id).bind(tenant_id).execute(pool).await.expect("insert company");
+    .bind(company_id)
+    .bind(tenant_id)
+    .execute(pool)
+    .await
+    .expect("insert company");
 
     let user_id = Uuid::new_v4();
     sqlx::query(
         "INSERT INTO users (id, email, name, status)
          VALUES ($1, $2, 'User', 'active')",
     )
-    .bind(user_id).bind(format!("u+{slug}@acme.com")).execute(pool).await.expect("insert user");
+    .bind(user_id)
+    .bind(format!("u+{slug}@acme.com"))
+    .execute(pool)
+    .await
+    .expect("insert user");
 
     (tenant_id, company_id, user_id)
 }
@@ -140,12 +145,20 @@ async fn migration_029_backfills_single_tenant_agent() {
     let (tenant, company, user) = seed_tenant_with_company(&pool, "single").await;
     let agent = insert_pre_migration_agent(&pool, user, &[company], "active").await;
 
-    apply_migration_029(&pool).await.expect("migration should succeed");
+    apply_migration_029(&pool)
+        .await
+        .expect("migration should succeed");
 
     let row = sqlx::query("SELECT tenant_id FROM agents WHERE id = $1")
-        .bind(agent).fetch_one(&pool).await.expect("fetch agent");
+        .bind(agent)
+        .fetch_one(&pool)
+        .await
+        .expect("fetch agent");
     let actual: Uuid = row.get("tenant_id");
-    assert_eq!(actual, tenant, "backfill should assign the company's tenant");
+    assert_eq!(
+        actual, tenant,
+        "backfill should assign the company's tenant"
+    );
 }
 
 #[tokio::test]
@@ -158,9 +171,9 @@ async fn migration_029_aborts_on_cross_tenant_agent() {
     let (_, company_b, _) = seed_tenant_with_company(&pool, "nu").await;
     let _agent = insert_pre_migration_agent(&pool, user, &[company_a, company_b], "active").await;
 
-    let err = apply_migration_029(&pool).await.expect_err(
-        "cross-tenant agent must abort migration",
-    );
+    let err = apply_migration_029(&pool)
+        .await
+        .expect_err("cross-tenant agent must abort migration");
     let msg = format!("{err}");
     assert!(
         msg.contains("spanning multiple tenants"),
@@ -178,9 +191,9 @@ async fn migration_029_aborts_on_unscoped_active_agent() {
     // Agent with empty allowed_* arrays — no derivable tenant.
     let _agent = insert_pre_migration_agent(&pool, user, &[], "active").await;
 
-    let err = apply_migration_029(&pool).await.expect_err(
-        "unscoped active agent must abort migration",
-    );
+    let err = apply_migration_029(&pool)
+        .await
+        .expect_err("unscoped active agent must abort migration");
     let msg = format!("{err}");
     assert!(
         msg.contains("no derivable tenant"),
@@ -199,10 +212,18 @@ async fn migration_029_leaves_revoked_agents_null() {
     // and should retain NULL tenant_id afterward.
     let agent = insert_pre_migration_agent(&pool, user, &[], "revoked").await;
 
-    apply_migration_029(&pool).await.expect("revoked unscoped agent should not abort");
+    apply_migration_029(&pool)
+        .await
+        .expect("revoked unscoped agent should not abort");
 
     let row = sqlx::query("SELECT tenant_id FROM agents WHERE id = $1")
-        .bind(agent).fetch_one(&pool).await.expect("fetch revoked");
+        .bind(agent)
+        .fetch_one(&pool)
+        .await
+        .expect("fetch revoked");
     let actual: Option<Uuid> = row.get("tenant_id");
-    assert!(actual.is_none(), "revoked agent should retain NULL tenant_id, got {actual:?}");
+    assert!(
+        actual.is_none(),
+        "revoked agent should retain NULL tenant_id, got {actual:?}"
+    );
 }


### PR DESCRIPTION
Third of four commits in the §2.2-B hierarchy storage+apply chain
(harden-tenant-provisioning). The blast-radius analysis lives in
`openspec/changes/harden-tenant-provisioning/NOTES-hierarchy-migration-blast-radius.md`
under the "Commit plan on PR #129" section.

## What landed before this

- **B1** — blast-radius notes (landed in #129 series).
- **B2** — migration `028_tenant_scoped_hierarchy.sql` (+ bootstrap.rs
  tenant_id/slug constraint surgery). Already in master.

## What this PR does

Adds `storage::hierarchy_store::HierarchyStore`, the Rust read/write
surface for the modern tenant-scoped `companies` / `organizations` /
`teams` tables — the same tables that bootstrap and idp-sync already
populate, and that `v_hierarchy` / `v_user_permissions` surface to
OPAL.

- `HierarchyStore::upsert_hierarchy(tenant_id, &[CompanyInput])` writes
  the full tree in a single transaction. `ON CONFLICT DO UPDATE SET name`
  gives idempotent repeat-apply and in-place rename.
- `HierarchyStore::get_hierarchy(tenant_id) -> Vec<Company>` reads
  through `v_hierarchy` and folds the flat LEFT JOIN rowset into the
  nested shape, deterministically ordered by slug at every level.
- `slugify(name)` derives per-parent slugs from free-form manifest
  names (lossy ASCII kebab-case, `"unnamed"` fallback for empty /
  all-punctuation inputs). The manifest schema keeps `name` only;
  adding an explicit `slug` field is a future manifest-schema bump,
  not in scope here.

## What is NOT in this PR

- **`provision_tenant` wiring.** The existing apply step still writes
  `organizational_units` only. B4 will call `upsert_hierarchy` from the
  provision path alongside (or replacing) the OU write. Keeping the
  wiring out of this PR keeps the diff at storage-layer only.
- **Prune semantics.** Soft-deleting rows absent from the manifest is
  deferred to B4 because it must interact correctly with idp-synced
  teams (migration 030 `external_id`/`idp_provider`), which a
  manifest-apply must NOT prune. That coordination fits better in the
  apply-wiring commit.
- **Reverse render + `NOT_RENDERED_SECTIONS` shrink.** Also B4.

## Tests

- 5 always-on unit tests for `slugify` (ASCII, leading/trailing
  punctuation, empty/all-punctuation, Unicode lossy but deterministic,
  digits + dashes preserved).
- 2 Docker-gated integration tests in
  `storage/tests/hierarchy_store_test.rs`:
  - `hierarchy_store_round_trip_and_idempotent` — upsert, read back,
    verify ordering and counts, re-apply identical input (summary and
    readback must be equal), rename flow (same slug, new name flows
    through `ON CONFLICT DO UPDATE`, UUIDs remain stable).
  - `hierarchy_store_is_tenant_isolated` — two tenants with the same
    company slug `shared` produce distinct UUIDs and distinct data;
    explicit regression guard for the migration 028 constraint flip
    from global `UNIQUE(slug)` to `UNIQUE(tenant_id, slug)`.

## Verification

- `cargo check -p storage --lib` ✅
- `cargo check -p storage --tests` ✅
- `cargo test -p storage --lib hierarchy_store::slugify_tests` → 5/5 ✅
- `cargo fmt --all` ✅
- `cargo clippy -p storage --all-targets -- -D clippy::correctness -D clippy::suspicious` ✅

Docker-gated integration tests skip cleanly when Docker is unavailable
(matches migration_028/029 convention), and will run in CI environments
with Docker.

## Commits

1. `feat(storage): HierarchyStore for tenant-scoped companies/orgs/teams (§2.2-B B3)`
2. `style: absorb pre-existing rustfmt drift in two test files` —
   drive-by; `cargo fmt --all` caught drift in
   `opal-fetcher/tests/tenant_isolation_test.rs` and
   `storage/tests/migration_029_agents_tenant_scope_test.rs` that
   predates this branch.

## Follow-up

- **B4** — `provision_tenant` apply wiring, reverse render via
  `manifest_render::render_hierarchy`, shrink `NOT_RENDERED_SECTIONS`
  to remove `"hierarchy"`, plus round-trip integration test in
  `cli/src/server/tenant_api.rs`.

Refs: harden-tenant-provisioning §2.2-B.
