### PR TITLE
fix(admin-ui): clear 21 lint errors from §12 wizard (react-hooks/refs + no-useless-escape)

### DIFF
--- a/admin-ui/src/api/tenant-manifest.ts
+++ b/admin-ui/src/api/tenant-manifest.ts
@@ -152,7 +152,7 @@ export function manifestToYaml(v: unknown, indent = 0): string {
   const pad = "  ".repeat(indent)
   if (v === null || v === undefined) return "null"
   if (typeof v === "string") {
-    if (v === "" || /[:#\n\-\{\}\[\]&*!|>%@`,]/.test(v) || /^\s|\s$/.test(v)) {
+    if (v === "" || /[:#\n\-{}[\]&*!|>%@`,]/.test(v) || /^\s|\s$/.test(v)) {
       return JSON.stringify(v)
     }
     return v

--- a/admin-ui/src/pages/tenants/wizard/steps.tsx
+++ b/admin-ui/src/pages/tenants/wizard/steps.tsx
@@ -225,12 +225,12 @@ export function SecretsStep({ manifest, onChange }: StepProps) {
         <p className="text-sm text-gray-500 italic">No references declared.</p>
       ) : (
         <ul className="space-y-3">
-          {entries.map(([key, ref]) => (
+          {entries.map(([key, secretRef]) => (
             <li key={key} className="rounded-md border border-gray-200 p-3 dark:border-gray-700">
               <div className="mb-2 flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <span className="font-mono text-sm font-semibold">{key}</span>
-                  <span className="rounded bg-gray-100 px-2 py-0.5 text-xs dark:bg-gray-700">{ref.kind}</span>
+                  <span className="rounded bg-gray-100 px-2 py-0.5 text-xs dark:bg-gray-700">{secretRef.kind}</span>
                 </div>
                 <button
                   type="button"
@@ -241,7 +241,7 @@ export function SecretsStep({ manifest, onChange }: StepProps) {
                   <Trash2 className="h-4 w-4" />
                 </button>
               </div>
-              <SecretRefFields refKey={key} ref={ref} onPatch={(p) => updateRef(key, p)} />
+              <SecretRefFields refKey={key} secretRef={secretRef} onPatch={(p) => updateRef(key, p)} />
             </li>
           ))}
         </ul>
@@ -252,20 +252,20 @@ export function SecretsStep({ manifest, onChange }: StepProps) {
 
 function SecretRefFields({
   refKey,
-  ref,
+  secretRef,
   onPatch,
 }: {
   refKey: string
-  ref: ManifestSecretReference
+  secretRef: ManifestSecretReference
   onPatch: (p: Partial<ManifestSecretReference>) => void
 }) {
-  switch (ref.kind) {
+  switch (secretRef.kind) {
     case "env":
       return (
         <input
           type="text"
           placeholder="ENV_VAR_NAME"
-          value={ref.var ?? ""}
+          value={secretRef.var ?? ""}
           onChange={(e) => onPatch({ var: e.target.value })}
           className={inputCls}
           aria-label={`${refKey} env variable`}
@@ -276,7 +276,7 @@ function SecretRefFields({
         <input
           type="text"
           placeholder="/etc/aeterna/secrets/name"
-          value={ref.path ?? ""}
+          value={secretRef.path ?? ""}
           onChange={(e) => onPatch({ path: e.target.value })}
           className={inputCls}
           aria-label={`${refKey} file path`}
@@ -285,16 +285,16 @@ function SecretRefFields({
     case "k8s":
       return (
         <div className="grid grid-cols-3 gap-2">
-          <input type="text" placeholder="secret name" value={ref.name ?? ""} onChange={(e) => onPatch({ name: e.target.value })} className={inputCls} aria-label={`${refKey} k8s name`} />
-          <input type="text" placeholder="key" value={ref.key ?? ""} onChange={(e) => onPatch({ key: e.target.value })} className={inputCls} aria-label={`${refKey} k8s key`} />
-          <input type="text" placeholder="namespace (optional)" value={ref.namespace ?? ""} onChange={(e) => onPatch({ namespace: e.target.value })} className={inputCls} aria-label={`${refKey} k8s namespace`} />
+          <input type="text" placeholder="secret name" value={secretRef.name ?? ""} onChange={(e) => onPatch({ name: e.target.value })} className={inputCls} aria-label={`${refKey} k8s name`} />
+          <input type="text" placeholder="key" value={secretRef.key ?? ""} onChange={(e) => onPatch({ key: e.target.value })} className={inputCls} aria-label={`${refKey} k8s key`} />
+          <input type="text" placeholder="namespace (optional)" value={secretRef.namespace ?? ""} onChange={(e) => onPatch({ namespace: e.target.value })} className={inputCls} aria-label={`${refKey} k8s namespace`} />
         </div>
       )
     case "postgres":
       return (
         <div className="grid grid-cols-2 gap-2">
-          <input type="text" placeholder="secret id" value={ref.secretId ?? ""} onChange={(e) => onPatch({ secretId: e.target.value })} className={inputCls} aria-label={`${refKey} pg secret id`} />
-          <input type="text" placeholder="label" value={ref.label ?? ""} onChange={(e) => onPatch({ label: e.target.value })} className={inputCls} aria-label={`${refKey} pg label`} />
+          <input type="text" placeholder="secret id" value={secretRef.secretId ?? ""} onChange={(e) => onPatch({ secretId: e.target.value })} className={inputCls} aria-label={`${refKey} pg secret id`} />
+          <input type="text" placeholder="label" value={secretRef.label ?? ""} onChange={(e) => onPatch({ label: e.target.value })} className={inputCls} aria-label={`${refKey} pg label`} />
         </div>
       )
     case "inline":
@@ -303,7 +303,7 @@ function SecretRefFields({
           <input
             type="password"
             placeholder="plaintext value (dev only)"
-            value={ref.inline ?? ""}
+            value={secretRef.inline ?? ""}
             onChange={(e) => onPatch({ inline: e.target.value })}
             className={inputCls}
             aria-label={`${refKey} inline value`}


### PR DESCRIPTION
Two independent root causes carried over from commit `2d58378c` (§12 admin-ui tenant provisioning wizard) that have been failing the `admin-ui` lint job on **every** PR since (#164, #165, #166, etc.).

## 1. `wizard/steps.tsx` — 18 errors, `react-hooks/refs`

The `SecretRefFields` helper named its `ManifestSecretReference` parameter `ref`, and the upstream `entries.map` destructure also bound the value to `ref`. `eslint-plugin-react-hooks` treats any property access on a binding named `ref` as accessing a React ref's `.current` during render and raises `react-hooks/refs`.

The binding is a plain domain object — not a React ref — so the diagnostic is a name-collision false positive, but the rule is correct to be conservative. **The right fix is to rename.**

Renamed the destructure binding, the prop, the parameter, and all usage sites from `ref` → `secretRef`. Pure rename, no behaviour change.

## 2. `api/tenant-manifest.ts:155` — 3 errors, `no-useless-escape`

The YAML scalar-quoting predicate had `\{`, `\}`, `\[` inside a character class. None need escaping inside `[...]` (only `\]` does, and that one was already correct). Dropped the three unnecessary backslashes; the matched set is byte-identical.

```diff
- if (v === "" || /[:#\n\-\{\}\[\]&*!|>%@`,]/.test(v) || /^\s|\s$/.test(v)) {
+ if (v === "" || /[:#\n\-{}[\]&*!|>%@`,]/.test(v) || /^\s|\s$/.test(v)) {
```

## Verification

- `npm run lint` → **0 errors** (was 21)
- `npx playwright test tenant-wizard tenant-consistency-runner --reporter=list` → **9/9 ✅**
  (the suites that exercise the renamed `SecretRefFields` component + the YAML serializer whose regex was touched)

## Why this matters

Unblocks the `admin-ui` CI lane on every future PR. Until this lands, every PR (even ones that don't touch `admin-ui/`) carries a red `admin-ui` check from master breakage.