### PR TITLE
feat(server): extend §10.5 scope gate to list/show/render/watch/grant/revoke

### DIFF
--- a/cli/src/server/manifest_api.rs
+++ b/cli/src/server/manifest_api.rs
@@ -30,12 +30,12 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
-use mk_core::types::{Role, RoleIdentifier};
 use serde::Deserialize;
 use serde_json::json;
 
+use super::AppState;
 use super::manifest_render::{RenderError, render_current_manifest};
-use super::{AppState, authenticated_platform_context};
+use super::tenant_api::require_platform_admin_or_scope;
 
 pub fn router(state: Arc<AppState>) -> Router {
     Router::new()
@@ -54,28 +54,6 @@ struct RenderQuery {
     redact: bool,
 }
 
-/// PA gate. Mirrors the pattern from `tenant_wiring_api` — the
-/// `authenticated_platform_context` helper authenticates off raw
-/// headers (no tenant resolution required for platform-scoped routes).
-async fn require_platform_admin(state: &AppState, headers: &HeaderMap) -> Result<(), Response> {
-    let (_uid, roles) = authenticated_platform_context(state, headers).await?;
-    if !is_platform_admin(&roles) {
-        return Err(error_response(
-            StatusCode::FORBIDDEN,
-            "forbidden",
-            "PlatformAdmin role required",
-        ));
-    }
-    Ok(())
-}
-
-/// Whether the role set grants platform-admin privileges. Unit-test
-/// seam identical to the one in `tenant_wiring_api`.
-fn is_platform_admin(roles: &[RoleIdentifier]) -> bool {
-    let pa: RoleIdentifier = Role::PlatformAdmin.into();
-    roles.contains(&pa)
-}
-
 #[tracing::instrument(skip_all, fields(slug = %slug, redact = q.redact))]
 async fn get_tenant_manifest(
     State(state): State<Arc<AppState>>,
@@ -83,7 +61,12 @@ async fn get_tenant_manifest(
     Path(slug): Path<String>,
     Query(q): Query<RenderQuery>,
 ) -> Response {
-    if let Err(resp) = require_platform_admin(&state, &headers).await {
+    // B2 §10.5 — read-only manifest render. Accepts PlatformAdmin user
+    // OR service token with `tenants:render`. `redact=true` mode does
+    // not relax the gate: redaction is for sharing sanitized manifests,
+    // not for demoting the endpoint to a lower-trust tier (per
+    // module-level doc).
+    if let Err(resp) = require_platform_admin_or_scope(&state, &headers, "tenants:render").await {
         return resp;
     }
     match render_current_manifest(&state, &slug, q.redact).await {
@@ -140,22 +123,13 @@ mod tests {
         assert!(q.redact);
     }
 
-    #[test]
-    fn is_platform_admin_accepts_pa_role() {
-        let pa: RoleIdentifier = Role::PlatformAdmin.into();
-        assert!(is_platform_admin(&[pa]));
-    }
-
-    #[test]
-    fn is_platform_admin_rejects_non_pa_roles() {
-        let viewer: RoleIdentifier = Role::Viewer.into();
-        assert!(!is_platform_admin(&[viewer]));
-    }
-
-    #[test]
-    fn is_platform_admin_rejects_empty_roles() {
-        assert!(!is_platform_admin(&[]));
-    }
+    // The local `is_platform_admin` / `require_platform_admin` helpers
+    // were removed when this endpoint migrated to the shared
+    // [`require_platform_admin_or_scope`] gate (B2 §10.5). The
+    // role-membership behaviour is now covered by
+    // `tenant_api::require_platform_admin*` tests; keeping a
+    // duplicate-shape test here would only re-pin
+    // `RoleIdentifier::contains` against itself.
 
     #[test]
     fn error_response_preserves_status() {

--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -1089,15 +1089,10 @@ async fn list_tenants(
     headers: HeaderMap,
     Query(query): Query<TenantListQuery>,
 ) -> impl IntoResponse {
-    // Migrated to the #44.d resolver chain: the old path required an
-    // X-Tenant-ID header to produce a TenantContext, even though this
-    // endpoint never consults it. `request_context` lets PlatformAdmins
-    // hit it with no tenant selected.
-    let ctx = match super::context::request_context(&state, &headers).await {
-        Ok(c) => c,
-        Err(response) => return response,
-    };
-    if let Err(response) = super::context::require_platform_admin(&ctx) {
+    // B2 §10.5 — accept either a PlatformAdmin user OR a service token
+    // carrying the `tenants:read` scope. Read-only endpoint, no audit
+    // rows, so the principal is discarded after the gate.
+    if let Err(response) = require_platform_admin_or_scope(&state, &headers, "tenants:read").await {
         return response;
     }
 
@@ -1131,7 +1126,8 @@ async fn show_tenant(
     headers: HeaderMap,
     Path(tenant): Path<String>,
 ) -> impl IntoResponse {
-    if let Err(response) = require_platform_admin(&state, &headers).await {
+    // B2 §10.5 — PA user OR service token with `tenants:read`.
+    if let Err(response) = require_platform_admin_or_scope(&state, &headers, "tenants:read").await {
         return response;
     }
 
@@ -2283,7 +2279,7 @@ async fn require_platform_admin(
 /// audit the action borrow the principal as an [`AuditActor`] via
 /// [`AuthPrincipal::as_audit_actor`] — the B2 §11.4 refactor makes
 /// the audit helpers accept either kind uniformly.
-async fn require_platform_admin_or_scope(
+pub(super) async fn require_platform_admin_or_scope(
     state: &AppState,
     headers: &HeaderMap,
     required_scope: &str,
@@ -2385,7 +2381,7 @@ impl<'a> From<&'a crate::server::service_token_validator::ServicePrincipal> for 
 /// borrow it as an `AuditActor` at each audit call site without
 /// re-authenticating.
 #[derive(Debug)]
-pub(crate) enum AuthPrincipal {
+pub(super) enum AuthPrincipal {
     User(TenantContext),
     Service(crate::server::service_token_validator::ServicePrincipal),
 }
@@ -2452,6 +2448,44 @@ impl AuthPrincipal {
             }
         }
     }
+
+    /// Return a [`TenantContext`] suitable for the **admin pool** write
+    /// path — `with_admin_context`, `persist_governance_event`, and the
+    /// `audit_tenant_action*` family when the call site already holds a
+    /// `&TenantContext` from pre-§10.5 days.
+    ///
+    /// Differs from [`to_downstream_tenant_context`] in *which* tenant
+    /// the synthesized context binds:
+    ///
+    ///   - For `User`: returns the user's own ctx (cloned). Behaviour
+    ///     identical to pre-§11.4.
+    ///   - For `Service`: binds `tenant_id = service-token's OWN
+    ///     tenant`, `target_tenant_id = None`, `user_id = agent_uuid`,
+    ///     `agent_id = Some(agent_uuid)`, empty roles. The caller's
+    ///     audit row therefore links *cause* (which agent in which
+    ///     tenant) rather than *effect* (the targeted tenant — which
+    ///     is already covered by the action's `target_id`).
+    ///
+    /// This is the same shape `provision_tenant` synthesizes inline
+    /// today; extracted here so grant/revoke connection (and any
+    /// future scope-gated mutation) can stop duplicating the match.
+    pub(crate) fn to_admin_pool_context(&self) -> mk_core::types::TenantContext {
+        match self {
+            AuthPrincipal::User(ctx) => ctx.clone(),
+            AuthPrincipal::Service(sp) => {
+                let agent_str = sp.agent_id.to_string();
+                mk_core::types::TenantContext {
+                    tenant_id: mk_core::TenantId::new(sp.tenant_id.to_string())
+                        .expect("service principal tenant_id is a valid uuid"),
+                    user_id: mk_core::types::UserId::new(agent_str.clone())
+                        .expect("agent UUID string fits UserId bounds"),
+                    roles: Vec::new(),
+                    target_tenant_id: None,
+                    agent_id: Some(agent_str),
+                }
+            }
+        }
+    }
 }
 
 /// B2 §11.4 — resolve an [`AuditActor`] to the audit-row fields.
@@ -2464,7 +2498,12 @@ impl AuthPrincipal {
 /// principals simply leave `selectedTargetTenantId` as `null`).
 fn audit_actor_fields(
     actor: AuditActor<'_>,
-) -> (PrincipalType, Option<uuid::Uuid>, Option<uuid::Uuid>, serde_json::Value) {
+) -> (
+    PrincipalType,
+    Option<uuid::Uuid>,
+    Option<uuid::Uuid>,
+    serde_json::Value,
+) {
     match actor {
         AuditActor::User(ctx) => {
             let actor_id = uuid::Uuid::parse_str(ctx.user_id.as_str()).ok();
@@ -3688,10 +3727,18 @@ async fn grant_git_provider_connection_to_tenant(
     headers: HeaderMap,
     Path((connection_id, tenant)): Path<(String, String)>,
 ) -> impl IntoResponse {
-    let ctx = match require_platform_admin(&state, &headers).await {
-        Ok(ctx) => ctx,
-        Err(response) => return response,
-    };
+    // B2 §10.5 — accepts PA user OR service token with
+    // `connections:manage`. Mutation: must thread the authenticated
+    // principal so audit rows attribute to the correct actor kind
+    // (user vs agent) and so the admin-pool write path
+    // (`persist_governance_event`) gets a synthesized ctx for service
+    // callers — same pattern as `provision_tenant`.
+    let principal =
+        match require_platform_admin_or_scope(&state, &headers, "connections:manage").await {
+            Ok(p) => p,
+            Err(response) => return response,
+        };
+    let ctx = principal.to_admin_pool_context();
 
     let tenant_record =
         match resolve_tenant_record_or_404(&state, &tenant, "connection_grant_failed").await {
@@ -3714,7 +3761,7 @@ async fn grant_git_provider_connection_to_tenant(
             persist_governance_event(state.as_ref(), &ctx, &event).await;
             audit_tenant_action(
                 state.as_ref(),
-                &ctx,
+                principal.as_audit_actor(),
                 "git_provider_connection_grant",
                 Some(connection_id.as_str()),
                 json!({
@@ -3742,10 +3789,13 @@ async fn revoke_git_provider_connection_from_tenant(
     headers: HeaderMap,
     Path((connection_id, tenant)): Path<(String, String)>,
 ) -> impl IntoResponse {
-    let ctx = match require_platform_admin(&state, &headers).await {
-        Ok(ctx) => ctx,
-        Err(response) => return response,
-    };
+    // B2 §10.5 — see `grant_git_provider_connection_to_tenant`.
+    let principal =
+        match require_platform_admin_or_scope(&state, &headers, "connections:manage").await {
+            Ok(p) => p,
+            Err(response) => return response,
+        };
+    let ctx = principal.to_admin_pool_context();
 
     let tenant_record =
         match resolve_tenant_record_or_404(&state, &tenant, "connection_revoke_failed").await {
@@ -3768,7 +3818,7 @@ async fn revoke_git_provider_connection_from_tenant(
             persist_governance_event(state.as_ref(), &ctx, &event).await;
             audit_tenant_action(
                 state.as_ref(),
-                &ctx,
+                principal.as_audit_actor(),
                 "git_provider_connection_revoke",
                 Some(connection_id.as_str()),
                 json!({
@@ -4502,47 +4552,22 @@ async fn provision_tenant(
     // provisioning audit rows therefore link cause (which principal)
     // to effect (target tenant + manifest hash + generation) whether
     // the apply came from a CI pipeline or a PA operator.
-    let principal = match require_platform_admin_or_scope(
-        &state,
-        &headers,
-        "tenants:provision",
-    )
-    .await
-    {
-        Ok(p) => p,
-        Err(response) => return response,
-    };
+    let principal =
+        match require_platform_admin_or_scope(&state, &headers, "tenants:provision").await {
+            Ok(p) => p,
+            Err(response) => return response,
+        };
 
     // B2 §11.4 — synthesize a `TenantContext` from the authenticated
     // principal so helpers that still require a ctx (notably
     // [`persist_governance_event`], which forwards it to the admin-pool
     // `with_admin_context` write path) accept both callers uniformly.
-    //
-    // For the User variant this is the authenticated user's own ctx
-    // (unchanged behaviour). For the Service variant we fabricate one
-    // with `tenant_id = service-token's own tenant`, `user_id =
-    // agent_uuid`, empty roles, and `agent_id = Some(agent_uuid)` so
-    // admin-context writes are attributable to the service agent.
-    //
-    // Audit rows use `principal.as_audit_actor()` directly (below) so
-    // they record `actor_type = 'agent'` for service callers — this
-    // ctx is only for call sites that still type-require
-    // `&TenantContext`.
-    let ctx: mk_core::types::TenantContext = match &principal {
-        AuthPrincipal::User(c) => c.clone(),
-        AuthPrincipal::Service(sp) => {
-            let agent_str = sp.agent_id.to_string();
-            mk_core::types::TenantContext {
-                tenant_id: mk_core::TenantId::new(sp.tenant_id.to_string())
-                    .expect("service principal tenant_id is a valid uuid"),
-                user_id: mk_core::types::UserId::new(agent_str.clone())
-                    .expect("agent UUID string fits UserId bounds"),
-                roles: Vec::new(),
-                target_tenant_id: None,
-                agent_id: Some(agent_str),
-            }
-        }
-    };
+    // See [`AuthPrincipal::to_admin_pool_context`] for the per-variant
+    // synthesis rules. Audit rows use `principal.as_audit_actor()`
+    // directly (below) so they record `actor_type = 'agent'` for
+    // service callers — this ctx is only for call sites that still
+    // type-require `&TenantContext`.
+    let ctx: mk_core::types::TenantContext = principal.to_admin_pool_context();
 
     // B2 §11.4 — base request-context extensions for every audit row this
     // handler writes. Cloned + amended at each call site with the values
@@ -5691,13 +5716,7 @@ async fn diff_tenant(
     // `_ctx` is `None` on the service-token path because the diff
     // handler emits no audit rows and therefore needs no user
     // attribution. See `docs/security/tenant-provisioning-security.md` §2.
-    let _ctx = match require_platform_admin_or_scope(
-        &state,
-        &headers,
-        "tenants:diff",
-    )
-    .await
-    {
+    let _ctx = match require_platform_admin_or_scope(&state, &headers, "tenants:diff").await {
         Ok(ctx) => ctx,
         Err(response) => return response,
     };
@@ -5834,20 +5853,20 @@ mod tests {
             tenant_id: mk_core::TenantId::new(actor_tenant.to_string()).unwrap(),
             user_id: mk_core::types::UserId::new(user_uuid.to_string()).unwrap(),
             roles: Vec::new(),
-            target_tenant_id: Some(
-                mk_core::TenantId::new(target_tenant.to_string()).unwrap(),
-            ),
+            target_tenant_id: Some(mk_core::TenantId::new(target_tenant.to_string()).unwrap()),
             agent_id: None,
         };
 
-        let (_, _, acting_as, envelope) =
-            super::audit_actor_fields(super::AuditActor::User(&ctx));
+        let (_, _, acting_as, envelope) = super::audit_actor_fields(super::AuditActor::User(&ctx));
 
         // `acting_as_tenant_id` is the filter key for
         // `/govern/audit?tenant=<slug>`; when the caller targeted a
         // different tenant we MUST record the target, not the actor.
         assert_eq!(acting_as, Some(target_tenant));
-        assert_eq!(envelope["selectedTargetTenantId"], target_tenant.to_string());
+        assert_eq!(
+            envelope["selectedTargetTenantId"],
+            target_tenant.to_string()
+        );
     }
 
     #[test]
@@ -5920,9 +5939,68 @@ mod tests {
         // `user_id` / `agent_id` both carry the agent UUID so the
         // downstream write path can attribute ownership.
         assert_eq!(ctx.user_id.as_str(), agent_uuid.to_string());
-        assert_eq!(ctx.agent_id.as_deref(), Some(agent_uuid.to_string().as_str()));
+        assert_eq!(
+            ctx.agent_id.as_deref(),
+            Some(agent_uuid.to_string().as_str())
+        );
         // Roles are empty — downstream MUST NOT re-check role for a
         // service caller; scope was already validated at the gate.
+        assert!(ctx.roles.is_empty());
+    }
+
+    #[test]
+    fn auth_principal_to_admin_pool_ctx_user_returns_clone() {
+        // User variant: identical to pre-§10.5 `require_platform_admin`
+        // ctx. No synthesis, no field changes — the admin pool path
+        // sees exactly what the authenticated user supplied.
+        let mut original = mk_core::types::TenantContext::default();
+        original.tenant_id =
+            mk_core::TenantId::new("11111111-1111-1111-1111-111111111111".to_string())
+                .expect("uuid string parses as TenantId");
+        original.user_id = mk_core::types::UserId::new("the-user".to_string()).unwrap();
+        original.roles = vec![Role::PlatformAdmin.into()];
+        let principal = super::AuthPrincipal::User(original.clone());
+
+        let ctx = principal.to_admin_pool_context();
+
+        assert_eq!(ctx.tenant_id, original.tenant_id);
+        assert_eq!(ctx.user_id, original.user_id);
+        assert_eq!(ctx.roles, original.roles);
+        assert_eq!(ctx.target_tenant_id, original.target_tenant_id);
+        assert_eq!(ctx.agent_id, original.agent_id);
+    }
+
+    #[test]
+    fn auth_principal_to_admin_pool_ctx_service_binds_principal_tenant() {
+        // Service variant binds the SERVICE-TOKEN'S OWN tenant_id —
+        // NOT the URL path's tenant_id (which `provision_tenant`,
+        // `grant_connection`, etc. read separately). This is what the
+        // admin pool's `with_admin_context` records as the *cause*
+        // tenant; the *effect* tenant is recorded via the action's
+        // `target_id`.
+        let agent_uuid = uuid::Uuid::new_v4();
+        let principal_tenant = uuid::Uuid::new_v4();
+        let principal = super::AuthPrincipal::Service(
+            crate::server::service_token_validator::ServicePrincipal {
+                agent_id: agent_uuid,
+                tenant_id: principal_tenant,
+                scopes: vec!["connections:manage".into()],
+            },
+        );
+
+        let ctx = principal.to_admin_pool_context();
+
+        // tenant bound to the service token's tenant, NOT some target.
+        assert_eq!(ctx.tenant_id.as_str(), principal_tenant.to_string());
+        // No impersonation — service tokens don't carry that concept.
+        assert!(ctx.target_tenant_id.is_none());
+        // Stable identity: user_id and agent_id both carry the agent UUID.
+        assert_eq!(ctx.user_id.as_str(), agent_uuid.to_string());
+        assert_eq!(
+            ctx.agent_id.as_deref(),
+            Some(agent_uuid.to_string().as_str())
+        );
+        // Empty roles — scope check at the gate is the auth gate.
         assert!(ctx.roles.is_empty());
     }
 

--- a/cli/src/server/tenant_events_api.rs
+++ b/cli/src/server/tenant_events_api.rs
@@ -41,46 +41,26 @@
 use std::convert::Infallible;
 use std::sync::Arc;
 
+use axum::Router;
 use axum::extract::{Path, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::HeaderMap;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
-use axum::{Json, Router};
 #[cfg(test)]
 use futures_util::stream::StreamExt as _;
 use futures_util::stream::{self, Stream};
-use mk_core::types::{Role, RoleIdentifier};
 use serde_json::json;
 use tokio::sync::broadcast;
 
+use super::AppState;
+use super::tenant_api::require_platform_admin_or_scope;
 use super::tenant_pubsub::{TenantChangeEvent, TenantChangeKind};
-use super::{AppState, authenticated_platform_context};
 
 pub fn router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/admin/tenants/{slug}/events", get(stream_tenant_events))
         .with_state(state)
-}
-
-/// PA gate, mirroring `tenant_wiring_api::require_platform_admin`.
-/// Duplicated rather than made `pub(crate)` to preserve the current
-/// module boundary — each `/admin/tenants/...` endpoint owns its auth
-/// surface so refactors in one do not silently open another.
-async fn require_platform_admin(state: &AppState, headers: &HeaderMap) -> Result<(), Response> {
-    let (_uid, roles) = authenticated_platform_context(state, headers).await?;
-    let pa: RoleIdentifier = Role::PlatformAdmin.into();
-    if !roles.contains(&pa) {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(json!({
-                "error": "forbidden",
-                "message": "PlatformAdmin role required",
-            })),
-        )
-            .into_response());
-    }
-    Ok(())
 }
 
 /// Render one [`TenantChangeEvent`] as an SSE frame.
@@ -118,7 +98,9 @@ async fn stream_tenant_events(
     headers: HeaderMap,
     Path(slug): Path<String>,
 ) -> Response {
-    if let Err(resp) = require_platform_admin(&state, &headers).await {
+    // B2 §10.5 — accepts PA user OR service token with `tenants:watch`.
+    // Read-only stream, no audit rows, principal discarded after gate.
+    if let Err(resp) = require_platform_admin_or_scope(&state, &headers, "tenants:watch").await {
         return resp;
     }
 

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -108,7 +108,12 @@ impl KnowledgeRepository for MockRepo {
         layer: KnowledgeLayer,
         path: &str,
     ) -> Result<Option<KnowledgeEntry>, Self::Error> {
-        Ok(self.items.read().await.get(&(layer, path.to_string())).cloned())
+        Ok(self
+            .items
+            .read()
+            .await
+            .get(&(layer, path.to_string()))
+            .cloned())
     }
 
     async fn store(
@@ -117,7 +122,10 @@ impl KnowledgeRepository for MockRepo {
         entry: KnowledgeEntry,
         _message: &str,
     ) -> Result<String, Self::Error> {
-        self.items.write().await.insert((entry.layer, entry.path.clone()), entry);
+        self.items
+            .write()
+            .await
+            .insert((entry.layer, entry.path.clone()), entry);
         Ok("mock-commit".to_string())
     }
 
@@ -179,11 +187,7 @@ pub struct TestNoopReasoner;
 
 #[async_trait]
 impl ReflectiveReasoner for TestNoopReasoner {
-    async fn reason(
-        &self,
-        query: &str,
-        _ctx: Option<&str>,
-    ) -> anyhow::Result<ReasoningTrace> {
+    async fn reason(&self, query: &str, _ctx: Option<&str>) -> anyhow::Result<ReasoningTrace> {
         let now = chrono::Utc::now();
         Ok(ReasoningTrace {
             strategy: ReasoningStrategy::SemanticOnly,
@@ -297,9 +301,8 @@ pub async fn build_test_state_with_plugin_auth(
     let tenant_store = Arc::new(TenantStore::new(postgres.pool().clone()));
     let tenant_repository_binding_store =
         Arc::new(TenantRepositoryBindingStore::new(postgres.pool().clone()));
-    let git_provider_connection_registry = Arc::new(
-        storage::git_provider_connection_store::InMemoryGitProviderConnectionStore::new(),
-    );
+    let git_provider_connection_registry =
+        Arc::new(storage::git_provider_connection_store::InMemoryGitProviderConnectionStore::new());
     let tenant_repo_resolver = Arc::new(
         TenantRepositoryResolver::new(
             tenant_repository_binding_store.clone(),

--- a/cli/tests/tenant_provisioning_consistency_test.rs
+++ b/cli/tests/tenant_provisioning_consistency_test.rs
@@ -106,10 +106,7 @@ async fn body_json(resp: axum::response::Response) -> Value {
 
 /// Submit `manifest` via the canonical provision route and return the
 /// (status, body) pair.
-async fn provision(
-    app: &axum::Router,
-    manifest: &Value,
-) -> (StatusCode, Value) {
+async fn provision(app: &axum::Router, manifest: &Value) -> (StatusCode, Value) {
     let resp = app
         .clone()
         .oneshot(admin_request(
@@ -326,6 +323,7 @@ async fn consistency_api_runner_inline_secret_rejected_by_default() {
     assert!(
         status == StatusCode::BAD_REQUEST || status == StatusCode::FORBIDDEN,
         "inline secret should be rejected when server config does not opt in (got {} body={})",
-        status, body
+        status,
+        body
     );
 }


### PR DESCRIPTION
Closes the B2 §10.5 scope-wiring chunk by migrating the remaining `/admin/tenants/...` routes off the legacy `require_platform_admin` helper.

## Routes migrated

| Route | Scope |
|---|---|
| `GET /admin/tenants` (list) | `tenants:read` |
| `GET /admin/tenants/{slug}` (show) | `tenants:read` |
| `GET /admin/tenants/{slug}/manifest` | `tenants:render` |
| `GET /admin/tenants/{slug}/events` (SSE) | `tenants:watch` |
| `POST/DELETE /admin/git-provider-connections/{id}/tenants/{slug}` (grant/revoke) | `connections:manage` |

## Refactor

Extracted `AuthPrincipal::to_admin_pool_context()` from the inline match that lived in `provision_tenant`, so every write path that still type-requires `&TenantContext` (grant/revoke included) uses the same User-clone / Service-synthesise rule. Synthesised ctx binds the service token's OWN `tenant_id` as the cause — the URL's target tenant is already covered by the action's `target_id`.

Mutation paths (grant/revoke) audit via `principal.as_audit_actor()` directly so `actor_type` reports `agent` for service callers. Read-only routes discard the principal after the gate (no audit rows).

## Visibility

- `require_platform_admin_or_scope` → `pub(super)` (was private)
- `AuthPrincipal` enum → `pub(super)` (was `pub(crate)`)

Sibling modules in `crate::server` now share one gate instead of duplicating the role check; removed now-dead `require_platform_admin` + `is_platform_admin` locals (and their tautological tests) from `manifest_api.rs` and `tenant_events_api.rs`.

## Tests

+2 unit tests on `AuthPrincipal::to_admin_pool_context` (User pass-through, Service principal-tenant bind).

- `cargo test -p aeterna --lib tenant_api::tests` — 98/98 ✅
- `cargo test -p aeterna --lib server::manifest_api::` — 3/3 ✅
- `cargo test -p aeterna --lib server::tenant_events_api::` — 4/4 ✅
- `cargo check -p aeterna --tests` ✅
- `cargo clippy -p aeterna --all-targets -- -D clippy::correctness -D clippy::suspicious` ✅
- `cargo fmt --all` ✅