### PR TITLE
chore(fmt): workspace rustfmt cleanup + CI invocation fix

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - run: cargo fmt --all --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: clippy

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -443,11 +443,7 @@ impl AeternaClient {
     /// flag only controls whether the *names* of the secret refs are
     /// visible. This matches the `RenderQuery` contract in
     /// `manifest_api.rs`.
-    pub async fn tenant_manifest(
-        &self,
-        tenant: &str,
-        redact: bool,
-    ) -> Result<serde_json::Value> {
+    pub async fn tenant_manifest(&self, tenant: &str, redact: bool) -> Result<serde_json::Value> {
         let path = if redact {
             format!("/api/v1/admin/tenants/{tenant}/manifest?redact=true")
         } else {

--- a/cli/src/commands/tenant.rs
+++ b/cli/src/commands/tenant.rs
@@ -3040,10 +3040,16 @@ mod tests {
             "tenant": {"slug": "acme"},
         });
         let s = serialize_rendered_manifest(&v).unwrap();
-        assert!(s.ends_with('\n'), "output must end with exactly one newline: {s:?}");
+        assert!(
+            s.ends_with('\n'),
+            "output must end with exactly one newline: {s:?}"
+        );
         assert!(!s.ends_with("\n\n"), "no double newline: {s:?}");
         // Indent check — `to_string_pretty` uses two spaces.
-        assert!(s.contains("  \"apiVersion\""), "expected 2-space indent: {s}");
+        assert!(
+            s.contains("  \"apiVersion\""),
+            "expected 2-space indent: {s}"
+        );
         // Round-trips back to the same JSON.
         let v2: serde_json::Value = serde_json::from_str(&s).unwrap();
         assert_eq!(v, v2);

--- a/memory/src/provider_registry.rs
+++ b/memory/src/provider_registry.rs
@@ -310,8 +310,7 @@ impl TenantProviderRegistry {
             Some(reg) => reg.resolve(tenant, reference).await,
             None => Err(crate::secret_resolver::ResolveError::BackendUnavailable {
                 kind: "none",
-                reason: "no SecretResolverRegistry installed on TenantProviderRegistry"
-                    .to_string(),
+                reason: "no SecretResolverRegistry installed on TenantProviderRegistry".to_string(),
             }),
         }
     }
@@ -865,7 +864,11 @@ impl mk_core::traits::TenantConfigProvider for RegistryConfigAdapter {
         // 3. Dispatch through the typed registry by SecretReference
         //    variant. NotFound → Ok(None); other errors surface as
         //    adapter errors so the caller can log with context.
-        match self.secret_registry.resolve(tenant_id, &tsr.reference).await {
+        match self
+            .secret_registry
+            .resolve(tenant_id, &tsr.reference)
+            .await
+        {
             Ok(bytes) => Ok(Some(bytes)),
             Err(crate::secret_resolver::ResolveError::NotFound { .. }) => Ok(None),
             Err(e) => Err(RegistryAdapterError(format!(

--- a/memory/src/secret_resolver.rs
+++ b/memory/src/secret_resolver.rs
@@ -500,9 +500,9 @@ mod redaction_coverage {
     use super::*;
     use crate::secret_resolvers::{EnvRefResolver, InlineRefResolver};
     use async_trait::async_trait;
+    use mk_core::SecretBytes;
     use mk_core::secret::SecretReference;
     use mk_core::types::TenantId;
-    use mk_core::SecretBytes;
 
     /// The literal bytes we use as a sentinel “plaintext” in every test
     /// below. If any of these bytes appear in a rendered error message,
@@ -589,7 +589,10 @@ mod redaction_coverage {
         assert_no_plaintext(&rendered, SENTINEL_PLAINTEXT);
         // Both fields are `&'static str` — cannot carry dynamic data.
         match err {
-            ResolveError::WrongKind { expected: _, actual: _ } => {}
+            ResolveError::WrongKind {
+                expected: _,
+                actual: _,
+            } => {}
             _ => unreachable!(),
         }
     }
@@ -728,7 +731,12 @@ mod redaction_coverage {
         let mut registry = SecretResolverRegistry::new();
         registry.register(std::sync::Arc::new(LeakyResolver));
         let err = registry
-            .resolve(&tid(), &SecretReference::Env { var: "X".to_string() })
+            .resolve(
+                &tid(),
+                &SecretReference::Env {
+                    var: "X".to_string(),
+                },
+            )
             .await
             .unwrap_err();
         let rendered = format!("{err}");

--- a/memory/src/secret_resolvers/env.rs
+++ b/memory/src/secret_resolvers/env.rs
@@ -15,9 +15,9 @@
 //!   preserved into [`SecretBytes`] without lossy conversion.
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
 
@@ -87,7 +87,9 @@ mod tests {
     }
 
     fn env_ref(var: &str) -> SecretReference {
-        SecretReference::Env { var: var.to_string() }
+        SecretReference::Env {
+            var: var.to_string(),
+        }
     }
 
     // Use a unique env-var prefix per test to avoid cross-test
@@ -117,7 +119,10 @@ mod tests {
     async fn unset_variable_is_not_found() {
         unsafe { std::env::remove_var(TEST_VAR_UNSET) };
         let r = EnvRefResolver::new();
-        let err = r.resolve(&tid(), &env_ref(TEST_VAR_UNSET)).await.unwrap_err();
+        let err = r
+            .resolve(&tid(), &env_ref(TEST_VAR_UNSET))
+            .await
+            .unwrap_err();
         match err {
             ResolveError::NotFound { kind, .. } => assert_eq!(kind, "env"),
             other => panic!("expected NotFound, got {other:?}"),
@@ -141,13 +146,18 @@ mod tests {
     async fn var_name_with_equals_is_malformed() {
         let r = EnvRefResolver::new();
         let err = r.resolve(&tid(), &env_ref("FOO=BAR")).await.unwrap_err();
-        assert!(matches!(err, ResolveError::MalformedReference { kind: "env", .. }));
+        assert!(matches!(
+            err,
+            ResolveError::MalformedReference { kind: "env", .. }
+        ));
     }
 
     #[tokio::test]
     async fn wrong_kind_is_rejected() {
         let r = EnvRefResolver::new();
-        let file_ref = SecretReference::File { path: "/x".to_string() };
+        let file_ref = SecretReference::File {
+            path: "/x".to_string(),
+        };
         let err = r.resolve(&tid(), &file_ref).await.unwrap_err();
         match err {
             ResolveError::WrongKind { expected, actual } => {

--- a/memory/src/secret_resolvers/file.rs
+++ b/memory/src/secret_resolvers/file.rs
@@ -24,9 +24,9 @@
 use std::path::Path;
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 use tokio::io::AsyncReadExt;
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
@@ -48,12 +48,12 @@ impl FileRefResolver {
     #[cfg(unix)]
     async fn check_mode(path: &Path) -> Result<(), ResolveError> {
         use std::os::unix::fs::MetadataExt;
-        let md = tokio::fs::metadata(path).await.map_err(|e| {
-            ResolveError::BackendUnavailable {
+        let md = tokio::fs::metadata(path)
+            .await
+            .map_err(|e| ResolveError::BackendUnavailable {
                 kind: "file",
                 reason: format!("stat failed: {e}"),
-            }
-        })?;
+            })?;
         let mode = md.mode() & 0o777;
         if mode & 0o077 != 0 {
             return Err(ResolveError::PermissionDenied {
@@ -161,10 +161,12 @@ impl SecretRefResolver for FileRefResolver {
         })?;
 
         let mut buf = Vec::with_capacity(md.len() as usize);
-        file.read_to_end(&mut buf).await.map_err(|e| ResolveError::BackendUnavailable {
-            kind: "file",
-            reason: format!("read failed: {e}"),
-        })?;
+        file.read_to_end(&mut buf)
+            .await
+            .map_err(|e| ResolveError::BackendUnavailable {
+                kind: "file",
+                reason: format!("read failed: {e}"),
+            })?;
 
         Ok(SecretBytes::from(buf))
     }
@@ -195,7 +197,9 @@ mod tests {
     }
 
     fn file_ref(p: &str) -> SecretReference {
-        SecretReference::File { path: p.to_string() }
+        SecretReference::File {
+            path: p.to_string(),
+        }
     }
 
     #[tokio::test]
@@ -228,13 +232,19 @@ mod tests {
     async fn empty_path_is_malformed() {
         let r = FileRefResolver::new();
         let err = r.resolve(&tid(), &file_ref("")).await.unwrap_err();
-        assert!(matches!(err, ResolveError::MalformedReference { kind: "file", .. }));
+        assert!(matches!(
+            err,
+            ResolveError::MalformedReference { kind: "file", .. }
+        ));
     }
 
     #[tokio::test]
     async fn relative_path_is_malformed() {
         let r = FileRefResolver::new();
-        let err = r.resolve(&tid(), &file_ref("relative/path")).await.unwrap_err();
+        let err = r
+            .resolve(&tid(), &file_ref("relative/path"))
+            .await
+            .unwrap_err();
         match err {
             ResolveError::MalformedReference { kind, reason } => {
                 assert_eq!(kind, "file");
@@ -247,9 +257,17 @@ mod tests {
     #[tokio::test]
     async fn wrong_kind_is_rejected() {
         let r = FileRefResolver::new();
-        let env = SecretReference::Env { var: "X".to_string() };
+        let env = SecretReference::Env {
+            var: "X".to_string(),
+        };
         let err = r.resolve(&tid(), &env).await.unwrap_err();
-        assert!(matches!(err, ResolveError::WrongKind { expected: "file", actual: "env" }));
+        assert!(matches!(
+            err,
+            ResolveError::WrongKind {
+                expected: "file",
+                actual: "env"
+            }
+        ));
     }
 
     #[cfg(unix)]
@@ -275,7 +293,10 @@ mod tests {
         let p = write_file(&dir, "world.secret", b"oops", 0o604).await;
         let r = FileRefResolver::new();
         let err = r.resolve(&tid(), &file_ref(&p)).await.unwrap_err();
-        assert!(matches!(err, ResolveError::PermissionDenied { kind: "file", .. }));
+        assert!(matches!(
+            err,
+            ResolveError::PermissionDenied { kind: "file", .. }
+        ));
     }
 
     #[tokio::test]

--- a/memory/src/secret_resolvers/inline.rs
+++ b/memory/src/secret_resolvers/inline.rs
@@ -11,9 +11,9 @@
 //! No I/O, no configuration. Construction is pure.
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
 
@@ -80,8 +80,16 @@ mod tests {
     #[tokio::test]
     async fn wrong_kind_is_rejected() {
         let r = InlineRefResolver::new();
-        let env = SecretReference::Env { var: "X".to_string() };
+        let env = SecretReference::Env {
+            var: "X".to_string(),
+        };
         let err = r.resolve(&tid(), &env).await.unwrap_err();
-        assert!(matches!(err, ResolveError::WrongKind { expected: "inline", actual: "env" }));
+        assert!(matches!(
+            err,
+            ResolveError::WrongKind {
+                expected: "inline",
+                actual: "env"
+            }
+        ));
     }
 }

--- a/memory/src/secret_resolvers/k8s.rs
+++ b/memory/src/secret_resolvers/k8s.rs
@@ -32,9 +32,9 @@ use std::fmt;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
 
@@ -94,7 +94,12 @@ impl<F: K8sSecretFetcher + 'static> SecretRefResolver for K8sRefResolver<F> {
         tenant: &TenantId,
         reference: &SecretReference,
     ) -> Result<SecretBytes, ResolveError> {
-        let SecretReference::K8s { namespace, name, key } = reference else {
+        let SecretReference::K8s {
+            namespace,
+            name,
+            key,
+        } = reference
+        else {
             return Err(ResolveError::WrongKind {
                 expected: "k8s",
                 actual: reference.kind(),
@@ -222,7 +227,11 @@ impl PodDownwardApiFetcher {
         match tokio::fs::read_to_string(path).await {
             Ok(s) => {
                 let t = s.trim();
-                if t.is_empty() { None } else { Some(t.to_string()) }
+                if t.is_empty() {
+                    None
+                } else {
+                    Some(t.to_string())
+                }
             }
             Err(_) => None,
         }
@@ -259,7 +268,7 @@ mod live {
     //! Live Kubernetes HTTP client. Private submodule so tests don't
     //! have to compile it without the feature flag.
     use super::*;
-    use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+    use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
     use serde_json::Value as JsonValue;
     use std::time::Duration;
 
@@ -269,7 +278,7 @@ mod live {
     #[derive(Debug)]
     pub(super) struct LiveK8sFetcher {
         client: reqwest::Client,
-        base_url: String, // e.g. https://10.0.0.1:443
+        base_url: String,            // e.g. https://10.0.0.1:443
         token: mk_core::SecretBytes, // bearer token; redacted on Debug
     }
 
@@ -286,18 +295,16 @@ mod live {
 
             // Read CA cert (PEM) and SA token. Both are blocking reads,
             // but from_pod_environment runs at bootstrap time — fine.
-            let ca_pem = std::fs::read(SA_CA_CERT_PATH).map_err(|e| {
-                ResolveError::BackendUnavailable {
+            let ca_pem =
+                std::fs::read(SA_CA_CERT_PATH).map_err(|e| ResolveError::BackendUnavailable {
                     kind: "k8s",
                     reason: format!("read CA cert {SA_CA_CERT_PATH}: {e}"),
-                }
-            })?;
-            let token_raw = std::fs::read(SA_TOKEN_PATH).map_err(|e| {
-                ResolveError::BackendUnavailable {
+                })?;
+            let token_raw =
+                std::fs::read(SA_TOKEN_PATH).map_err(|e| ResolveError::BackendUnavailable {
                     kind: "k8s",
                     reason: format!("read SA token {SA_TOKEN_PATH}: {e}"),
-                }
-            })?;
+                })?;
             let token = mk_core::SecretBytes::from(token_raw);
 
             let ca = reqwest::Certificate::from_pem(&ca_pem).map_err(|e| {
@@ -316,7 +323,11 @@ mod live {
                     reason: format!("build http client: {e}"),
                 })?;
 
-            Ok(Self { client, base_url, token })
+            Ok(Self {
+                client,
+                base_url,
+                token,
+            })
         }
 
         pub(super) async fn fetch(
@@ -365,10 +376,8 @@ mod live {
                     // retags this NotFound with the caller's real
                     // TenantId before it escapes the module.
                     return Err(ResolveError::NotFound {
-                        tenant: TenantId::new(
-                            "00000000-0000-0000-0000-000000000000".to_string(),
-                        )
-                        .expect("dummy zero-uuid is a valid TenantId"),
+                        tenant: TenantId::new("00000000-0000-0000-0000-000000000000".to_string())
+                            .expect("dummy zero-uuid is a valid TenantId"),
                         kind: "k8s",
                     });
                 }
@@ -380,10 +389,13 @@ mod live {
                 }
             }
 
-            let body: JsonValue = resp.json().await.map_err(|e| ResolveError::BackendUnavailable {
-                kind: "k8s",
-                reason: format!("parse Secret JSON: {e}"),
-            })?;
+            let body: JsonValue =
+                resp.json()
+                    .await
+                    .map_err(|e| ResolveError::BackendUnavailable {
+                        kind: "k8s",
+                        reason: format!("parse Secret JSON: {e}"),
+                    })?;
 
             // Secrets look like: { "data": { "<key>": "<base64>" }, ... }
             let b64 = body
@@ -395,10 +407,12 @@ mod live {
                     reason: format!("key '{key}' not present in Secret {namespace}/{name}"),
                 })?;
 
-            let raw = B64.decode(b64).map_err(|e| ResolveError::BackendUnavailable {
-                kind: "k8s",
-                reason: format!("base64 decode of Secret value failed: {e}"),
-            })?;
+            let raw = B64
+                .decode(b64)
+                .map_err(|e| ResolveError::BackendUnavailable {
+                    kind: "k8s",
+                    reason: format!("base64 decode of Secret value failed: {e}"),
+                })?;
             Ok(SecretBytes::from(raw))
         }
     }
@@ -453,10 +467,11 @@ mod tests {
             name: &str,
             key: &str,
         ) -> Result<SecretBytes, ResolveError> {
-            self.calls
-                .lock()
-                .unwrap()
-                .push((namespace.to_string(), name.to_string(), key.to_string()));
+            self.calls.lock().unwrap().push((
+                namespace.to_string(),
+                name.to_string(),
+                key.to_string(),
+            ));
             match &*self.response.lock().unwrap() {
                 Ok(v) => Ok(SecretBytes::from(v.clone())),
                 Err(e) => Err(clone_err(e)),
@@ -466,21 +481,26 @@ mod tests {
 
     fn clone_err(e: &ResolveError) -> ResolveError {
         match e {
-            ResolveError::NotFound { tenant, kind } => {
-                ResolveError::NotFound { tenant: tenant.clone(), kind }
-            }
-            ResolveError::PermissionDenied { kind, reason } => {
-                ResolveError::PermissionDenied { kind, reason: reason.clone() }
-            }
-            ResolveError::BackendUnavailable { kind, reason } => {
-                ResolveError::BackendUnavailable { kind, reason: reason.clone() }
-            }
-            ResolveError::MalformedReference { kind, reason } => {
-                ResolveError::MalformedReference { kind, reason: reason.clone() }
-            }
-            ResolveError::WrongKind { expected, actual } => {
-                ResolveError::WrongKind { expected: *expected, actual: *actual }
-            }
+            ResolveError::NotFound { tenant, kind } => ResolveError::NotFound {
+                tenant: tenant.clone(),
+                kind,
+            },
+            ResolveError::PermissionDenied { kind, reason } => ResolveError::PermissionDenied {
+                kind,
+                reason: reason.clone(),
+            },
+            ResolveError::BackendUnavailable { kind, reason } => ResolveError::BackendUnavailable {
+                kind,
+                reason: reason.clone(),
+            },
+            ResolveError::MalformedReference { kind, reason } => ResolveError::MalformedReference {
+                kind,
+                reason: reason.clone(),
+            },
+            ResolveError::WrongKind { expected, actual } => ResolveError::WrongKind {
+                expected: *expected,
+                actual: *actual,
+            },
         }
     }
 
@@ -492,10 +512,13 @@ mod tests {
 
     #[tokio::test]
     async fn explicit_namespace_wins_over_default() {
-        let r = K8sRefResolver::new(MockFetcher::ok(b"payload"))
-            .with_default_namespace("fallback-ns");
+        let r =
+            K8sRefResolver::new(MockFetcher::ok(b"payload")).with_default_namespace("fallback-ns");
         let out = r
-            .resolve(&tid(), &k8s_ref(Some("explicit-ns"), "my-secret", "api-key"))
+            .resolve(
+                &tid(),
+                &k8s_ref(Some("explicit-ns"), "my-secret", "api-key"),
+            )
             .await
             .unwrap();
         assert_eq!(out.expose(), b"payload");
@@ -507,16 +530,20 @@ mod tests {
 
     #[tokio::test]
     async fn default_namespace_used_when_reference_omits_it() {
-        let r = K8sRefResolver::new(MockFetcher::ok(b"payload"))
-            .with_default_namespace("pod-ns");
-        r.resolve(&tid(), &k8s_ref(None, "my-secret", "api-key")).await.unwrap();
+        let r = K8sRefResolver::new(MockFetcher::ok(b"payload")).with_default_namespace("pod-ns");
+        r.resolve(&tid(), &k8s_ref(None, "my-secret", "api-key"))
+            .await
+            .unwrap();
         assert_eq!(r.fetcher.last_call().unwrap().0, "pod-ns");
     }
 
     #[tokio::test]
     async fn missing_namespace_and_no_default_is_malformed() {
         let r = K8sRefResolver::new(MockFetcher::ok(b"x"));
-        let err = r.resolve(&tid(), &k8s_ref(None, "my-secret", "k")).await.unwrap_err();
+        let err = r
+            .resolve(&tid(), &k8s_ref(None, "my-secret", "k"))
+            .await
+            .unwrap_err();
         match err {
             ResolveError::MalformedReference { kind, reason } => {
                 assert_eq!(kind, "k8s");
@@ -529,10 +556,22 @@ mod tests {
     #[tokio::test]
     async fn empty_name_or_key_is_malformed() {
         let r = K8sRefResolver::new(MockFetcher::ok(b"x")).with_default_namespace("ns");
-        let err = r.resolve(&tid(), &k8s_ref(None, "", "k")).await.unwrap_err();
-        assert!(matches!(err, ResolveError::MalformedReference { kind: "k8s", .. }));
-        let err = r.resolve(&tid(), &k8s_ref(None, "n", "")).await.unwrap_err();
-        assert!(matches!(err, ResolveError::MalformedReference { kind: "k8s", .. }));
+        let err = r
+            .resolve(&tid(), &k8s_ref(None, "", "k"))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ResolveError::MalformedReference { kind: "k8s", .. }
+        ));
+        let err = r
+            .resolve(&tid(), &k8s_ref(None, "n", ""))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ResolveError::MalformedReference { kind: "k8s", .. }
+        ));
     }
 
     #[tokio::test]
@@ -544,7 +583,10 @@ mod tests {
             key: "k".to_string(),
         };
         let err = r.resolve(&tid(), &bad).await.unwrap_err();
-        assert!(matches!(err, ResolveError::MalformedReference { kind: "k8s", .. }));
+        assert!(matches!(
+            err,
+            ResolveError::MalformedReference { kind: "k8s", .. }
+        ));
     }
 
     #[tokio::test]
@@ -555,7 +597,10 @@ mod tests {
         }))
         .with_default_namespace("ns");
         let tenant = tid();
-        let err = r.resolve(&tenant, &k8s_ref(None, "n", "k")).await.unwrap_err();
+        let err = r
+            .resolve(&tenant, &k8s_ref(None, "n", "k"))
+            .await
+            .unwrap_err();
         match err {
             ResolveError::NotFound { tenant: t, kind } => {
                 assert_eq!(t, tenant);
@@ -568,9 +613,17 @@ mod tests {
     #[tokio::test]
     async fn wrong_kind_is_rejected() {
         let r = K8sRefResolver::new(MockFetcher::ok(b"x")).with_default_namespace("ns");
-        let env = SecretReference::Env { var: "X".to_string() };
+        let env = SecretReference::Env {
+            var: "X".to_string(),
+        };
         let err = r.resolve(&tid(), &env).await.unwrap_err();
-        assert!(matches!(err, ResolveError::WrongKind { expected: "k8s", actual: "env" }));
+        assert!(matches!(
+            err,
+            ResolveError::WrongKind {
+                expected: "k8s",
+                actual: "env"
+            }
+        ));
     }
 
     #[test]

--- a/memory/src/secret_resolvers/postgres.rs
+++ b/memory/src/secret_resolvers/postgres.rs
@@ -20,9 +20,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 use storage::secret_backend::{SecretBackend, SecretBackendError};
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
@@ -116,9 +116,7 @@ mod tests {
         }
         fn not_found() -> Arc<Self> {
             Arc::new(Self {
-                response: Mutex::new(Some(Err(SecretBackendError::NotFound(
-                    "stub".to_string(),
-                )))),
+                response: Mutex::new(Some(Err(SecretBackendError::NotFound("stub".to_string())))),
             })
         }
         fn db_error() -> Arc<Self> {
@@ -144,15 +142,16 @@ mod tests {
         ) -> Result<Vec<(String, SecretReference)>, SecretBackendError> {
             Ok(Vec::new())
         }
-        async fn get(&self, _reference: &SecretReference) -> Result<SecretBytes, SecretBackendError> {
+        async fn get(
+            &self,
+            _reference: &SecretReference,
+        ) -> Result<SecretBytes, SecretBackendError> {
             match self.response.lock().unwrap().as_ref() {
                 Some(Ok(v)) => Ok(SecretBytes::from(v.clone())),
                 Some(Err(SecretBackendError::NotFound(s))) => {
                     Err(SecretBackendError::NotFound(s.clone()))
                 }
-                Some(Err(SecretBackendError::Aead(s))) => {
-                    Err(SecretBackendError::Aead(s.clone()))
-                }
+                Some(Err(SecretBackendError::Aead(s))) => Err(SecretBackendError::Aead(s.clone())),
                 Some(Err(_)) | None => Err(SecretBackendError::Aead("stub".to_string())),
             }
         }
@@ -198,17 +197,28 @@ mod tests {
     async fn db_error_surfaces_as_backend_unavailable() {
         let r = PostgresRefResolver::new(StubBackend::db_error());
         let err = r.resolve(&tid(), &pg_ref()).await.unwrap_err();
-        assert!(matches!(err, ResolveError::BackendUnavailable { kind: "postgres", .. }));
+        assert!(matches!(
+            err,
+            ResolveError::BackendUnavailable {
+                kind: "postgres",
+                ..
+            }
+        ));
     }
 
     #[tokio::test]
     async fn wrong_kind_is_rejected_without_backend_call() {
         let r = PostgresRefResolver::new(StubBackend::ok(b"x"));
-        let env = SecretReference::Env { var: "X".to_string() };
+        let env = SecretReference::Env {
+            var: "X".to_string(),
+        };
         let err = r.resolve(&tid(), &env).await.unwrap_err();
         assert!(matches!(
             err,
-            ResolveError::WrongKind { expected: "postgres", actual: "env" }
+            ResolveError::WrongKind {
+                expected: "postgres",
+                actual: "env"
+            }
         ));
     }
 }

--- a/memory/src/secret_resolvers/vault.rs
+++ b/memory/src/secret_resolvers/vault.rs
@@ -1,0 +1,9 @@
+//! HashiCorp Vault backend — compiled only under `feature = "vault"`.
+//!
+//! `mod.rs` declares this module behind `#[cfg(feature = "vault")]`;
+//! without the feature, `vault_stub` is re-exported as `vault`
+//! instead. This file exists so `rustfmt`'s module traversal
+//! (which, unlike `cargo`, does not honour cfg gates) can succeed
+//! even when the feature is off.
+//!
+//! The real Vault implementation is tracked under B4 §3.4.

--- a/memory/src/secret_resolvers/vault_stub.rs
+++ b/memory/src/secret_resolvers/vault_stub.rs
@@ -14,9 +14,9 @@
 //! construction code identical across builds.
 
 use async_trait::async_trait;
+use mk_core::SecretBytes;
 use mk_core::secret::SecretReference;
 use mk_core::types::TenantId;
-use mk_core::SecretBytes;
 
 use crate::secret_resolver::{ResolveError, SecretRefResolver};
 
@@ -92,8 +92,16 @@ mod tests {
     #[tokio::test]
     async fn wrong_kind_is_rejected() {
         let r = VaultRefResolver::new();
-        let env = SecretReference::Env { var: "X".to_string() };
+        let env = SecretReference::Env {
+            var: "X".to_string(),
+        };
         let err = r.resolve(&tid(), &env).await.unwrap_err();
-        assert!(matches!(err, ResolveError::WrongKind { expected: "vault", actual: "env" }));
+        assert!(matches!(
+            err,
+            ResolveError::WrongKind {
+                expected: "vault",
+                actual: "env"
+            }
+        ));
     }
 }


### PR DESCRIPTION
Unblocks the `fmt` gate for all open PRs.

## Three changes

**1. CI invocation fix — `.github/workflows/pr-fast.yml`**

Changed `cargo fmt --all --check` → `cargo fmt --all -- --check`.

The former does **not** forward `--check` to rustfmt. With the project's `.rustfmt.toml` carrying nightly-only options (`wrap_comments`, `format_strings`, `trailing_semicolon`, `version = "Two"`, etc.), stable rustfmt emits per-file warnings on stderr. The mis-invoked form treats these warnings as fatal and exits 1 with **no diff output** — producing the confusing fmt failures we've been seeing on every PR.

Reproducible locally:
```
cargo fmt --all --check      # exit 1 (misleading; only warnings, no diff)
cargo fmt --all -- --check   # exit 0 (correct: warnings tolerated, diffs surfaced)
```

**2. rustfmt module-traversal fix — `memory/src/secret_resolvers/vault.rs`**

New empty stub file. `mod.rs` declares `pub mod vault;` under `#[cfg(feature = "vault")]`, but `rustfmt` traverses every `mod` declaration regardless of cfg, so a missing `vault.rs` was aborting rustfmt with `Error writing files: failed to resolve mod vault`. The stub is a doc-only file that documents *why* it exists and points at B4 §3.4 for the real implementation.

**3. Actual fmt drift — 9 files across `memory/` + `cli/`**

- `cli/src/client.rs`, `cli/src/commands/tenant.rs`: drift pre-existing on master.
- `memory/src/provider_registry.rs`, `memory/src/secret_resolver.rs`, `memory/src/secret_resolvers/{env,file,inline,k8s,postgres,vault_stub}.rs`: **previously invisible to CI** because the fmt job was short-circuiting on the vault.rs missing-module error before reaching them. Once unblocked (change #2), real stable-rustfmt drift surfaced across 7 files in `memory/`.

## Validation

- `cargo fmt --all -- --check` → exit 0 locally on rustc 1.95.0
- No semantic code changes — pure formatting + one doc-only file

## Follow-up (not in this PR)

The nightly-only options in `.rustfmt.toml` are silently no-ops on stable. Clean options: (a) move the fmt job to nightly rustfmt so those options activate, or (b) delete them from `.rustfmt.toml`. Option (b) would reformat ~10+ more files (stable default layout differs), so out of scope here.