### PR TITLE
feat(server): service-token lifecycle (B2 §10.2/§10.4/§10.6)

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - run: cargo fmt --all --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: clippy

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -443,11 +443,7 @@ impl AeternaClient {
     /// flag only controls whether the *names* of the secret refs are
     /// visible. This matches the `RenderQuery` contract in
     /// `manifest_api.rs`.
-    pub async fn tenant_manifest(
-        &self,
-        tenant: &str,
-        redact: bool,
-    ) -> Result<serde_json::Value> {
+    pub async fn tenant_manifest(&self, tenant: &str, redact: bool) -> Result<serde_json::Value> {
         let path = if redact {
             format!("/api/v1/admin/tenants/{tenant}/manifest?redact=true")
         } else {

--- a/cli/src/commands/tenant.rs
+++ b/cli/src/commands/tenant.rs
@@ -3040,10 +3040,16 @@ mod tests {
             "tenant": {"slug": "acme"},
         });
         let s = serialize_rendered_manifest(&v).unwrap();
-        assert!(s.ends_with('\n'), "output must end with exactly one newline: {s:?}");
+        assert!(
+            s.ends_with('\n'),
+            "output must end with exactly one newline: {s:?}"
+        );
         assert!(!s.ends_with("\n\n"), "no double newline: {s:?}");
         // Indent check — `to_string_pretty` uses two spaces.
-        assert!(s.contains("  \"apiVersion\""), "expected 2-space indent: {s}");
+        assert!(
+            s.contains("  \"apiVersion\""),
+            "expected 2-space indent: {s}"
+        );
         // Round-trips back to the same JSON.
         let v2: serde_json::Value = serde_json::from_str(&s).unwrap();
         assert_eq!(v, v2);

--- a/cli/src/server/mod.rs
+++ b/cli/src/server/mod.rs
@@ -23,6 +23,7 @@ pub mod project_api;
 pub mod request_context;
 pub mod role_grants;
 pub mod router;
+pub mod service_tokens;
 pub mod sessions;
 pub mod sync;
 pub mod team_api;

--- a/cli/src/server/router.rs
+++ b/cli/src/server/router.rs
@@ -18,7 +18,8 @@ use super::auth_middleware::AuthenticationLayer;
 use super::{
     AppState, admin_sync, backup_api, bootstrap_api, govern_api, health, knowledge_api,
     lifecycle_api, manifest_api, mcp_transport, memory_api, org_api, plugin_auth, project_api,
-    role_grants, sessions, sync, team_api, tenant_api, tenant_wiring_api, user_api, webhooks,
+    role_grants, service_tokens, sessions, sync, team_api, tenant_api, tenant_wiring_api, user_api,
+    webhooks,
 };
 
 pub fn build_router(state: Arc<AppState>) -> Router {
@@ -56,6 +57,12 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .merge(project_api::router(state.clone()))
         .merge(user_api::router(state.clone()))
         .nest("/admin", role_grants::router(state.clone()))
+        // B2 §10.2 / §10.4 / §10.6 — service-token lifecycle
+        // (mint / revoke / list). PlatformAdmin-gated inside the
+        // handlers; routes are `/auth/tokens{,/:id}` relative to
+        // this protected_api, so they become
+        // `/api/v1/auth/tokens{,/:id}` once nested.
+        .merge(service_tokens::router(state.clone()))
         .merge(govern_api::router(state.clone()))
         .merge(sync::router(state.clone()))
         .merge(memory_api::router(state.clone()))

--- a/cli/src/server/service_tokens.rs
+++ b/cli/src/server/service_tokens.rs
@@ -1,0 +1,722 @@
+//! B2 §10.2 / §10.4 / §10.6 — Service token lifecycle (mint / revoke / list).
+//!
+//! A service token is an `Aeterna::Agent` principal with
+//! `agent_type = "service"`, persisted in the `agents` table
+//! (migrations 009 + 029 already provide the full schema — no new
+//! migration is introduced by this module).
+//!
+//! Mint is **PlatformAdmin-only**. The raw JWT is returned exactly once
+//! at mint time and is not re-derivable. List / revoke are also
+//! PlatformAdmin-only for v1; a TenantAdmin self-service surface is a
+//! deliberate follow-up.
+//!
+//! Endpoints:
+//!
+//! * `POST   /api/v1/auth/tokens`         — mint (§10.2)
+//! * `GET    /api/v1/auth/tokens`         — list active tokens (§10.6)
+//! * `DELETE /api/v1/auth/tokens/:id`     — revoke (§10.4)
+//!
+//! JWT shape (piggy-backs on §10.1 claims):
+//!
+//! * `sub`        = agent UUID (string form)
+//! * `tenant_id`  = tenant UUID (string form)
+//! * `token_type` = `"service"`   (§10.1 `PluginTokenClaims::TOKEN_TYPE_SERVICE`)
+//! * `scopes`     = the granted capability list
+//! * `kind`       = `"plugin-access"` (reused so existing validator works)
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{delete, post};
+use axum::{Json, Router};
+use chrono::{DateTime, Utc};
+use jsonwebtoken::{EncodingKey, Header, encode};
+use mk_core::types::{Role, RoleIdentifier};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sqlx::Row;
+use uuid::Uuid;
+
+use super::plugin_auth::PluginTokenClaims;
+use super::{AppState, authenticated_platform_context};
+
+// ─── Constants ────────────────────────────────────────────────────────────
+
+pub const DEFAULT_EXPIRES_IN_SECONDS: u64 = 4 * 60 * 60;
+pub const MIN_EXPIRES_IN_SECONDS: u64 = 60;
+pub const MAX_EXPIRES_IN_SECONDS: u64 = 24 * 60 * 60;
+pub const MAX_NAME_LEN: usize = 255;
+
+pub const KNOWN_CAPABILITIES: &[&str] = &[
+    "memory:read",
+    "memory:write",
+    "memory:delete",
+    "memory:promote",
+    "knowledge:read",
+    "knowledge:propose",
+    "knowledge:edit",
+    "policy:read",
+    "policy:create",
+    "policy:simulate",
+    "governance:read",
+    "governance:submit",
+    "org:read",
+    "agent:register",
+    "agent:delegate",
+];
+
+// ─── Request / response types ───────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MintServiceTokenRequest {
+    pub name: String,
+    pub tenant_id: String,
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub expires_in_seconds: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MintServiceTokenResponse {
+    pub token_id: Uuid,
+    pub token: String,
+    pub name: String,
+    pub tenant_id: Uuid,
+    pub tenant_slug: String,
+    pub capabilities: Vec<String>,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceTokenSummary {
+    pub token_id: Uuid,
+    pub name: String,
+    pub tenant_id: Uuid,
+    pub capabilities: Vec<String>,
+    pub status: String,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub created_by: Option<Uuid>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ListTokensQuery {
+    #[serde(default)]
+    pub tenant_id: Option<String>,
+    #[serde(default)]
+    pub include_revoked: Option<bool>,
+}
+
+// ─── Router ───────────────────────────────────────────────────────────────
+
+pub fn router(state: Arc<AppState>) -> Router {
+    // Paths are relative — `build_router` nests the protected router
+    // under `/api/v1`, so these become `/api/v1/auth/tokens{,/:id}`.
+    Router::new()
+        .route("/auth/tokens", post(mint_handler).get(list_handler))
+        .route("/auth/tokens/:id", delete(revoke_handler))
+        .with_state(state)
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+fn error_response(status: StatusCode, code: &str, message: &str) -> Response {
+    (status, Json(json!({ "error": code, "message": message }))).into_response()
+}
+
+async fn require_platform_admin(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<mk_core::types::UserId, Response> {
+    let (user_id, roles) = authenticated_platform_context(state, headers).await?;
+    let pa: RoleIdentifier = Role::PlatformAdmin.into();
+    if !roles.iter().any(|r| r == &pa) {
+        return Err(error_response(
+            StatusCode::FORBIDDEN,
+            "forbidden_scope",
+            "PlatformAdmin role required",
+        ));
+    }
+    Ok(user_id)
+}
+
+pub fn validate_capabilities(caps: &[String]) -> Result<(), (StatusCode, &'static str, String)> {
+    if caps.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "capabilities must be a non-empty array".to_string(),
+        ));
+    }
+    for cap in caps {
+        if cap.len() > 128 {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "invalid_capability",
+                format!("capability exceeds 128 chars: {cap}"),
+            ));
+        }
+        if !KNOWN_CAPABILITIES
+            .iter()
+            .any(|known| *known == cap.as_str())
+        {
+            return Err((
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "invalid_capability",
+                format!("unknown capability: {cap}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn resolve_expires_in(requested: Option<u64>) -> Result<u64, (StatusCode, String)> {
+    let v = requested.unwrap_or(DEFAULT_EXPIRES_IN_SECONDS);
+    if !(MIN_EXPIRES_IN_SECONDS..=MAX_EXPIRES_IN_SECONDS).contains(&v) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "expiresInSeconds must be between {MIN_EXPIRES_IN_SECONDS} and {MAX_EXPIRES_IN_SECONDS}"
+            ),
+        ));
+    }
+    Ok(v)
+}
+
+pub fn validate_name(name: &str) -> Result<&str, (StatusCode, String)> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() || trimmed.len() > MAX_NAME_LEN {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("name must be 1..={MAX_NAME_LEN} chars"),
+        ));
+    }
+    Ok(trimmed)
+}
+
+pub fn mint_service_jwt(
+    jwt_secret: &str,
+    issuer: &str,
+    agent_id: Uuid,
+    tenant_id: Uuid,
+    capabilities: &[String],
+    ttl_seconds: u64,
+    jti: Uuid,
+) -> Result<String, jsonwebtoken::errors::Error> {
+    let now = Utc::now().timestamp();
+    let claims = PluginTokenClaims {
+        sub: agent_id.to_string(),
+        idp_provider: "aeterna-service".to_string(),
+        tenant_id: tenant_id.to_string(),
+        iss: issuer.to_string(),
+        aud: vec![PluginTokenClaims::AUDIENCE.to_string()],
+        iat: now,
+        exp: now + ttl_seconds as i64,
+        jti: jti.to_string(),
+        github_id: 0,
+        email: None,
+        kind: PluginTokenClaims::KIND.to_string(),
+        token_type: PluginTokenClaims::TOKEN_TYPE_SERVICE.to_string(),
+        scopes: capabilities.to_vec(),
+    };
+    let key = EncodingKey::from_secret(jwt_secret.as_bytes());
+    encode(&Header::new(jsonwebtoken::Algorithm::HS256), &claims, &key)
+}
+
+// ─── Handlers ──────────────────────────────────────────────────────────────
+
+async fn mint_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<MintServiceTokenRequest>,
+) -> Response {
+    let caller_uid = match require_platform_admin(&state, &headers).await {
+        Ok(uid) => uid,
+        Err(resp) => return resp,
+    };
+
+    let name = match validate_name(&req.name) {
+        Ok(n) => n.to_string(),
+        Err((status, msg)) => return error_response(status, "invalid_request", &msg),
+    };
+    if let Err((status, code, msg)) = validate_capabilities(&req.capabilities) {
+        return error_response(status, code, &msg);
+    }
+    let ttl = match resolve_expires_in(req.expires_in_seconds) {
+        Ok(v) => v,
+        Err((status, msg)) => return error_response(status, "invalid_request", &msg),
+    };
+
+    let tenant = match state.tenant_store.get_tenant(&req.tenant_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return error_response(
+                StatusCode::NOT_FOUND,
+                "tenant_not_found",
+                &format!("tenant not found: {}", req.tenant_id),
+            );
+        }
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "tenant_lookup_failed",
+                &e.to_string(),
+            );
+        }
+    };
+
+    let tenant_uuid = match Uuid::parse_str(tenant.id.as_str()) {
+        Ok(u) => u,
+        Err(_) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "tenant_uuid_malformed",
+                "tenant.id is not a valid UUID",
+            );
+        }
+    };
+
+    let caller_uuid = match Uuid::parse_str(caller_uid.as_str()) {
+        Ok(u) => u,
+        Err(_) => {
+            return error_response(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "caller_identity_not_uuid",
+                "Service-token mint requires a UUID-addressable caller",
+            );
+        }
+    };
+
+    let agent_id = Uuid::new_v4();
+    let jti = Uuid::new_v4();
+    let now = Utc::now();
+    let expires_at = now + chrono::Duration::seconds(ttl as i64);
+    let caps_json = match serde_json::to_value(&req.capabilities) {
+        Ok(v) => v,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "capabilities_serialize_failed",
+                &e.to_string(),
+            );
+        }
+    };
+
+    let insert_result = sqlx::query(
+        r#"
+        INSERT INTO agents (
+            id, name, agent_type, tenant_id,
+            delegated_by_user_id, delegation_depth, max_delegation_depth,
+            capabilities, status, expires_at, created_at, updated_at
+        ) VALUES (
+            $1, $2, 'service', $3,
+            $4, 1, 3,
+            $5, 'active', $6, $7, $7
+        )
+        "#,
+    )
+    .bind(agent_id)
+    .bind(&name)
+    .bind(tenant_uuid)
+    .bind(caller_uuid)
+    .bind(caps_json)
+    .bind(expires_at)
+    .bind(now)
+    .execute(state.postgres.pool())
+    .await;
+
+    if let Err(e) = insert_result {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "agent_insert_failed",
+            &e.to_string(),
+        );
+    }
+
+    let cfg = &state.plugin_auth_state.config;
+    let jwt_secret = match cfg.jwt_secret.as_deref() {
+        Some(s) => s,
+        None => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "configuration_error",
+                "JWT secret is not configured",
+            );
+        }
+    };
+    let issuer = cfg
+        .token_issuer
+        .clone()
+        .unwrap_or_else(|| "aeterna".to_string());
+
+    let token = match mint_service_jwt(
+        jwt_secret,
+        &issuer,
+        agent_id,
+        tenant_uuid,
+        &req.capabilities,
+        ttl,
+        jti,
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "token_mint_failed",
+                &e.to_string(),
+            );
+        }
+    };
+
+    tracing::info!(
+        agent_id = %agent_id,
+        tenant_id = %tenant_uuid,
+        caller_uid = %caller_uuid,
+        ttl_seconds = ttl,
+        capabilities = ?req.capabilities,
+        "Minted service token",
+    );
+
+    (
+        StatusCode::CREATED,
+        Json(MintServiceTokenResponse {
+            token_id: agent_id,
+            token,
+            name,
+            tenant_id: tenant_uuid,
+            tenant_slug: tenant.slug.clone(),
+            capabilities: req.capabilities,
+            expires_at,
+            created_at: now,
+        }),
+    )
+        .into_response()
+}
+
+async fn revoke_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(token_id): Path<Uuid>,
+) -> Response {
+    if let Err(resp) = require_platform_admin(&state, &headers).await {
+        return resp;
+    }
+
+    let result = sqlx::query(
+        r#"
+        UPDATE agents
+        SET status = 'revoked',
+            updated_at = NOW()
+        WHERE id = $1
+          AND agent_type = 'service'
+          AND status = 'active'
+        "#,
+    )
+    .bind(token_id)
+    .execute(state.postgres.pool())
+    .await;
+
+    match result {
+        Ok(r) if r.rows_affected() == 0 => error_response(
+            StatusCode::NOT_FOUND,
+            "token_not_found",
+            "service token not found, already revoked, or not a service token",
+        ),
+        Ok(_) => {
+            tracing::info!(token_id = %token_id, "Revoked service token");
+            (
+                StatusCode::OK,
+                Json(json!({ "revoked": true, "tokenId": token_id })),
+            )
+                .into_response()
+        }
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "revoke_failed",
+            &e.to_string(),
+        ),
+    }
+}
+
+async fn list_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(q): Query<ListTokensQuery>,
+) -> Response {
+    if let Err(resp) = require_platform_admin(&state, &headers).await {
+        return resp;
+    }
+
+    let include_revoked = q.include_revoked.unwrap_or(false);
+
+    let tenant_filter: Option<Uuid> = match q.tenant_id.as_ref() {
+        Some(tid) => match state.tenant_store.get_tenant(tid).await {
+            Ok(Some(t)) => match Uuid::parse_str(t.id.as_str()) {
+                Ok(u) => Some(u),
+                Err(_) => {
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "tenant_uuid_malformed",
+                        "tenant.id is not a valid UUID",
+                    );
+                }
+            },
+            Ok(None) => {
+                return error_response(
+                    StatusCode::NOT_FOUND,
+                    "tenant_not_found",
+                    &format!("tenant not found: {tid}"),
+                );
+            }
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "tenant_lookup_failed",
+                    &e.to_string(),
+                );
+            }
+        },
+        None => None,
+    };
+
+    let rows_result = sqlx::query(
+        r#"
+        SELECT
+            id,
+            name,
+            tenant_id,
+            capabilities,
+            status,
+            expires_at,
+            created_at,
+            delegated_by_user_id
+        FROM agents
+        WHERE agent_type = 'service'
+          AND deleted_at IS NULL
+          AND ($1 OR status = 'active')
+          AND ($2::uuid IS NULL OR tenant_id = $2)
+          AND (expires_at IS NULL OR expires_at > NOW())
+        ORDER BY created_at DESC
+        "#,
+    )
+    .bind(include_revoked)
+    .bind(tenant_filter)
+    .fetch_all(state.postgres.pool())
+    .await;
+
+    let rows = match rows_result {
+        Ok(r) => r,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "list_failed",
+                &e.to_string(),
+            );
+        }
+    };
+
+    let tokens: Vec<ServiceTokenSummary> = rows
+        .into_iter()
+        .map(|r| {
+            let caps: serde_json::Value = r.get("capabilities");
+            let capabilities: Vec<String> = serde_json::from_value(caps).unwrap_or_default();
+            ServiceTokenSummary {
+                token_id: r.get("id"),
+                name: r.get("name"),
+                tenant_id: r.get("tenant_id"),
+                capabilities,
+                status: r.get("status"),
+                expires_at: r.get("expires_at"),
+                created_at: r.get("created_at"),
+                created_by: r.get("delegated_by_user_id"),
+            }
+        })
+        .collect();
+
+    Json(json!({ "tokens": tokens })).into_response()
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{DecodingKey, Validation, decode};
+
+    fn caps(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn name_rejects_empty() {
+        assert!(validate_name("").is_err());
+        assert!(validate_name("   ").is_err());
+    }
+
+    #[test]
+    fn name_rejects_over_limit() {
+        let long = "x".repeat(MAX_NAME_LEN + 1);
+        assert!(validate_name(&long).is_err());
+    }
+
+    #[test]
+    fn name_accepts_reasonable() {
+        assert_eq!(
+            validate_name("ci-deployer-prod").unwrap(),
+            "ci-deployer-prod"
+        );
+        assert_eq!(validate_name("  trimmed  ").unwrap(), "trimmed");
+    }
+
+    #[test]
+    fn capabilities_rejects_empty() {
+        assert!(validate_capabilities(&[]).is_err());
+    }
+
+    #[test]
+    fn capabilities_rejects_unknown() {
+        let err = validate_capabilities(&caps(&["memory:yolo"])).unwrap_err();
+        assert_eq!(err.0, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(err.1, "invalid_capability");
+    }
+
+    #[test]
+    fn capabilities_rejects_oversized() {
+        let big = "x".repeat(129);
+        let err = validate_capabilities(&[big]).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn capabilities_unknown_string_rejected() {
+        assert!(
+            validate_capabilities(&caps(&["memory:read", "knowledge:search"])).is_err(),
+            "knowledge:search is not in the allow-list"
+        );
+        assert!(validate_capabilities(&caps(&["memory:read", "knowledge:read"])).is_ok());
+    }
+
+    #[test]
+    fn capabilities_full_known_set_is_accepted() {
+        let all: Vec<String> = KNOWN_CAPABILITIES.iter().map(|s| s.to_string()).collect();
+        assert!(validate_capabilities(&all).is_ok());
+    }
+
+    #[test]
+    fn expires_in_default_is_four_hours() {
+        assert_eq!(
+            resolve_expires_in(None).unwrap(),
+            DEFAULT_EXPIRES_IN_SECONDS
+        );
+    }
+
+    #[test]
+    fn expires_in_below_min_is_rejected() {
+        assert!(resolve_expires_in(Some(MIN_EXPIRES_IN_SECONDS - 1)).is_err());
+    }
+
+    #[test]
+    fn expires_in_above_max_is_rejected() {
+        assert!(resolve_expires_in(Some(MAX_EXPIRES_IN_SECONDS + 1)).is_err());
+    }
+
+    #[test]
+    fn expires_in_at_bounds_is_accepted() {
+        assert_eq!(
+            resolve_expires_in(Some(MIN_EXPIRES_IN_SECONDS)).unwrap(),
+            MIN_EXPIRES_IN_SECONDS
+        );
+        assert_eq!(
+            resolve_expires_in(Some(MAX_EXPIRES_IN_SECONDS)).unwrap(),
+            MAX_EXPIRES_IN_SECONDS
+        );
+    }
+
+    #[test]
+    fn service_jwt_round_trip() {
+        let secret = "unit-test-secret";
+        let agent_id = Uuid::new_v4();
+        let tenant_id = Uuid::new_v4();
+        let jti = Uuid::new_v4();
+        let cap_list = caps(&["memory:read", "knowledge:read"]);
+
+        let token = mint_service_jwt(
+            secret,
+            "aeterna-test",
+            agent_id,
+            tenant_id,
+            &cap_list,
+            3600,
+            jti,
+        )
+        .unwrap();
+
+        let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
+        validation.set_audience(&[PluginTokenClaims::AUDIENCE]);
+        validation.set_issuer(&["aeterna-test"]);
+
+        let decoded = decode::<PluginTokenClaims>(
+            &token,
+            &DecodingKey::from_secret(secret.as_bytes()),
+            &validation,
+        )
+        .unwrap();
+
+        assert_eq!(decoded.claims.sub, agent_id.to_string());
+        assert_eq!(decoded.claims.tenant_id, tenant_id.to_string());
+        assert_eq!(
+            decoded.claims.token_type,
+            PluginTokenClaims::TOKEN_TYPE_SERVICE
+        );
+        assert_eq!(decoded.claims.kind, PluginTokenClaims::KIND);
+        assert_eq!(decoded.claims.scopes, cap_list);
+        assert_eq!(decoded.claims.github_id, 0);
+        assert_eq!(decoded.claims.email, None);
+        assert_eq!(decoded.claims.jti, jti.to_string());
+        assert!(decoded.claims.exp > decoded.claims.iat);
+        assert_eq!(decoded.claims.exp - decoded.claims.iat, 3600);
+    }
+
+    #[test]
+    fn service_jwt_wrong_secret_fails_to_decode() {
+        let token = mint_service_jwt(
+            "right",
+            "aeterna-test",
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &caps(&["memory:read"]),
+            60,
+            Uuid::new_v4(),
+        )
+        .unwrap();
+
+        let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
+        validation.set_audience(&[PluginTokenClaims::AUDIENCE]);
+        validation.set_issuer(&["aeterna-test"]);
+
+        let decoded =
+            decode::<PluginTokenClaims>(&token, &DecodingKey::from_secret(b"wrong"), &validation);
+        assert!(decoded.is_err());
+    }
+
+    #[test]
+    fn known_capabilities_is_non_empty_and_unique() {
+        assert!(!KNOWN_CAPABILITIES.is_empty());
+        let mut sorted: Vec<&&str> = KNOWN_CAPABILITIES.iter().collect();
+        sorted.sort();
+        let len_before = sorted.len();
+        sorted.dedup();
+        assert_eq!(
+            len_before,
+            sorted.len(),
+            "KNOWN_CAPABILITIES must not contain duplicates"
+        );
+    }
+}

--- a/memory/src/provider_registry.rs
+++ b/memory/src/provider_registry.rs
@@ -310,8 +310,7 @@ impl TenantProviderRegistry {
             Some(reg) => reg.resolve(tenant, reference).await,
             None => Err(crate::secret_resolver::ResolveError::BackendUnavailable {
                 kind: "none",
-                reason: "no SecretResolverRegistry installed on TenantProviderRegistry"
-                    .to_string(),
+                reason: "no SecretResolverRegistry installed on TenantProviderRegistry".to_string(),
             }),
         }
     }
@@ -865,7 +864,11 @@ impl mk_core::traits::TenantConfigProvider for RegistryConfigAdapter {
         // 3. Dispatch through the typed registry by SecretReference
         //    variant. NotFound → Ok(None); other errors surface as
         //    adapter errors so the caller can log with context.
-        match self.secret_registry.resolve(tenant_id, &tsr.reference).await {
+        match self
+            .secret_registry
+            .resolve(tenant_id, &tsr.reference)
+            .await
+        {
             Ok(bytes) => Ok(Some(bytes)),
             Err(crate::secret_resolver::ResolveError::NotFound { .. }) => Ok(None),
             Err(e) => Err(RegistryAdapterError(format!(

--- a/memory/src/secret_resolver.rs
+++ b/memory/src/secret_resolver.rs
@@ -500,9 +500,9 @@ mod redaction_coverage {
     use super::*;
     use crate::secret_resolvers::{EnvRefResolver, InlineRefResolver};
     use async_trait::async_trait;
+    use mk_core::SecretBytes;
     use mk_core::secret::SecretReference;
     use mk_core::types::TenantId;
-    use mk_core::SecretBytes;
 
     /// The literal bytes we use as a sentinel “plaintext” in every test
     /// below. If any of these bytes appear in a rendered error message,
@@ -589,7 +589,10 @@ mod redaction_coverage {
         assert_no_plaintext(&rendered, SENTINEL_PLAINTEXT);
         // Both fields are `&'static str` — cannot carry dynamic data.
         match err {
-            ResolveError::WrongKind { expected: _, actual: _ } => {}
+            ResolveError::WrongKind {
+                expected: _,
+                actual: _,
+            } => {}
             _ => unreachable!(),
         }
     }
@@ -728,7 +731,12 @@ mod redaction_coverage {
         let mut registry = SecretResolverRegistry::new();
         registry.register(std::sync::Arc::new(LeakyResolver));
         let err = registry
-            .resolve(&tid(), &SecretReference::Env { var: "X".to_string() })
+            .resolve(
+                &tid(),
+                &SecretReference::Env {
+                    var: "X".to_string(),
+                },
+            )
             .await
             .unwrap_err();
         let rendered = format!("{err}");

--- a/memory/src/secret_resolvers/env.rs
+++ b/memory/src/secret_resolvers/env.rs
@@ -15,9 +15,9 @@
 //!   preserved into [`SecretBytes`] without lossy conversion.
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
 
@@ -87,7 +87,9 @@ mod tests {
     }
 
     fn env_ref(var: &str) -> SecretReference {
-        SecretReference::Env { var: var.to_string() }
+        SecretReference::Env {
+            var: var.to_string(),
+        }
     }
 
     // Use a unique env-var prefix per test to avoid cross-test
@@ -117,7 +119,10 @@ mod tests {
     async fn unset_variable_is_not_found() {
         unsafe { std::env::remove_var(TEST_VAR_UNSET) };
         let r = EnvRefResolver::new();
-        let err = r.resolve(&tid(), &env_ref(TEST_VAR_UNSET)).await.unwrap_err();
+        let err = r
+            .resolve(&tid(), &env_ref(TEST_VAR_UNSET))
+            .await
+            .unwrap_err();
         match err {
             ResolveError::NotFound { kind, .. } => assert_eq!(kind, "env"),
             other => panic!("expected NotFound, got {other:?}"),
@@ -141,13 +146,18 @@ mod tests {
     async fn var_name_with_equals_is_malformed() {
         let r = EnvRefResolver::new();
         let err = r.resolve(&tid(), &env_ref("FOO=BAR")).await.unwrap_err();
-        assert!(matches!(err, ResolveError::MalformedReference { kind: "env", .. }));
+        assert!(matches!(
+            err,
+            ResolveError::MalformedReference { kind: "env", .. }
+        ));
     }
 
     #[tokio::test]
     async fn wrong_kind_is_rejected() {
         let r = EnvRefResolver::new();
-        let file_ref = SecretReference::File { path: "/x".to_string() };
+        let file_ref = SecretReference::File {
+            path: "/x".to_string(),
+        };
         let err = r.resolve(&tid(), &file_ref).await.unwrap_err();
         match err {
             ResolveError::WrongKind { expected, actual } => {

--- a/memory/src/secret_resolvers/file.rs
+++ b/memory/src/secret_resolvers/file.rs
@@ -24,9 +24,9 @@
 use std::path::Path;
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 use tokio::io::AsyncReadExt;
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
@@ -48,12 +48,12 @@ impl FileRefResolver {
     #[cfg(unix)]
     async fn check_mode(path: &Path) -> Result<(), ResolveError> {
         use std::os::unix::fs::MetadataExt;
-        let md = tokio::fs::metadata(path).await.map_err(|e| {
-            ResolveError::BackendUnavailable {
+        let md = tokio::fs::metadata(path)
+            .await
+            .map_err(|e| ResolveError::BackendUnavailable {
                 kind: "file",
                 reason: format!("stat failed: {e}"),
-            }
-        })?;
+            })?;
         let mode = md.mode() & 0o777;
         if mode & 0o077 != 0 {
             return Err(ResolveError::PermissionDenied {
@@ -161,10 +161,12 @@ impl SecretRefResolver for FileRefResolver {
         })?;
 
         let mut buf = Vec::with_capacity(md.len() as usize);
-        file.read_to_end(&mut buf).await.map_err(|e| ResolveError::BackendUnavailable {
-            kind: "file",
-            reason: format!("read failed: {e}"),
-        })?;
+        file.read_to_end(&mut buf)
+            .await
+            .map_err(|e| ResolveError::BackendUnavailable {
+                kind: "file",
+                reason: format!("read failed: {e}"),
+            })?;
 
         Ok(SecretBytes::from(buf))
     }
@@ -195,7 +197,9 @@ mod tests {
     }
 
     fn file_ref(p: &str) -> SecretReference {
-        SecretReference::File { path: p.to_string() }
+        SecretReference::File {
+            path: p.to_string(),
+        }
     }
 
     #[tokio::test]
@@ -228,13 +232,19 @@ mod tests {
     async fn empty_path_is_malformed() {
         let r = FileRefResolver::new();
         let err = r.resolve(&tid(), &file_ref("")).await.unwrap_err();
-        assert!(matches!(err, ResolveError::MalformedReference { kind: "file", .. }));
+        assert!(matches!(
+            err,
+            ResolveError::MalformedReference { kind: "file", .. }
+        ));
     }
 
     #[tokio::test]
     async fn relative_path_is_malformed() {
         let r = FileRefResolver::new();
-        let err = r.resolve(&tid(), &file_ref("relative/path")).await.unwrap_err();
+        let err = r
+            .resolve(&tid(), &file_ref("relative/path"))
+            .await
+            .unwrap_err();
         match err {
             ResolveError::MalformedReference { kind, reason } => {
                 assert_eq!(kind, "file");
@@ -247,9 +257,17 @@ mod tests {
     #[tokio::test]
     async fn wrong_kind_is_rejected() {
         let r = FileRefResolver::new();
-        let env = SecretReference::Env { var: "X".to_string() };
+        let env = SecretReference::Env {
+            var: "X".to_string(),
+        };
         let err = r.resolve(&tid(), &env).await.unwrap_err();
-        assert!(matches!(err, ResolveError::WrongKind { expected: "file", actual: "env" }));
+        assert!(matches!(
+            err,
+            ResolveError::WrongKind {
+                expected: "file",
+                actual: "env"
+            }
+        ));
     }
 
     #[cfg(unix)]
@@ -275,7 +293,10 @@ mod tests {
         let p = write_file(&dir, "world.secret", b"oops", 0o604).await;
         let r = FileRefResolver::new();
         let err = r.resolve(&tid(), &file_ref(&p)).await.unwrap_err();
-        assert!(matches!(err, ResolveError::PermissionDenied { kind: "file", .. }));
+        assert!(matches!(
+            err,
+            ResolveError::PermissionDenied { kind: "file", .. }
+        ));
     }
 
     #[tokio::test]

--- a/memory/src/secret_resolvers/inline.rs
+++ b/memory/src/secret_resolvers/inline.rs
@@ -11,9 +11,9 @@
 //! No I/O, no configuration. Construction is pure.
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
 
@@ -80,8 +80,16 @@ mod tests {
     #[tokio::test]
     async fn wrong_kind_is_rejected() {
         let r = InlineRefResolver::new();
-        let env = SecretReference::Env { var: "X".to_string() };
+        let env = SecretReference::Env {
+            var: "X".to_string(),
+        };
         let err = r.resolve(&tid(), &env).await.unwrap_err();
-        assert!(matches!(err, ResolveError::WrongKind { expected: "inline", actual: "env" }));
+        assert!(matches!(
+            err,
+            ResolveError::WrongKind {
+                expected: "inline",
+                actual: "env"
+            }
+        ));
     }
 }

--- a/memory/src/secret_resolvers/k8s.rs
+++ b/memory/src/secret_resolvers/k8s.rs
@@ -32,9 +32,9 @@ use std::fmt;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
 
@@ -94,7 +94,12 @@ impl<F: K8sSecretFetcher + 'static> SecretRefResolver for K8sRefResolver<F> {
         tenant: &TenantId,
         reference: &SecretReference,
     ) -> Result<SecretBytes, ResolveError> {
-        let SecretReference::K8s { namespace, name, key } = reference else {
+        let SecretReference::K8s {
+            namespace,
+            name,
+            key,
+        } = reference
+        else {
             return Err(ResolveError::WrongKind {
                 expected: "k8s",
                 actual: reference.kind(),
@@ -222,7 +227,11 @@ impl PodDownwardApiFetcher {
         match tokio::fs::read_to_string(path).await {
             Ok(s) => {
                 let t = s.trim();
-                if t.is_empty() { None } else { Some(t.to_string()) }
+                if t.is_empty() {
+                    None
+                } else {
+                    Some(t.to_string())
+                }
             }
             Err(_) => None,
         }
@@ -259,7 +268,7 @@ mod live {
     //! Live Kubernetes HTTP client. Private submodule so tests don't
     //! have to compile it without the feature flag.
     use super::*;
-    use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+    use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
     use serde_json::Value as JsonValue;
     use std::time::Duration;
 
@@ -269,7 +278,7 @@ mod live {
     #[derive(Debug)]
     pub(super) struct LiveK8sFetcher {
         client: reqwest::Client,
-        base_url: String, // e.g. https://10.0.0.1:443
+        base_url: String,            // e.g. https://10.0.0.1:443
         token: mk_core::SecretBytes, // bearer token; redacted on Debug
     }
 
@@ -286,18 +295,16 @@ mod live {
 
             // Read CA cert (PEM) and SA token. Both are blocking reads,
             // but from_pod_environment runs at bootstrap time — fine.
-            let ca_pem = std::fs::read(SA_CA_CERT_PATH).map_err(|e| {
-                ResolveError::BackendUnavailable {
+            let ca_pem =
+                std::fs::read(SA_CA_CERT_PATH).map_err(|e| ResolveError::BackendUnavailable {
                     kind: "k8s",
                     reason: format!("read CA cert {SA_CA_CERT_PATH}: {e}"),
-                }
-            })?;
-            let token_raw = std::fs::read(SA_TOKEN_PATH).map_err(|e| {
-                ResolveError::BackendUnavailable {
+                })?;
+            let token_raw =
+                std::fs::read(SA_TOKEN_PATH).map_err(|e| ResolveError::BackendUnavailable {
                     kind: "k8s",
                     reason: format!("read SA token {SA_TOKEN_PATH}: {e}"),
-                }
-            })?;
+                })?;
             let token = mk_core::SecretBytes::from(token_raw);
 
             let ca = reqwest::Certificate::from_pem(&ca_pem).map_err(|e| {
@@ -316,7 +323,11 @@ mod live {
                     reason: format!("build http client: {e}"),
                 })?;
 
-            Ok(Self { client, base_url, token })
+            Ok(Self {
+                client,
+                base_url,
+                token,
+            })
         }
 
         pub(super) async fn fetch(
@@ -365,10 +376,8 @@ mod live {
                     // retags this NotFound with the caller's real
                     // TenantId before it escapes the module.
                     return Err(ResolveError::NotFound {
-                        tenant: TenantId::new(
-                            "00000000-0000-0000-0000-000000000000".to_string(),
-                        )
-                        .expect("dummy zero-uuid is a valid TenantId"),
+                        tenant: TenantId::new("00000000-0000-0000-0000-000000000000".to_string())
+                            .expect("dummy zero-uuid is a valid TenantId"),
                         kind: "k8s",
                     });
                 }
@@ -380,10 +389,13 @@ mod live {
                 }
             }
 
-            let body: JsonValue = resp.json().await.map_err(|e| ResolveError::BackendUnavailable {
-                kind: "k8s",
-                reason: format!("parse Secret JSON: {e}"),
-            })?;
+            let body: JsonValue =
+                resp.json()
+                    .await
+                    .map_err(|e| ResolveError::BackendUnavailable {
+                        kind: "k8s",
+                        reason: format!("parse Secret JSON: {e}"),
+                    })?;
 
             // Secrets look like: { "data": { "<key>": "<base64>" }, ... }
             let b64 = body
@@ -395,10 +407,12 @@ mod live {
                     reason: format!("key '{key}' not present in Secret {namespace}/{name}"),
                 })?;
 
-            let raw = B64.decode(b64).map_err(|e| ResolveError::BackendUnavailable {
-                kind: "k8s",
-                reason: format!("base64 decode of Secret value failed: {e}"),
-            })?;
+            let raw = B64
+                .decode(b64)
+                .map_err(|e| ResolveError::BackendUnavailable {
+                    kind: "k8s",
+                    reason: format!("base64 decode of Secret value failed: {e}"),
+                })?;
             Ok(SecretBytes::from(raw))
         }
     }
@@ -453,10 +467,11 @@ mod tests {
             name: &str,
             key: &str,
         ) -> Result<SecretBytes, ResolveError> {
-            self.calls
-                .lock()
-                .unwrap()
-                .push((namespace.to_string(), name.to_string(), key.to_string()));
+            self.calls.lock().unwrap().push((
+                namespace.to_string(),
+                name.to_string(),
+                key.to_string(),
+            ));
             match &*self.response.lock().unwrap() {
                 Ok(v) => Ok(SecretBytes::from(v.clone())),
                 Err(e) => Err(clone_err(e)),
@@ -466,21 +481,26 @@ mod tests {
 
     fn clone_err(e: &ResolveError) -> ResolveError {
         match e {
-            ResolveError::NotFound { tenant, kind } => {
-                ResolveError::NotFound { tenant: tenant.clone(), kind }
-            }
-            ResolveError::PermissionDenied { kind, reason } => {
-                ResolveError::PermissionDenied { kind, reason: reason.clone() }
-            }
-            ResolveError::BackendUnavailable { kind, reason } => {
-                ResolveError::BackendUnavailable { kind, reason: reason.clone() }
-            }
-            ResolveError::MalformedReference { kind, reason } => {
-                ResolveError::MalformedReference { kind, reason: reason.clone() }
-            }
-            ResolveError::WrongKind { expected, actual } => {
-                ResolveError::WrongKind { expected: *expected, actual: *actual }
-            }
+            ResolveError::NotFound { tenant, kind } => ResolveError::NotFound {
+                tenant: tenant.clone(),
+                kind,
+            },
+            ResolveError::PermissionDenied { kind, reason } => ResolveError::PermissionDenied {
+                kind,
+                reason: reason.clone(),
+            },
+            ResolveError::BackendUnavailable { kind, reason } => ResolveError::BackendUnavailable {
+                kind,
+                reason: reason.clone(),
+            },
+            ResolveError::MalformedReference { kind, reason } => ResolveError::MalformedReference {
+                kind,
+                reason: reason.clone(),
+            },
+            ResolveError::WrongKind { expected, actual } => ResolveError::WrongKind {
+                expected: *expected,
+                actual: *actual,
+            },
         }
     }
 
@@ -492,10 +512,13 @@ mod tests {
 
     #[tokio::test]
     async fn explicit_namespace_wins_over_default() {
-        let r = K8sRefResolver::new(MockFetcher::ok(b"payload"))
-            .with_default_namespace("fallback-ns");
+        let r =
+            K8sRefResolver::new(MockFetcher::ok(b"payload")).with_default_namespace("fallback-ns");
         let out = r
-            .resolve(&tid(), &k8s_ref(Some("explicit-ns"), "my-secret", "api-key"))
+            .resolve(
+                &tid(),
+                &k8s_ref(Some("explicit-ns"), "my-secret", "api-key"),
+            )
             .await
             .unwrap();
         assert_eq!(out.expose(), b"payload");
@@ -507,16 +530,20 @@ mod tests {
 
     #[tokio::test]
     async fn default_namespace_used_when_reference_omits_it() {
-        let r = K8sRefResolver::new(MockFetcher::ok(b"payload"))
-            .with_default_namespace("pod-ns");
-        r.resolve(&tid(), &k8s_ref(None, "my-secret", "api-key")).await.unwrap();
+        let r = K8sRefResolver::new(MockFetcher::ok(b"payload")).with_default_namespace("pod-ns");
+        r.resolve(&tid(), &k8s_ref(None, "my-secret", "api-key"))
+            .await
+            .unwrap();
         assert_eq!(r.fetcher.last_call().unwrap().0, "pod-ns");
     }
 
     #[tokio::test]
     async fn missing_namespace_and_no_default_is_malformed() {
         let r = K8sRefResolver::new(MockFetcher::ok(b"x"));
-        let err = r.resolve(&tid(), &k8s_ref(None, "my-secret", "k")).await.unwrap_err();
+        let err = r
+            .resolve(&tid(), &k8s_ref(None, "my-secret", "k"))
+            .await
+            .unwrap_err();
         match err {
             ResolveError::MalformedReference { kind, reason } => {
                 assert_eq!(kind, "k8s");
@@ -529,10 +556,22 @@ mod tests {
     #[tokio::test]
     async fn empty_name_or_key_is_malformed() {
         let r = K8sRefResolver::new(MockFetcher::ok(b"x")).with_default_namespace("ns");
-        let err = r.resolve(&tid(), &k8s_ref(None, "", "k")).await.unwrap_err();
-        assert!(matches!(err, ResolveError::MalformedReference { kind: "k8s", .. }));
-        let err = r.resolve(&tid(), &k8s_ref(None, "n", "")).await.unwrap_err();
-        assert!(matches!(err, ResolveError::MalformedReference { kind: "k8s", .. }));
+        let err = r
+            .resolve(&tid(), &k8s_ref(None, "", "k"))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ResolveError::MalformedReference { kind: "k8s", .. }
+        ));
+        let err = r
+            .resolve(&tid(), &k8s_ref(None, "n", ""))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ResolveError::MalformedReference { kind: "k8s", .. }
+        ));
     }
 
     #[tokio::test]
@@ -544,7 +583,10 @@ mod tests {
             key: "k".to_string(),
         };
         let err = r.resolve(&tid(), &bad).await.unwrap_err();
-        assert!(matches!(err, ResolveError::MalformedReference { kind: "k8s", .. }));
+        assert!(matches!(
+            err,
+            ResolveError::MalformedReference { kind: "k8s", .. }
+        ));
     }
 
     #[tokio::test]
@@ -555,7 +597,10 @@ mod tests {
         }))
         .with_default_namespace("ns");
         let tenant = tid();
-        let err = r.resolve(&tenant, &k8s_ref(None, "n", "k")).await.unwrap_err();
+        let err = r
+            .resolve(&tenant, &k8s_ref(None, "n", "k"))
+            .await
+            .unwrap_err();
         match err {
             ResolveError::NotFound { tenant: t, kind } => {
                 assert_eq!(t, tenant);
@@ -568,9 +613,17 @@ mod tests {
     #[tokio::test]
     async fn wrong_kind_is_rejected() {
         let r = K8sRefResolver::new(MockFetcher::ok(b"x")).with_default_namespace("ns");
-        let env = SecretReference::Env { var: "X".to_string() };
+        let env = SecretReference::Env {
+            var: "X".to_string(),
+        };
         let err = r.resolve(&tid(), &env).await.unwrap_err();
-        assert!(matches!(err, ResolveError::WrongKind { expected: "k8s", actual: "env" }));
+        assert!(matches!(
+            err,
+            ResolveError::WrongKind {
+                expected: "k8s",
+                actual: "env"
+            }
+        ));
     }
 
     #[test]

--- a/memory/src/secret_resolvers/postgres.rs
+++ b/memory/src/secret_resolvers/postgres.rs
@@ -20,9 +20,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 use storage::secret_backend::{SecretBackend, SecretBackendError};
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
@@ -116,9 +116,7 @@ mod tests {
         }
         fn not_found() -> Arc<Self> {
             Arc::new(Self {
-                response: Mutex::new(Some(Err(SecretBackendError::NotFound(
-                    "stub".to_string(),
-                )))),
+                response: Mutex::new(Some(Err(SecretBackendError::NotFound("stub".to_string())))),
             })
         }
         fn db_error() -> Arc<Self> {
@@ -144,15 +142,16 @@ mod tests {
         ) -> Result<Vec<(String, SecretReference)>, SecretBackendError> {
             Ok(Vec::new())
         }
-        async fn get(&self, _reference: &SecretReference) -> Result<SecretBytes, SecretBackendError> {
+        async fn get(
+            &self,
+            _reference: &SecretReference,
+        ) -> Result<SecretBytes, SecretBackendError> {
             match self.response.lock().unwrap().as_ref() {
                 Some(Ok(v)) => Ok(SecretBytes::from(v.clone())),
                 Some(Err(SecretBackendError::NotFound(s))) => {
                     Err(SecretBackendError::NotFound(s.clone()))
                 }
-                Some(Err(SecretBackendError::Aead(s))) => {
-                    Err(SecretBackendError::Aead(s.clone()))
-                }
+                Some(Err(SecretBackendError::Aead(s))) => Err(SecretBackendError::Aead(s.clone())),
                 Some(Err(_)) | None => Err(SecretBackendError::Aead("stub".to_string())),
             }
         }
@@ -198,17 +197,28 @@ mod tests {
     async fn db_error_surfaces_as_backend_unavailable() {
         let r = PostgresRefResolver::new(StubBackend::db_error());
         let err = r.resolve(&tid(), &pg_ref()).await.unwrap_err();
-        assert!(matches!(err, ResolveError::BackendUnavailable { kind: "postgres", .. }));
+        assert!(matches!(
+            err,
+            ResolveError::BackendUnavailable {
+                kind: "postgres",
+                ..
+            }
+        ));
     }
 
     #[tokio::test]
     async fn wrong_kind_is_rejected_without_backend_call() {
         let r = PostgresRefResolver::new(StubBackend::ok(b"x"));
-        let env = SecretReference::Env { var: "X".to_string() };
+        let env = SecretReference::Env {
+            var: "X".to_string(),
+        };
         let err = r.resolve(&tid(), &env).await.unwrap_err();
         assert!(matches!(
             err,
-            ResolveError::WrongKind { expected: "postgres", actual: "env" }
+            ResolveError::WrongKind {
+                expected: "postgres",
+                actual: "env"
+            }
         ));
     }
 }

--- a/memory/src/secret_resolvers/vault.rs
+++ b/memory/src/secret_resolvers/vault.rs
@@ -1,0 +1,9 @@
+//! HashiCorp Vault backend — compiled only under `feature = "vault"`.
+//!
+//! `mod.rs` declares this module behind `#[cfg(feature = "vault")]`;
+//! without the feature, `vault_stub` is re-exported as `vault`
+//! instead. This file exists so `rustfmt`'s module traversal
+//! (which, unlike `cargo`, does not honour cfg gates) can succeed
+//! even when the feature is off.
+//!
+//! The real Vault implementation is tracked under B4 §3.4.

--- a/memory/src/secret_resolvers/vault_stub.rs
+++ b/memory/src/secret_resolvers/vault_stub.rs
@@ -14,9 +14,9 @@
 //! construction code identical across builds.
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
 
@@ -92,8 +92,16 @@ mod tests {
     #[tokio::test]
     async fn wrong_kind_is_rejected() {
         let r = VaultRefResolver::new();
-        let env = SecretReference::Env { var: "X".to_string() };
+        let env = SecretReference::Env {
+            var: "X".to_string(),
+        };
         let err = r.resolve(&tid(), &env).await.unwrap_err();
-        assert!(matches!(err, ResolveError::WrongKind { expected: "vault", actual: "env" }));
+        assert!(matches!(
+            err,
+            ResolveError::WrongKind {
+                expected: "vault",
+                actual: "env"
+            }
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Delivers the PlatformAdmin-gated **service-token lifecycle** (mint / revoke / list) for B2 §10.2, §10.4, §10.6. Service tokens are `Aeterna::Agent` principals with `agent_type = 'service'`, persisted in the existing `agents` table — **no new migration**.

## Endpoints

| Method | Path | Spec | Gate |
|--------|------|------|------|
| `POST`   | `/api/v1/auth/tokens`     | §10.2 | PlatformAdmin |
| `GET`    | `/api/v1/auth/tokens`     | §10.6 | PlatformAdmin |
| `DELETE` | `/api/v1/auth/tokens/:id` | §10.4 | PlatformAdmin |

## Design decisions

- **Service token = `Aeterna::Agent` with `kind='service'`.** Uniform principal type for CI/CD tokens and AI-delegated agents — one code path, one Cedar entity, one delegation chain. Context and rationale in design discussion (`z8ebDN1kzK`).
- **Reuses §10.1 `PluginTokenClaims`** with `token_type = "service"` and `scopes = capabilities`. `kind` stays `"plugin-access"` so the existing validator accepts the token; §10.5 middleware can branch on `token_type`.
- **Capability allow-list** (`KNOWN_CAPABILITIES`) mirrors `policies/cedar/agent-delegation.cedar` — fails loud on typos; adding a new capability is an explicit policy change.
- **Fail-safe mint order:** INSERT agents row first, then mint JWT. A DB failure means no JWT ever issued.
- **Revoke flips `status`** (row kept for audit trail). §10.5 middleware will short-circuit revoked agents on request validation.
- **Bounds:** `expiresInSeconds` ∈ `[60, 86400]`, default `14400` (4h) per tasks.md §10.2. Name ≤ 255 chars.

## Testing

**15/15 unit tests passing** (`cargo test -p aeterna --lib server::service_tokens`):

- `validate_name` — empty, whitespace-only, over-limit, happy path (3 tests)
- `validate_capabilities` — empty, unknown, oversized, unknown-in-mix, full known set (5 tests)
- `resolve_expires_in` — default, below-min, above-max, at bounds (4 tests)
- `mint_service_jwt` — round-trip with right secret, reject with wrong secret (2 tests)
- `KNOWN_CAPABILITIES` — non-empty and unique (1 test)

DB-path integration tests (mint → persist → list → revoke) are a **follow-up commit on this branch** requiring testcontainer AppState fixture.

## Validation budget

| Check | Result |
|---|---|
| `cargo check -p aeterna` | ✅ clean |
| `cargo test -p aeterna --lib server::service_tokens` | ✅ 15/15 |
| `cargo clippy -p aeterna --lib -- -D warnings` | ✅ no warnings |
| `cargo fmt --check` | ✅ clean |
| New migrations | 0 |
| LOC | +731 (1 new file, 2 edited) |

## Out of scope (explicit follow-ups)

- **§10.3** capability-subset enforcement — moot while PA-only; becomes relevant when TenantAdmin self-service lands.
- **§10.5** consuming middleware that decodes service tokens on incoming requests.
- **§10.6+** CLI surface (`aeterna auth token mint/revoke/list`).
- **TenantAdmin self-service mint** — a TA minting tokens for their own tenant. Requires lowering the PA-only gate and adding capability-subset enforcement (§10.3).
- **Testcontainer integration tests** for the DB-hitting handler paths.

## Roadmap context

One piece of a larger authz-management surface. See `plan-b2-10-2-service-token-mint.md` (generated in review conversation `z8ebDN1kzK`) for full context. Companion pieces already live in master: role-grant management (`role_grants.rs` — `POST/DELETE/GET /admin/roles/*`) covering TenantAdmin and scoped-role grants. Still pending: custom-role policy effectiveness (Phase G), opal-fetcher tenant isolation hardening (Phase A), PlatformAdmin impersonation (separate change).
