### PR TITLE
feat(prereqs): OpenBao deployment option (subchart + bootstrap Job, Phase 1)

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -190,9 +190,12 @@ jobs:
             --set openbao.server.dev.enabled=false \
             >/tmp/prereqs-external.yaml
 
-          ! helm template prereqs charts/aeterna-prereqs \
+          if helm template prereqs charts/aeterna-prereqs \
             --set openbao.enabled=true \
-            --set openbao.mode=bogus >/tmp/prereqs-invalid.log 2>&1
+            --set openbao.mode=bogus >/tmp/prereqs-invalid.log 2>&1; then
+            echo "::error::invalid openbao.mode unexpectedly rendered successfully"
+            exit 1
+          fi
           grep -q 'openbao.mode=' /tmp/prereqs-invalid.log
 
           helm template aeterna charts/aeterna \

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -140,15 +140,21 @@ jobs:
         run: |
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
           helm repo add qdrant https://qdrant.github.io/qdrant-helm
+          helm repo add valkey https://valkey.io/valkey-helm/
+          helm repo add openbao https://openbao.github.io/openbao-helm
           helm repo add weaviate https://weaviate.github.io/weaviate-helm/
           helm repo add percona https://percona.github.io/percona-helm-charts/
           helm repo update
-      - name: Helm dependency build
+      - name: Helm dependency build (main chart)
         run: helm dependency build charts/aeterna
-      - name: Helm lint
+      - name: Helm dependency build (prereqs chart)
+        run: helm dependency build charts/aeterna-prereqs
+      - name: Helm lint (main chart)
         # Note: lint returns 0 even when template 'fail' functions fire — they're
         # logged as INFO. That's fine: we want lint to catch STRUCTURAL issues here.
         run: helm lint charts/aeterna
+      - name: Helm lint (prereqs chart)
+        run: helm lint charts/aeterna-prereqs
       - name: Helm template (with minimal connection overrides)
         # The chart requires postgresql.host, redis.host, vectorStore.host at
         # render time (enforced by fail() in templates). None of the fixtures
@@ -161,6 +167,41 @@ jobs:
             --set vectorStore.host=qdrant.ci.local \
             --debug > /tmp/manifest.yaml
           echo "Rendered $(wc -l < /tmp/manifest.yaml) lines across $(grep -c '^kind:' /tmp/manifest.yaml) K8s objects"
+      - name: Helm template prereqs OpenBao modes
+        run: |
+          helm template prereqs charts/aeterna-prereqs > /tmp/prereqs-disabled.yaml
+          test "$(grep -c '^kind:' /tmp/prereqs-disabled.yaml)" -gt 0
+
+          helm template prereqs charts/aeterna-prereqs \
+            --set openbao.enabled=true \
+            --set openbao.mode=internal-dev-seal \
+            >/tmp/prereqs-dev.yaml
+
+          helm template prereqs charts/aeterna-prereqs \
+            --set openbao.enabled=true \
+            --set openbao.mode=internal-shamir \
+            --set openbao.server.dev.enabled=false \
+            --set openbao.server.standalone.enabled=true \
+            >/tmp/prereqs-shamir.yaml
+
+          helm template prereqs charts/aeterna-prereqs \
+            --set openbao.enabled=true \
+            --set openbao.mode=external \
+            --set openbao.server.dev.enabled=false \
+            >/tmp/prereqs-external.yaml
+
+          ! helm template prereqs charts/aeterna-prereqs \
+            --set openbao.enabled=true \
+            --set openbao.mode=bogus >/tmp/prereqs-invalid.log 2>&1
+          grep -q 'openbao.mode=' /tmp/prereqs-invalid.log
+
+          helm template aeterna charts/aeterna \
+            --set postgresql.host=pg.ci.local \
+            --set redis.host=redis.ci.local \
+            --set vectorStore.host=qdrant.ci.local \
+            --set vault.enabled=true \
+            >/tmp/aeterna-vault.yaml
+          grep -q 'name: VAULT_ADDR' /tmp/aeterna-vault.yaml
       - name: Install kubeconform
         run: |
           curl -sL https://github.com/yannh/kubeconform/releases/download/v0.6.4/kubeconform-linux-amd64.tar.gz | tar xz

--- a/charts/aeterna-prereqs/Chart.lock
+++ b/charts/aeterna-prereqs/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: dragonfly
+  repository: oci://ghcr.io/dragonflydb/dragonfly/helm
+  version: v1.37.0
+- name: qdrant
+  repository: https://qdrant.github.io/qdrant-helm
+  version: 0.10.1
+- name: valkey
+  repository: https://valkey.io/valkey-helm/
+  version: 0.9.4
+- name: openbao
+  repository: https://openbao.github.io/openbao-helm
+  version: 0.27.2
+digest: sha256:3e21a7d984b9b499947c5f2dd9ea9d757515fdfaab954d3e73c81219a7dc62e8
+generated: "2026-04-27T09:53:10.499946+02:00"

--- a/charts/aeterna-prereqs/Chart.yaml
+++ b/charts/aeterna-prereqs/Chart.yaml
@@ -45,3 +45,9 @@ dependencies:
     repository: https://valkey.io/valkey-helm/
     condition: cache.valkey.enabled
     alias: valkey
+
+  - name: openbao
+    version: "~0.27.0"
+    repository: https://openbao.github.io/openbao-helm
+    condition: openbao.enabled
+    alias: openbao

--- a/charts/aeterna-prereqs/templates/NOTES.txt
+++ b/charts/aeterna-prereqs/templates/NOTES.txt
@@ -35,3 +35,40 @@ Install the main Aeterna chart with connection parameters:
 
 Or use the connection secret:
   Secret name: {{ include "prereqs.connectionSecretName" . }}
+
+{{- if .Values.openbao.enabled }}
+
+=== OpenBao (secrets backend) ===
+
+Mode: {{ .Values.openbao.mode }}
+Service: {{ include "prereqs.openbao.addr" . }}
+Bootstrap Secret: {{ include "prereqs.openbao.bootstrapSecretName" . }}
+
+The bootstrap Job runs as a Helm post-install/post-upgrade hook and stores
+connection credentials (root_token, kv_path{{ if eq .Values.openbao.mode "internal-shamir" }}, unseal_key{{ end }})
+into the Secret above. Wire the Aeterna chart to it with:
+
+  --set vault.bootstrapSecretName={{ include "prereqs.openbao.bootstrapSecretName" . }}
+
+  {{- if eq .Values.openbao.mode "internal-dev-seal" }}
+
+⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️
+                  DEV-SEAL MODE — DO NOT USE FOR PRODUCTION
+⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️  ⚠️
+
+OpenBao is running in dev mode:
+  • Storage is IN-MEMORY — all secrets are LOST on pod restart.
+  • Root token is the well-known string "{{ (((.Values.openbao).server).dev).devRootToken | default "root" }}".
+  • Unsealed automatically — no key custody.
+  • TLS disabled.
+
+This mode is ONLY appropriate for ephemeral CI / e2e clusters that are
+created fresh per run. For shared clusters use mode=internal-shamir.
+For production use mode=external with a real auto-unseal seal stanza.
+  {{- else if eq .Values.openbao.mode "internal-shamir" }}
+
+⚠️  internal-shamir mode: 1-of-1 unseal key is stored in the bootstrap Secret.
+   This is convenient but NOT production-grade key custody. Migrate to
+   mode=external with an auto-unseal seal stanza before exposing real data.
+  {{- end }}
+{{- end }}

--- a/charts/aeterna-prereqs/templates/NOTES.txt
+++ b/charts/aeterna-prereqs/templates/NOTES.txt
@@ -48,7 +48,9 @@ The bootstrap Job runs as a Helm post-install/post-upgrade hook and stores
 connection credentials (root_token, kv_path{{ if eq .Values.openbao.mode "internal-shamir" }}, unseal_key{{ end }})
 into the Secret above. Wire the Aeterna chart to it with:
 
-  --set vault.bootstrapSecretName={{ include "prereqs.openbao.bootstrapSecretName" . }}
+  --set vault.enabled=true \
+  --set vault.kubernetesAuthPath={{ .Values.openbao.bootstrap.kubernetesAuthPath }} \
+  --set vault.kubernetesAuthRole={{ .Values.openbao.bootstrap.kubernetesAuthRole }}
 
   {{- if eq .Values.openbao.mode "internal-dev-seal" }}
 

--- a/charts/aeterna-prereqs/templates/_helpers.tpl
+++ b/charts/aeterna-prereqs/templates/_helpers.tpl
@@ -124,3 +124,66 @@ requests:
   memory: {{ $limits.memory }}
   {{- end }}
 {{- end }}
+
+{{/*
+OpenBao bootstrap Secret name (consumed by Aeterna chart).
+*/}}
+{{- define "prereqs.openbao.bootstrapSecretName" -}}
+{{- if .Values.openbao.bootstrap.secretName }}
+{{- .Values.openbao.bootstrap.secretName }}
+{{- else }}
+{{- printf "%s-openbao-bootstrap" (include "prereqs.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+OpenBao bootstrap ServiceAccount name.
+*/}}
+{{- define "prereqs.openbao.bootstrapSA" -}}
+{{- if .Values.openbao.bootstrap.serviceAccount.name }}
+{{- .Values.openbao.bootstrap.serviceAccount.name }}
+{{- else }}
+{{- printf "%s-openbao-bootstrap" (include "prereqs.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+In-cluster OpenBao address. Upstream chart names its service `<release>-openbao`
+where `<release>` is the *subchart* release — i.e. parent .Release.Name.
+*/}}
+{{- define "prereqs.openbao.addr" -}}
+{{- printf "http://%s-openbao.%s.svc:8200" .Release.Name .Release.Namespace }}
+{{- end }}
+
+{{/*
+Guardrail: validate that openbao.mode is supported and that the upstream subchart
+values are consistent with the chosen mode. Fails `helm template/install` early
+with an actionable message if the contract is broken.
+*/}}
+{{- define "prereqs.openbao.assertSealMode" -}}
+{{- $mode := .Values.openbao.mode | default "internal-dev-seal" -}}
+{{- $valid := list "internal-dev-seal" "internal-shamir" "external" -}}
+{{- if not (has $mode $valid) -}}
+{{- fail (printf "openbao.mode=%q is invalid. Must be one of: %s" $mode (join ", " $valid)) -}}
+{{- end -}}
+{{- $dev := (((.Values.openbao).server).dev).enabled | default false -}}
+{{- $standalone := (((.Values.openbao).server).standalone).enabled | default false -}}
+{{- if eq $mode "internal-dev-seal" -}}
+{{- if not $dev -}}
+{{- fail "openbao.mode=internal-dev-seal requires openbao.server.dev.enabled=true. Set it explicitly or switch mode." -}}
+{{- end -}}
+{{- end -}}
+{{- if eq $mode "internal-shamir" -}}
+{{- if $dev -}}
+{{- fail "openbao.mode=internal-shamir is incompatible with openbao.server.dev.enabled=true (dev mode is in-memory and auto-unsealed). Set openbao.server.dev.enabled=false and openbao.server.standalone.enabled=true." -}}
+{{- end -}}
+{{- if not $standalone -}}
+{{- fail "openbao.mode=internal-shamir requires openbao.server.standalone.enabled=true." -}}
+{{- end -}}
+{{- end -}}
+{{- if eq $mode "external" -}}
+{{- if $dev -}}
+{{- fail "openbao.mode=external is incompatible with openbao.server.dev.enabled=true. Disable dev mode and configure an auto-unseal seal stanza in openbao.server.{standalone,ha}.config." -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/aeterna-prereqs/templates/_helpers.tpl
+++ b/charts/aeterna-prereqs/templates/_helpers.tpl
@@ -148,6 +148,13 @@ OpenBao bootstrap ServiceAccount name.
 {{- end }}
 
 {{/*
+OpenBao Kubernetes auth subject namespace for the Aeterna workload.
+*/}}
+{{- define "prereqs.openbao.aeternaServiceAccountNamespace" -}}
+{{- .Values.openbao.bootstrap.aeternaServiceAccountNamespace | default .Release.Namespace -}}
+{{- end }}
+
+{{/*
 In-cluster OpenBao address. Upstream chart names its service `<release>-openbao`
 where `<release>` is the *subchart* release — i.e. parent .Release.Name.
 */}}

--- a/charts/aeterna-prereqs/templates/openbao-bootstrap-job.yaml
+++ b/charts/aeterna-prereqs/templates/openbao-bootstrap-job.yaml
@@ -1,0 +1,94 @@
+{{- if and .Values.openbao.enabled .Values.openbao.bootstrap.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-openbao-bootstrap" (include "prereqs.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "prereqs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: openbao-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": {{ .Values.openbao.bootstrap.hookWeight | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "prereqs.labels" . | nindent 8 }}
+        app.kubernetes.io/component: openbao-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "prereqs.openbao.bootstrapSA" . }}
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        # Copy the `bao` binary out of the openbao image into a shared volume.
+        # This avoids requiring a single image with both bao and kubectl.
+        - name: copy-bao
+          image: "{{ .Values.openbao.bootstrap.image.repository }}:{{ .Values.openbao.bootstrap.image.tag }}"
+          imagePullPolicy: {{ .Values.openbao.bootstrap.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              cp /bin/bao /shared/bao
+              chmod +x /shared/bao
+          securityContext:
+            {{- toYaml .Values.openbao.bootstrap.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+      containers:
+        - name: bootstrap
+          # bitnami/kubectl ships with kubectl + curl + jq + bash on a small base.
+          image: docker.io/bitnami/kubectl:1.30
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            {{- toYaml .Values.openbao.bootstrap.securityContext | nindent 12 }}
+          command: ["bash", "/scripts/bootstrap.sh"]
+          env:
+            - name: MODE
+              value: {{ .Values.openbao.mode | quote }}
+            - name: BAO_ADDR
+              value: {{ include "prereqs.openbao.addr" . | quote }}
+            - name: KV_PATH
+              value: {{ .Values.openbao.bootstrap.kvPath | quote }}
+            - name: SECRET_NAME
+              value: {{ include "prereqs.openbao.bootstrapSecretName" . | quote }}
+            - name: NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: PATH
+              # Prepend /shared so `bao` from the initContainer is on PATH.
+              value: "/shared:/opt/bitnami/kubectl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            {{- if eq .Values.openbao.mode "internal-dev-seal" }}
+            - name: DEV_ROOT_TOKEN
+              value: {{ (((.Values.openbao).server).dev).devRootToken | default "root" | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+              readOnly: true
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.openbao.bootstrap.resources | nindent 12 }}
+      volumes:
+        - name: shared
+          emptyDir: {}
+        - name: scripts
+          configMap:
+            name: {{ printf "%s-openbao-bootstrap-script" (include "prereqs.fullname" .) | trunc 63 | trimSuffix "-" }}
+            defaultMode: 0755
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/aeterna-prereqs/templates/openbao-bootstrap-job.yaml
+++ b/charts/aeterna-prereqs/templates/openbao-bootstrap-job.yaml
@@ -60,10 +60,20 @@ spec:
               value: {{ include "prereqs.openbao.addr" . | quote }}
             - name: KV_PATH
               value: {{ .Values.openbao.bootstrap.kvPath | quote }}
+            - name: KUBERNETES_AUTH_PATH
+              value: {{ .Values.openbao.bootstrap.kubernetesAuthPath | quote }}
+            - name: KUBERNETES_AUTH_ROLE
+              value: {{ .Values.openbao.bootstrap.kubernetesAuthRole | quote }}
+            - name: AETERNA_SERVICE_ACCOUNT_NAME
+              value: {{ .Values.openbao.bootstrap.aeternaServiceAccountName | quote }}
+            - name: AETERNA_SERVICE_ACCOUNT_NAMESPACE
+              value: {{ include "prereqs.openbao.aeternaServiceAccountNamespace" . | quote }}
             - name: SECRET_NAME
               value: {{ include "prereqs.openbao.bootstrapSecretName" . | quote }}
             - name: NAMESPACE
               value: {{ .Release.Namespace | quote }}
+            - name: CHART_VERSION
+              value: {{ .Chart.Version | quote }}
             - name: PATH
               # Prepend /shared so `bao` from the initContainer is on PATH.
               value: "/shared:/opt/bitnami/kubectl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/charts/aeterna-prereqs/templates/openbao-bootstrap-job.yaml
+++ b/charts/aeterna-prereqs/templates/openbao-bootstrap-job.yaml
@@ -60,6 +60,10 @@ spec:
               value: {{ include "prereqs.openbao.addr" . | quote }}
             - name: KV_PATH
               value: {{ .Values.openbao.bootstrap.kvPath | quote }}
+            - name: GLOBAL_SECRETS_PREFIX
+              value: {{ .Values.openbao.bootstrap.globalSecretsPathPrefix | quote }}
+            - name: TENANT_SECRETS_PREFIX
+              value: {{ .Values.openbao.bootstrap.tenantSecretsPathPrefix | quote }}
             - name: KUBERNETES_AUTH_PATH
               value: {{ .Values.openbao.bootstrap.kubernetesAuthPath | quote }}
             - name: KUBERNETES_AUTH_ROLE

--- a/charts/aeterna-prereqs/templates/openbao-bootstrap-rbac.yaml
+++ b/charts/aeterna-prereqs/templates/openbao-bootstrap-rbac.yaml
@@ -1,0 +1,66 @@
+{{- if and .Values.openbao.enabled .Values.openbao.bootstrap.enabled -}}
+{{- include "prereqs.openbao.assertSealMode" . -}}
+{{- if .Values.openbao.bootstrap.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prereqs.openbao.bootstrapSA" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "prereqs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: openbao-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "prereqs.openbao.bootstrapSA" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "prereqs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: openbao-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  # Manage exactly one Secret — the bootstrap output Secret — in this namespace.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ include "prereqs.openbao.bootstrapSecretName" . | quote }}
+    verbs: ["get", "update", "patch"]
+  # Need to be able to create the Secret if it does not exist yet — list/create at namespace scope.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  # Read OpenBao pod status to wait for readiness.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "prereqs.openbao.bootstrapSA" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "prereqs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: openbao-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "prereqs.openbao.bootstrapSA" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "prereqs.openbao.bootstrapSA" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/aeterna-prereqs/templates/openbao-bootstrap-rbac.yaml
+++ b/charts/aeterna-prereqs/templates/openbao-bootstrap-rbac.yaml
@@ -41,6 +41,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
+  # Issue TokenRequest JWTs for the Aeterna ServiceAccount when it already exists.
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    resourceNames:
+      - {{ .Values.openbao.bootstrap.aeternaServiceAccountName | quote }}
+    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/aeterna-prereqs/templates/openbao-bootstrap-script-cm.yaml
+++ b/charts/aeterna-prereqs/templates/openbao-bootstrap-script-cm.yaml
@@ -1,0 +1,160 @@
+{{- if and .Values.openbao.enabled .Values.openbao.bootstrap.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-openbao-bootstrap-script" (include "prereqs.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "prereqs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: openbao-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  bootstrap.sh: |
+    #!/usr/bin/env bash
+    # OpenBao bootstrap — idempotent.
+    # Modes: internal-dev-seal | internal-shamir | external
+    set -euo pipefail
+
+    log() { printf '[bootstrap] %s\n' "$*" >&2; }
+    die() { log "FATAL: $*"; exit 1; }
+
+    : "${MODE:?MODE is required}"
+    : "${BAO_ADDR:?BAO_ADDR is required}"
+    : "${KV_PATH:?KV_PATH is required}"
+    : "${SECRET_NAME:?SECRET_NAME is required}"
+    : "${NAMESPACE:?NAMESPACE is required}"
+    export VAULT_ADDR="$BAO_ADDR"  # bao CLI honours both
+
+    # ---------- Wait for OpenBao to respond on /v1/sys/health ----------
+    log "Waiting for OpenBao at $BAO_ADDR ..."
+    for i in $(seq 1 60); do
+      # /sys/health returns:
+      #  200 = initialized + unsealed + active
+      #  429 = unsealed + standby
+      #  472 = data recovery mode
+      #  473 = performance standby
+      #  501 = not initialized
+      #  503 = sealed
+      code=$(curl -ksS -o /dev/null -w '%{http_code}' "$BAO_ADDR/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200" || echo "000")
+      if [ "$code" = "200" ] || [ "$code" = "429" ]; then
+        log "OpenBao reachable (HTTP $code)"
+        break
+      fi
+      log "  ...not ready yet (HTTP $code), retry $i/60"
+      sleep 2
+    done
+    [ "$code" = "200" ] || [ "$code" = "429" ] || die "OpenBao did not become reachable"
+
+    # ---------- Initialize / unseal per mode ----------
+    ROOT_TOKEN=""
+    UNSEAL_KEY=""
+
+    init_status=$(curl -ksS "$BAO_ADDR/v1/sys/init" | jq -r '.initialized')
+    log "sys/init.initialized = $init_status"
+
+    case "$MODE" in
+      internal-dev-seal)
+        # Dev mode: server is auto-initialized, auto-unsealed, root token comes from chart values.
+        # We expect VAULT_DEV_ROOT_TOKEN to be passed in env.
+        : "${DEV_ROOT_TOKEN:?DEV_ROOT_TOKEN required for internal-dev-seal}"
+        ROOT_TOKEN="$DEV_ROOT_TOKEN"
+        log "dev-seal mode: using configured dev root token"
+        ;;
+
+      internal-shamir)
+        if [ "$init_status" = "true" ]; then
+          log "already initialized — reading existing root token from Secret"
+          # Re-fetch from existing Secret if present
+          existing=$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o json 2>/dev/null || echo "")
+          if [ -n "$existing" ]; then
+            ROOT_TOKEN=$(echo "$existing" | jq -r '.data.root_token // empty' | base64 -d || true)
+            UNSEAL_KEY=$(echo "$existing" | jq -r '.data.unseal_key // empty' | base64 -d || true)
+          fi
+          [ -n "$ROOT_TOKEN" ] || die "OpenBao initialized but no Secret with root_token found — manual recovery required"
+        else
+          log "initializing OpenBao with shamir (1/1)"
+          init_resp=$(curl -ksS -X POST -d '{"secret_shares":1,"secret_threshold":1}' "$BAO_ADDR/v1/sys/init")
+          ROOT_TOKEN=$(echo "$init_resp" | jq -r '.root_token')
+          UNSEAL_KEY=$(echo "$init_resp" | jq -r '.keys[0]')
+          [ "$ROOT_TOKEN" != "null" ] && [ -n "$ROOT_TOKEN" ] || die "init failed: $init_resp"
+        fi
+        # Unseal if currently sealed
+        sealed=$(curl -ksS "$BAO_ADDR/v1/sys/seal-status" | jq -r '.sealed')
+        if [ "$sealed" = "true" ]; then
+          log "unsealing"
+          curl -ksS -X POST -d "{\"key\":\"$UNSEAL_KEY\"}" "$BAO_ADDR/v1/sys/unseal" >/dev/null
+        fi
+        ;;
+
+      external)
+        if [ "$init_status" = "true" ]; then
+          log "already initialized — reading existing root token from Secret"
+          existing=$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o json 2>/dev/null || echo "")
+          if [ -n "$existing" ]; then
+            ROOT_TOKEN=$(echo "$existing" | jq -r '.data.root_token // empty' | base64 -d || true)
+          fi
+          [ -n "$ROOT_TOKEN" ] || die "OpenBao initialized but no Secret with root_token found — manual recovery required"
+        else
+          log "initializing OpenBao with auto-unseal (recovery 1/1)"
+          init_resp=$(curl -ksS -X POST -d '{"recovery_shares":1,"recovery_threshold":1}' "$BAO_ADDR/v1/sys/init")
+          ROOT_TOKEN=$(echo "$init_resp" | jq -r '.root_token')
+          [ "$ROOT_TOKEN" != "null" ] && [ -n "$ROOT_TOKEN" ] || die "init failed: $init_resp"
+        fi
+        ;;
+
+      *)
+        die "unknown MODE=$MODE"
+        ;;
+    esac
+
+    # ---------- Wait for active (unsealed) status ----------
+    log "waiting for active status"
+    for i in $(seq 1 30); do
+      code=$(curl -ksS -o /dev/null -w '%{http_code}' "$BAO_ADDR/v1/sys/health" || echo "000")
+      [ "$code" = "200" ] && break
+      sleep 2
+    done
+    [ "$code" = "200" ] || die "OpenBao not active after unseal (HTTP $code)"
+
+    # ---------- Enable kv-v2 at $KV_PATH if not already mounted ----------
+    log "ensuring kv-v2 mount at $KV_PATH/"
+    mounts=$(curl -ksS -H "X-Vault-Token: $ROOT_TOKEN" "$BAO_ADDR/v1/sys/mounts")
+    if echo "$mounts" | jq -e --arg p "${KV_PATH}/" '.[$p]' >/dev/null 2>&1; then
+      log "  $KV_PATH/ already mounted — skipping"
+    else
+      curl -ksS -X POST -H "X-Vault-Token: $ROOT_TOKEN" \
+        -d '{"type":"kv","options":{"version":"2"}}' \
+        "$BAO_ADDR/v1/sys/mounts/$KV_PATH" >/dev/null
+      log "  mounted kv-v2 at $KV_PATH/"
+    fi
+
+    # ---------- Persist credentials into Secret ----------
+    log "writing Secret $NAMESPACE/$SECRET_NAME"
+    tmp=$(mktemp)
+    cat > "$tmp" <<EOF
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: $SECRET_NAME
+      namespace: $NAMESPACE
+      labels:
+        app.kubernetes.io/component: openbao-bootstrap
+        app.kubernetes.io/managed-by: aeterna-prereqs
+    type: Opaque
+    stringData:
+      bao_addr: "$BAO_ADDR"
+      root_token: "$ROOT_TOKEN"
+      kv_path: "$KV_PATH"
+      mode: "$MODE"
+    EOF
+    if [ -n "$UNSEAL_KEY" ]; then
+      printf '  unseal_key: "%s"\n' "$UNSEAL_KEY" >> "$tmp"
+    fi
+    kubectl apply -f "$tmp"
+    rm -f "$tmp"
+
+    log "bootstrap complete — mode=$MODE secret=$NAMESPACE/$SECRET_NAME"
+{{- end }}

--- a/charts/aeterna-prereqs/templates/openbao-bootstrap-script-cm.yaml
+++ b/charts/aeterna-prereqs/templates/openbao-bootstrap-script-cm.yaml
@@ -210,7 +210,7 @@ data:
         die "kubernetes auth verification failed for role=$KUBERNETES_AUTH_ROLE"
       fi
       role_policies="$(echo "$login_out" | jq -r '.auth.policies[]?' | sort | tr '\n' ' ')"
-      echo "$role_policies" | grep -q 'aeterna-pod' || die "kubernetes auth verification token missing aeterna-pod policy"
+      echo "$role_policies" | grep -qw 'aeterna-pod' || die "kubernetes auth verification token missing aeterna-pod policy"
       unset sa_jwt client_token role_policies login_out
       log "  kubernetes auth verified"
     else

--- a/charts/aeterna-prereqs/templates/openbao-bootstrap-script-cm.yaml
+++ b/charts/aeterna-prereqs/templates/openbao-bootstrap-script-cm.yaml
@@ -24,6 +24,8 @@ data:
     : "${MODE:?MODE is required}"
     : "${BAO_ADDR:?BAO_ADDR is required}"
     : "${KV_PATH:?KV_PATH is required}"
+    : "${GLOBAL_SECRETS_PREFIX:?GLOBAL_SECRETS_PREFIX is required}"
+    : "${TENANT_SECRETS_PREFIX:?TENANT_SECRETS_PREFIX is required}"
     : "${KUBERNETES_AUTH_PATH:?KUBERNETES_AUTH_PATH is required}"
     : "${KUBERNETES_AUTH_ROLE:?KUBERNETES_AUTH_ROLE is required}"
     : "${AETERNA_SERVICE_ACCOUNT_NAME:?AETERNA_SERVICE_ACCOUNT_NAME is required}"
@@ -33,7 +35,14 @@ data:
     : "${CHART_VERSION:?CHART_VERSION is required}"
     export VAULT_ADDR="$BAO_ADDR"  # bao CLI honours both
 
-    marker_path="${KV_PATH}/aeterna/.bootstrap-marker"
+    global_prefix="${GLOBAL_SECRETS_PREFIX#/}"
+    global_prefix="${global_prefix%/}"
+    tenant_prefix="${TENANT_SECRETS_PREFIX#/}"
+    tenant_prefix="${tenant_prefix%/}"
+    [ -n "$global_prefix" ] || die "GLOBAL_SECRETS_PREFIX must not normalize to empty"
+    [ -n "$tenant_prefix" ] || die "TENANT_SECRETS_PREFIX must not normalize to empty"
+
+    marker_path="${KV_PATH}/${global_prefix}/aeterna/.bootstrap-marker"
     auth_mount="${KUBERNETES_AUTH_PATH%/}/"
     policy_name="aeterna-pod"
 
@@ -166,10 +175,16 @@ data:
     log "ensuring policy $policy_name"
     policy_file="$(mktemp)"
     cat > "$policy_file" <<EOF
-    path "${KV_PATH}/data/aeterna/*" {
+    path "${KV_PATH}/data/${global_prefix}/*" {
       capabilities = ["read"]
     }
-    path "${KV_PATH}/metadata/aeterna/*" {
+    path "${KV_PATH}/metadata/${global_prefix}/*" {
+      capabilities = ["read", "list"]
+    }
+    path "${KV_PATH}/data/${tenant_prefix}/*" {
+      capabilities = ["read"]
+    }
+    path "${KV_PATH}/metadata/${tenant_prefix}/*" {
       capabilities = ["read", "list"]
     }
     EOF

--- a/charts/aeterna-prereqs/templates/openbao-bootstrap-script-cm.yaml
+++ b/charts/aeterna-prereqs/templates/openbao-bootstrap-script-cm.yaml
@@ -24,9 +24,24 @@ data:
     : "${MODE:?MODE is required}"
     : "${BAO_ADDR:?BAO_ADDR is required}"
     : "${KV_PATH:?KV_PATH is required}"
+    : "${KUBERNETES_AUTH_PATH:?KUBERNETES_AUTH_PATH is required}"
+    : "${KUBERNETES_AUTH_ROLE:?KUBERNETES_AUTH_ROLE is required}"
+    : "${AETERNA_SERVICE_ACCOUNT_NAME:?AETERNA_SERVICE_ACCOUNT_NAME is required}"
+    : "${AETERNA_SERVICE_ACCOUNT_NAMESPACE:?AETERNA_SERVICE_ACCOUNT_NAMESPACE is required}"
     : "${SECRET_NAME:?SECRET_NAME is required}"
     : "${NAMESPACE:?NAMESPACE is required}"
+    : "${CHART_VERSION:?CHART_VERSION is required}"
     export VAULT_ADDR="$BAO_ADDR"  # bao CLI honours both
+
+    marker_path="${KV_PATH}/aeterna/.bootstrap-marker"
+    auth_mount="${KUBERNETES_AUTH_PATH%/}/"
+    policy_name="aeterna-pod"
+
+    have_cmd() { command -v "$1" >/dev/null 2>&1; }
+    bao_json() { bao "$@" -format=json; }
+    sa_exists() {
+      kubectl -n "$AETERNA_SERVICE_ACCOUNT_NAMESPACE" get serviceaccount "$AETERNA_SERVICE_ACCOUNT_NAME" >/dev/null 2>&1
+    }
 
     # ---------- Wait for OpenBao to respond on /v1/sys/health ----------
     log "Waiting for OpenBao at $BAO_ADDR ..."
@@ -119,16 +134,87 @@ data:
     done
     [ "$code" = "200" ] || die "OpenBao not active after unseal (HTTP $code)"
 
+    export VAULT_TOKEN="$ROOT_TOKEN"
+
     # ---------- Enable kv-v2 at $KV_PATH if not already mounted ----------
     log "ensuring kv-v2 mount at $KV_PATH/"
-    mounts=$(curl -ksS -H "X-Vault-Token: $ROOT_TOKEN" "$BAO_ADDR/v1/sys/mounts")
+    mounts=$(bao_json secrets list)
     if echo "$mounts" | jq -e --arg p "${KV_PATH}/" '.[$p]' >/dev/null 2>&1; then
       log "  $KV_PATH/ already mounted — skipping"
     else
-      curl -ksS -X POST -H "X-Vault-Token: $ROOT_TOKEN" \
-        -d '{"type":"kv","options":{"version":"2"}}' \
-        "$BAO_ADDR/v1/sys/mounts/$KV_PATH" >/dev/null
+      bao secrets enable -path="$KV_PATH" -version=2 kv >/dev/null
       log "  mounted kv-v2 at $KV_PATH/"
+    fi
+
+    # ---------- Enable and configure Kubernetes auth ----------
+    log "ensuring Kubernetes auth at $KUBERNETES_AUTH_PATH/"
+    auths=$(bao_json auth list)
+    if echo "$auths" | jq -e --arg p "$auth_mount" '.[$p]' >/dev/null 2>&1; then
+      log "  $KUBERNETES_AUTH_PATH already enabled — skipping"
+    else
+      bao auth enable -path="$KUBERNETES_AUTH_PATH" kubernetes >/dev/null
+      log "  enabled kubernetes auth at $KUBERNETES_AUTH_PATH/"
+    fi
+
+    log "configuring Kubernetes auth"
+    bao write "$KUBERNETES_AUTH_PATH/config" \
+      kubernetes_host="https://kubernetes.default.svc" \
+      kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+      token_reviewer_jwt=@/var/run/secrets/kubernetes.io/serviceaccount/token >/dev/null
+
+    # ---------- Policy + role for Aeterna ----------
+    log "ensuring policy $policy_name"
+    policy_file="$(mktemp)"
+    cat > "$policy_file" <<EOF
+    path "${KV_PATH}/data/aeterna/*" {
+      capabilities = ["read"]
+    }
+    path "${KV_PATH}/metadata/aeterna/*" {
+      capabilities = ["read", "list"]
+    }
+    EOF
+    bao policy write "$policy_name" "$policy_file" >/dev/null
+    rm -f "$policy_file"
+
+    log "ensuring Kubernetes auth role $KUBERNETES_AUTH_ROLE"
+    bao write "$KUBERNETES_AUTH_PATH/role/$KUBERNETES_AUTH_ROLE" \
+      bound_service_account_names="$AETERNA_SERVICE_ACCOUNT_NAME" \
+      bound_service_account_namespaces="$AETERNA_SERVICE_ACCOUNT_NAMESPACE" \
+      policies="$policy_name" \
+      ttl="1h" >/dev/null
+
+    # ---------- Marker secret for startup self-test ----------
+    log "ensuring marker secret at $marker_path"
+    existing_marker=""
+    if bao kv get "$marker_path" >/dev/null 2>&1; then
+      existing_marker="$(bao kv get "$marker_path" -format=json | jq -r '.data.data.chart_version // empty')"
+    fi
+    if [ "$existing_marker" = "$CHART_VERSION" ]; then
+      log "  marker already at chart_version=$CHART_VERSION — skipping"
+    else
+      timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      bao kv put "$marker_path" chart_version="$CHART_VERSION" timestamp="$timestamp" >/dev/null
+      log "  marker updated to chart_version=$CHART_VERSION"
+    fi
+
+    # ---------- Best-effort auth verification ----------
+    if sa_exists; then
+      log "verifying Kubernetes auth using serviceaccount $AETERNA_SERVICE_ACCOUNT_NAMESPACE/$AETERNA_SERVICE_ACCOUNT_NAME"
+      sa_jwt="$(kubectl -n "$AETERNA_SERVICE_ACCOUNT_NAMESPACE" create token "$AETERNA_SERVICE_ACCOUNT_NAME" --duration=10m)"
+      login_out="$(curl -ksS -X POST \
+        -H 'Content-Type: application/json' \
+        -d "{\"role\":\"$KUBERNETES_AUTH_ROLE\",\"jwt\":\"$sa_jwt\"}" \
+        "$BAO_ADDR/v1/${KUBERNETES_AUTH_PATH}/login")"
+      client_token="$(echo "$login_out" | jq -r '.auth.client_token // empty')"
+      if [ -z "$client_token" ]; then
+        die "kubernetes auth verification failed for role=$KUBERNETES_AUTH_ROLE"
+      fi
+      role_policies="$(echo "$login_out" | jq -r '.auth.policies[]?' | sort | tr '\n' ' ')"
+      echo "$role_policies" | grep -q 'aeterna-pod' || die "kubernetes auth verification token missing aeterna-pod policy"
+      unset sa_jwt client_token role_policies login_out
+      log "  kubernetes auth verified"
+    else
+      log "Aeterna serviceaccount $AETERNA_SERVICE_ACCOUNT_NAMESPACE/$AETERNA_SERVICE_ACCOUNT_NAME not found yet — skipping auth verification"
     fi
 
     # ---------- Persist credentials into Secret ----------

--- a/charts/aeterna-prereqs/templates/openbao-bootstrap-script-cm.yaml
+++ b/charts/aeterna-prereqs/templates/openbao-bootstrap-script-cm.yaml
@@ -39,8 +39,8 @@ data:
     global_prefix="${global_prefix%/}"
     tenant_prefix="${TENANT_SECRETS_PREFIX#/}"
     tenant_prefix="${tenant_prefix%/}"
-    [ -n "$global_prefix" ] || die "GLOBAL_SECRETS_PREFIX must not normalize to empty"
-    [ -n "$tenant_prefix" ] || die "TENANT_SECRETS_PREFIX must not normalize to empty"
+    [ -n "$global_prefix" ] || die "GLOBAL_SECRETS_PREFIX cannot be empty or contain only slashes"
+    [ -n "$tenant_prefix" ] || die "TENANT_SECRETS_PREFIX cannot be empty or contain only slashes"
 
     marker_path="${KV_PATH}/${global_prefix}/aeterna/.bootstrap-marker"
     auth_mount="${KUBERNETES_AUTH_PATH%/}/"
@@ -175,6 +175,10 @@ data:
     log "ensuring policy $policy_name"
     policy_file="$(mktemp)"
     cat > "$policy_file" <<EOF
+    # Warning: this role is for a shared multi-tenant Aeterna workload.
+    # It can read both the global tree and any tenant tree beneath the
+    # configured prefixes. Hard per-tenant Vault/OpenBao isolation requires
+    # distinct workloads/auth roles per tenant, not a single shared role.
     path "${KV_PATH}/data/${global_prefix}/*" {
       capabilities = ["read"]
     }

--- a/charts/aeterna-prereqs/templates/tests/openbao-smoke.yaml
+++ b/charts/aeterna-prereqs/templates/tests/openbao-smoke.yaml
@@ -47,7 +47,7 @@ spec:
           bash /scripts/bootstrap.sh
           export VAULT_ADDR="$BAO_ADDR"
           export VAULT_TOKEN="$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o jsonpath='{.data.root_token}' | base64 -d)"
-          bao kv get "${KV_PATH}/aeterna/.bootstrap-marker" >/dev/null
+          test "$(bao kv get "${KV_PATH}/aeterna/.bootstrap-marker" -format=json | jq -r '.data.data.chart_version')" = "$CHART_VERSION"
       env:
         - name: MODE
           value: {{ .Values.openbao.mode | quote }}

--- a/charts/aeterna-prereqs/templates/tests/openbao-smoke.yaml
+++ b/charts/aeterna-prereqs/templates/tests/openbao-smoke.yaml
@@ -1,0 +1,98 @@
+{{- if and .Values.openbao.enabled .Values.openbao.bootstrap.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ printf "%s-openbao-smoke" (include "prereqs.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "prereqs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: openbao-smoke
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ include "prereqs.openbao.bootstrapSA" . }}
+  securityContext:
+    runAsNonRoot: true
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  initContainers:
+    - name: copy-bao
+      image: "{{ .Values.openbao.bootstrap.image.repository }}:{{ .Values.openbao.bootstrap.image.tag }}"
+      imagePullPolicy: {{ .Values.openbao.bootstrap.image.pullPolicy }}
+      command:
+        - sh
+        - -c
+        - |
+          set -eu
+          cp /bin/bao /shared/bao
+          chmod +x /shared/bao
+      securityContext:
+        {{- toYaml .Values.openbao.bootstrap.securityContext | nindent 8 }}
+      volumeMounts:
+        - name: shared
+          mountPath: /shared
+  containers:
+    - name: smoke
+      image: docker.io/bitnami/kubectl:1.30
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        {{- toYaml .Values.openbao.bootstrap.securityContext | nindent 8 }}
+      command:
+        - bash
+        - -ec
+        - |
+          bash /scripts/bootstrap.sh
+          export VAULT_ADDR="$BAO_ADDR"
+          export VAULT_TOKEN="$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o jsonpath='{.data.root_token}' | base64 -d)"
+          bao kv get "${KV_PATH}/aeterna/.bootstrap-marker" >/dev/null
+      env:
+        - name: MODE
+          value: {{ .Values.openbao.mode | quote }}
+        - name: BAO_ADDR
+          value: {{ include "prereqs.openbao.addr" . | quote }}
+        - name: KV_PATH
+          value: {{ .Values.openbao.bootstrap.kvPath | quote }}
+        - name: KUBERNETES_AUTH_PATH
+          value: {{ .Values.openbao.bootstrap.kubernetesAuthPath | quote }}
+        - name: KUBERNETES_AUTH_ROLE
+          value: {{ .Values.openbao.bootstrap.kubernetesAuthRole | quote }}
+        - name: AETERNA_SERVICE_ACCOUNT_NAME
+          value: {{ .Values.openbao.bootstrap.aeternaServiceAccountName | quote }}
+        - name: AETERNA_SERVICE_ACCOUNT_NAMESPACE
+          value: {{ include "prereqs.openbao.aeternaServiceAccountNamespace" . | quote }}
+        - name: SECRET_NAME
+          value: {{ include "prereqs.openbao.bootstrapSecretName" . | quote }}
+        - name: NAMESPACE
+          value: {{ .Release.Namespace | quote }}
+        - name: CHART_VERSION
+          value: {{ .Chart.Version | quote }}
+        - name: PATH
+          value: "/shared:/opt/bitnami/kubectl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        {{- if eq .Values.openbao.mode "internal-dev-seal" }}
+        - name: DEV_ROOT_TOKEN
+          value: {{ (((.Values.openbao).server).dev).devRootToken | default "root" | quote }}
+        {{- end }}
+      volumeMounts:
+        - name: shared
+          mountPath: /shared
+          readOnly: true
+        - name: scripts
+          mountPath: /scripts
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+      resources:
+        {{- toYaml .Values.openbao.bootstrap.resources | nindent 8 }}
+  volumes:
+    - name: shared
+      emptyDir: {}
+    - name: scripts
+      configMap:
+        name: {{ printf "%s-openbao-bootstrap-script" (include "prereqs.fullname" .) | trunc 63 | trimSuffix "-" }}
+        defaultMode: 0755
+    - name: tmp
+      emptyDir: {}
+{{- end }}

--- a/charts/aeterna-prereqs/templates/tests/openbao-smoke.yaml
+++ b/charts/aeterna-prereqs/templates/tests/openbao-smoke.yaml
@@ -47,7 +47,7 @@ spec:
           bash /scripts/bootstrap.sh
           export VAULT_ADDR="$BAO_ADDR"
           export VAULT_TOKEN="$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o jsonpath='{.data.root_token}' | base64 -d)"
-          test "$(bao kv get "${KV_PATH}/aeterna/.bootstrap-marker" -format=json | jq -r '.data.data.chart_version')" = "$CHART_VERSION"
+          test "$(bao kv get "${KV_PATH}/${GLOBAL_SECRETS_PREFIX}/aeterna/.bootstrap-marker" -format=json | jq -r '.data.data.chart_version')" = "$CHART_VERSION"
       env:
         - name: MODE
           value: {{ .Values.openbao.mode | quote }}
@@ -55,6 +55,10 @@ spec:
           value: {{ include "prereqs.openbao.addr" . | quote }}
         - name: KV_PATH
           value: {{ .Values.openbao.bootstrap.kvPath | quote }}
+        - name: GLOBAL_SECRETS_PREFIX
+          value: {{ .Values.openbao.bootstrap.globalSecretsPathPrefix | quote }}
+        - name: TENANT_SECRETS_PREFIX
+          value: {{ .Values.openbao.bootstrap.tenantSecretsPathPrefix | quote }}
         - name: KUBERNETES_AUTH_PATH
           value: {{ .Values.openbao.bootstrap.kubernetesAuthPath | quote }}
         - name: KUBERNETES_AUTH_ROLE

--- a/charts/aeterna-prereqs/values-e2e.yaml
+++ b/charts/aeterna-prereqs/values-e2e.yaml
@@ -1,0 +1,41 @@
+# values-e2e.yaml — prereqs overlay for the Aeterna e2e suite.
+#
+# Used by `aeterna-e2e` (PR #169). Activates OpenBao in dev-seal mode for
+# ephemeral KinD/k3d clusters. Data is in-memory and root token is well-known.
+# DO NOT use this overlay against any cluster carrying real data.
+#
+# Usage (from .github/workflows/e2e-conformance.yaml):
+#   helm install aeterna-prereqs ./charts/aeterna-prereqs \
+#     -n aeterna --create-namespace \
+#     -f ./charts/aeterna-prereqs/values-e2e.yaml
+
+openbao:
+  enabled: true
+  mode: internal-dev-seal
+  bootstrap:
+    enabled: true
+    kvPath: "secret"
+  server:
+    dev:
+      enabled: true
+      devRootToken: "root"
+    # Keep resources tiny for CI runners.
+    resources:
+      limits:
+        cpu: 200m
+        memory: 128Mi
+      requests:
+        cpu: 25m
+        memory: 64Mi
+
+# Slim down sibling components for CI as well.
+postgresql:
+  enabled: true
+
+cache:
+  dragonfly:
+    enabled: true
+
+vectorStore:
+  qdrant:
+    enabled: true

--- a/charts/aeterna-prereqs/values.yaml
+++ b/charts/aeterna-prereqs/values.yaml
@@ -168,3 +168,100 @@ valkey:
     requests:
       cpu: 50m
       memory: 128Mi
+
+## OpenBao subchart (secrets backend for Aeterna)
+## https://github.com/openbao/openbao-helm
+##
+## Three deployment modes are supported via `openbao.mode`:
+##
+##   internal-dev-seal  — single pod, in-memory dev mode, root token = "root".
+##                        Data is ephemeral. ONLY for ephemeral CI / e2e clusters.
+##                        REQUIRES: openbao.server.dev.enabled=true
+##
+##   internal-shamir    — single pod with file storage and Shamir unseal.
+##                        Bootstrap Job stores 1 unseal key + root token in a Secret.
+##                        Convenient for shared dev clusters; NOT production-grade.
+##                        REQUIRES: openbao.server.standalone.enabled=true
+##
+##   external           — assumes the embedded OpenBao subchart is configured with
+##                        an external auto-unseal seal stanza (e.g. AWS KMS, GCP KMS,
+##                        Azure Key Vault, Transit). Bootstrap Job runs init only.
+##                        Suitable for production with proper operator review.
+##
+## The bootstrap Job writes connection info into a Secret consumed by the Aeterna
+## chart via `vault.bootstrapSecretName`. See the Aeterna chart for wiring details.
+openbao:
+  enabled: false
+  ## Deployment mode — gates the bootstrap Job behaviour.
+  ## One of: internal-dev-seal | internal-shamir | external
+  mode: internal-dev-seal
+
+  ## Bootstrap Job — runs once on `helm install/upgrade` to initialise OpenBao,
+  ## persist credentials into a Secret, and enable a kv-v2 mount at `secret/`.
+  bootstrap:
+    enabled: true
+    ## Container image used by the bootstrap Job. Must include `bao` and `kubectl`.
+    image:
+      repository: openbao/openbao
+      tag: "2.5.3"
+      pullPolicy: IfNotPresent
+    ## Override the generated Secret name (default: <release>-openbao-bootstrap).
+    secretName: ""
+    ## KV-v2 mount path to enable post-init.
+    kvPath: "secret"
+    ## Helm hook weight + delete-policy. Default: hook on post-install,post-upgrade.
+    hookWeight: 5
+    ## ServiceAccount + RBAC scope (namespace-local).
+    serviceAccount:
+      create: true
+      name: ""
+    resources:
+      limits:
+        cpu: 200m
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 100
+      runAsGroup: 1000
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+
+  ## --- Below: passthrough to the upstream openbao chart ---
+  ## Defaults shown match `mode: internal-dev-seal`. Override per-mode as needed.
+  ## See: https://github.com/openbao/openbao-helm/blob/main/charts/openbao/values.yaml
+  global:
+    enabled: true
+  injector:
+    enabled: false
+  csi:
+    enabled: false
+  server:
+    image:
+      repository: openbao/openbao
+      tag: "2.5.3"
+    dev:
+      enabled: true
+      devRootToken: "root"
+    standalone:
+      enabled: false
+    ha:
+      enabled: false
+    dataStorage:
+      enabled: false
+    auditStorage:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi

--- a/charts/aeterna-prereqs/values.yaml
+++ b/charts/aeterna-prereqs/values.yaml
@@ -209,6 +209,12 @@ openbao:
     secretName: ""
     ## KV-v2 mount path to enable post-init.
     kvPath: "secret"
+    ## Global/shared secret prefix under the KV-v2 mount.
+    ## Example: secret/global/github/app
+    globalSecretsPathPrefix: "global"
+    ## Tenant-scoped secret prefix under the KV-v2 mount.
+    ## Example: secret/tenants/<tenant-id>/llm/openai
+    tenantSecretsPathPrefix: "tenants"
     ## Kubernetes auth path configured for the Aeterna workload.
     kubernetesAuthPath: "auth/kubernetes"
     ## Kubernetes auth role bound to the Aeterna ServiceAccount.

--- a/charts/aeterna-prereqs/values.yaml
+++ b/charts/aeterna-prereqs/values.yaml
@@ -209,6 +209,14 @@ openbao:
     secretName: ""
     ## KV-v2 mount path to enable post-init.
     kvPath: "secret"
+    ## Kubernetes auth path configured for the Aeterna workload.
+    kubernetesAuthPath: "auth/kubernetes"
+    ## Kubernetes auth role bound to the Aeterna ServiceAccount.
+    kubernetesAuthRole: "aeterna"
+    ## ServiceAccount name expected to authenticate from the Aeterna chart.
+    aeternaServiceAccountName: "aeterna"
+    ## Namespace of the Aeterna ServiceAccount. Empty = this release namespace.
+    aeternaServiceAccountNamespace: ""
     ## Helm hook weight + delete-policy. Default: hook on post-install,post-upgrade.
     hookWeight: 5
     ## ServiceAccount + RBAC scope (namespace-local).

--- a/charts/aeterna/README.md
+++ b/charts/aeterna/README.md
@@ -166,6 +166,23 @@ cnpg:
   enabled: false
 ```
 
+## Vault / OpenBao Secret Resolution
+
+When you deploy OpenBao via the `aeterna-prereqs` chart, enable Vault wiring in
+the main chart so `SecretReference::Vault` values resolve from the application:
+
+```yaml
+vault:
+  enabled: true
+  # Empty = assume the sibling prereqs chart service name
+  address: ""
+  kubernetesAuthPath: "auth/kubernetes"
+  kubernetesAuthRole: "aeterna"
+```
+
+If `vault.address` is left blank, the chart assumes OpenBao is reachable at
+`http://<release>-prereqs-openbao:8200`.
+
 ## LLM Provider Configuration
 
 ```yaml

--- a/charts/aeterna/README.md
+++ b/charts/aeterna/README.md
@@ -183,6 +183,40 @@ vault:
 If `vault.address` is left blank, the chart assumes OpenBao is reachable at
 `http://<release>-prereqs-openbao:8200`.
 
+Recommended KV-v2 layout for multi-tenant deployments:
+
+- Global/shared secrets: `secret/global/<domain>/<name>`
+- Tenant-scoped secrets: `secret/tenants/<tenant-id>/<domain>/<name>`
+
+Reference them from tenant config with explicit `SecretReference::Vault`
+paths:
+
+```json
+{
+  "kind": "vault",
+  "mount": "secret",
+  "path": "global/github/app",
+  "field": "private_key"
+}
+```
+
+```json
+{
+  "kind": "vault",
+  "mount": "secret",
+  "path": "tenants/{tenant_id}/llm/openai",
+  "field": "api_key"
+}
+```
+
+`{tenant_id}` is expanded by the server at read time from the current tenant.
+Use a global path when a secret is intentionally shared across tenants.
+
+Note: with a single Aeterna deployment, OpenBao auth is still performed by the
+application's Kubernetes service account, so this layout provides clear
+namespace separation and safe defaults, not hard per-tenant Vault auth
+isolation. Hard isolation requires separate workloads and auth roles per tenant.
+
 ## LLM Provider Configuration
 
 ```yaml

--- a/charts/aeterna/templates/NOTES.txt
+++ b/charts/aeterna/templates/NOTES.txt
@@ -1,0 +1,13 @@
+{{- if .Values.vault.enabled }}
+Vault / OpenBao integration is enabled for the Aeterna workload.
+
+Vault address: {{ include "aeterna.vault.address" . }}
+Kubernetes auth path: {{ .Values.vault.kubernetesAuthPath }}
+Kubernetes auth role: {{ .Values.vault.kubernetesAuthRole }}
+ServiceAccount subject: system:serviceaccount:{{ .Release.Namespace }}:{{ include "aeterna.vault.serviceAccountName" . }}
+
+{{- if not .Values.vault.address }}
+The chart is assuming the prereqs chart was installed alongside this release
+and that the OpenBao service is reachable at the default sibling DNS name above.
+{{- end }}
+{{- end }}

--- a/charts/aeterna/templates/_helpers.tpl
+++ b/charts/aeterna/templates/_helpers.tpl
@@ -60,6 +60,24 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Vault address for the Aeterna workload.
+*/}}
+{{- define "aeterna.vault.address" -}}
+{{- if .Values.vault.address -}}
+{{- .Values.vault.address -}}
+{{- else -}}
+{{- printf "http://%s-prereqs-openbao:8200" .Release.Name -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+ServiceAccount name used for Vault/OpenBao Kubernetes auth.
+*/}}
+{{- define "aeterna.vault.serviceAccountName" -}}
+{{- .Values.vault.aeternaServiceAccount | default (include "aeterna.serviceAccountName" .) -}}
+{{- end }}
+
+{{/*
 Return the image reference
 */}}
 {{- define "aeterna.image" -}}

--- a/charts/aeterna/templates/aeterna/deployment.yaml
+++ b/charts/aeterna/templates/aeterna/deployment.yaml
@@ -272,6 +272,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.vault.enabled }}
+            - name: VAULT_ADDR
+              value: {{ include "aeterna.vault.address" . | quote }}
+            - name: VAULT_K8S_AUTH_PATH
+              value: {{ .Values.vault.kubernetesAuthPath | quote }}
+            - name: VAULT_K8S_AUTH_ROLE
+              value: {{ .Values.vault.kubernetesAuthRole | quote }}
+            {{- end }}
             {{- if .Values.githubOrgSync.enabled }}
             - name: AETERNA_GITHUB_ORG_NAME
               value: {{ .Values.githubOrgSync.orgName | quote }}

--- a/charts/aeterna/templates/validation/_validation.tpl
+++ b/charts/aeterna/templates/validation/_validation.tpl
@@ -123,6 +123,17 @@ Validate Okta-backed auth boundary configuration.
 {{- end -}}
 
 {{/*
+Validate Vault/OpenBao secret-resolution configuration.
+*/}}
+{{- define "aeterna.validate.vault" -}}
+{{- if .Values.vault.enabled -}}
+  {{- if not .Values.aeterna.serviceAccount.automount -}}
+{{- fail "Invalid configuration: vault.enabled requires aeterna.serviceAccount.automount=true so the workload can use Kubernetes auth with Vault/OpenBao." -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Run all validations. Include this once in a rendered resource.
 */}}
 {{- define "aeterna.validate.all" -}}
@@ -133,4 +144,5 @@ Run all validations. Include this once in a rendered resource.
 {{- include "aeterna.validate.codesearch" . -}}
 {{- include "aeterna.validate.secrets" . -}}
 {{- include "aeterna.validate.okta" . -}}
+{{- include "aeterna.validate.vault" . -}}
 {{- end -}}

--- a/charts/aeterna/values.schema.json
+++ b/charts/aeterna/values.schema.json
@@ -152,6 +152,17 @@
         }
       }
     },
+    "vault": {
+      "type": "object",
+      "description": "Vault/OpenBao secret resolution configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "address": { "type": "string", "default": "" },
+        "kubernetesAuthPath": { "type": "string", "default": "auth/kubernetes" },
+        "kubernetesAuthRole": { "type": "string", "default": "aeterna" },
+        "aeternaServiceAccount": { "type": "string", "default": "" }
+      }
+    },
     "vectorBackend": {
       "type": "object",
       "description": "Vector backend configuration",

--- a/charts/aeterna/values.yaml
+++ b/charts/aeterna/values.yaml
@@ -357,6 +357,24 @@ k8sAuth:
   # Format: "system:serviceaccount:<namespace>:<name>"
   syncSaSubject: ""
 
+## Vault / OpenBao secret-resolution configuration.
+## When enabled, the Aeterna server resolves `SecretReference::Vault`
+## values against the configured Vault-compatible endpoint using
+## Kubernetes auth from its ServiceAccount token.
+vault:
+  ## Enable Vault/OpenBao runtime wiring in the Aeterna deployment.
+  enabled: false
+  ## Explicit Vault/OpenBao address. Empty = assume the prereqs chart
+  ## was installed alongside this chart as `<release>-prereqs-openbao`.
+  address: ""
+  ## Kubernetes auth mount path configured in Vault/OpenBao.
+  kubernetesAuthPath: "auth/kubernetes"
+  ## Kubernetes auth role for the Aeterna workload.
+  kubernetesAuthRole: "aeterna"
+  ## Override the ServiceAccount name expected by the prereqs bootstrap role.
+  ## Empty = use the chart's own ServiceAccount name.
+  aeternaServiceAccount: ""
+
 tenantConfigProvider:
   enabled: true
   seedTenants: []

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ config.workspace = true
 errors.workspace = true
 utils.workspace = true
 storage.workspace = true
-memory = { workspace = true, features = ["llm-integration", "embedding-integration", "google-provider", "bedrock-provider"] }
+memory = { workspace = true, features = ["llm-integration", "embedding-integration", "google-provider", "bedrock-provider", "vault"] }
 knowledge.workspace = true
 tools.workspace = true
 sync.workspace = true

--- a/cli/src/server/bootstrap.rs
+++ b/cli/src/server/bootstrap.rs
@@ -47,6 +47,7 @@ use super::service_token_validator;
 use super::{AppState, PluginAuthState, bootstrap_tracker};
 
 const DEFAULT_K8S_NAMESPACE: &str = "default";
+const SYSTEM_MARKER_TENANT_ID: &str = "00000000-0000-0000-0000-000000000000";
 
 const ENV_AUTH_BACKEND: &str = "AETERNA_AUTH_BACKEND";
 const AUTH_BACKEND_ALLOW_ALL: &str = "allow-all";
@@ -571,7 +572,7 @@ async fn vault_marker_self_test(registry: &TenantProviderRegistry) {
         return;
     }
 
-    let tenant = TenantId::new("00000000-0000-0000-0000-000000000000".to_string())
+    let tenant = TenantId::new(SYSTEM_MARKER_TENANT_ID.to_string())
         .expect("hard-coded zero uuid is a valid TenantId");
     let chart_version_ref = SecretReference::Vault {
         mount: "secret".to_string(),

--- a/cli/src/server/bootstrap.rs
+++ b/cli/src/server/bootstrap.rs
@@ -576,12 +576,12 @@ async fn vault_marker_self_test(registry: &TenantProviderRegistry) {
         .expect("hard-coded zero uuid is a valid TenantId");
     let chart_version_ref = SecretReference::Vault {
         mount: "secret".to_string(),
-        path: "aeterna/.bootstrap-marker".to_string(),
+        path: "global/aeterna/.bootstrap-marker".to_string(),
         field: "chart_version".to_string(),
     };
     let timestamp_ref = SecretReference::Vault {
         mount: "secret".to_string(),
-        path: "aeterna/.bootstrap-marker".to_string(),
+        path: "global/aeterna/.bootstrap-marker".to_string(),
         field: "timestamp".to_string(),
     };
 

--- a/cli/src/server/bootstrap.rs
+++ b/cli/src/server/bootstrap.rs
@@ -22,10 +22,11 @@ use memory::llm::create_llm_service_from_env;
 use memory::manager::MemoryManager;
 use memory::provider_registry::TenantProviderRegistry;
 use memory::reasoning::{DefaultReflectiveReasoner, ReflectiveReasoner};
+use mk_core::secret::SecretReference;
 use mk_core::traits::AuthorizationService;
 use mk_core::types::{
     DEFAULT_TENANT_SLUG, INSTANCE_SCOPE_TENANT_ID, PROVIDER_GITHUB, ReasoningStrategy,
-    ReasoningTrace, Role, RoleIdentifier, TenantContext, UserId,
+    ReasoningTrace, Role, RoleIdentifier, TenantContext, TenantId, UserId,
 };
 use storage::git_provider_connection_store::{
     InMemoryGitProviderConnectionStore, RedisGitProviderConnectionStore,
@@ -270,6 +271,8 @@ pub async fn bootstrap() -> anyhow::Result<Arc<AppState>> {
 
         registry.set_secret_resolver_registry(Arc::new(secret_registry));
     }
+
+    vault_marker_self_test(&registry).await;
 
     let provider_registry = Arc::new(registry);
 
@@ -558,6 +561,53 @@ fn tenant_config_provider_namespace_from_config(k8s_auth: &config::KubernetesAut
         .as_deref()
         .unwrap_or(DEFAULT_K8S_NAMESPACE)
         .to_string()
+}
+
+async fn vault_marker_self_test(registry: &TenantProviderRegistry) {
+    if std::env::var("VAULT_ADDR")
+        .map(|v| v.trim().is_empty())
+        .unwrap_or(true)
+    {
+        return;
+    }
+
+    let tenant = TenantId::new("00000000-0000-0000-0000-000000000000".to_string())
+        .expect("hard-coded zero uuid is a valid TenantId");
+    let chart_version_ref = SecretReference::Vault {
+        mount: "secret".to_string(),
+        path: "aeterna/.bootstrap-marker".to_string(),
+        field: "chart_version".to_string(),
+    };
+    let timestamp_ref = SecretReference::Vault {
+        mount: "secret".to_string(),
+        path: "aeterna/.bootstrap-marker".to_string(),
+        field: "timestamp".to_string(),
+    };
+
+    match registry
+        .resolve_secret_ref(&tenant, &chart_version_ref)
+        .await
+    {
+        Ok(chart_version) => {
+            let chart_version = String::from_utf8_lossy(chart_version.expose()).to_string();
+            let timestamp = registry
+                .resolve_secret_ref(&tenant, &timestamp_ref)
+                .await
+                .ok()
+                .map(|value| String::from_utf8_lossy(value.expose()).to_string());
+            tracing::info!(
+                chart_version = %chart_version,
+                marker_timestamp = timestamp.as_deref().unwrap_or("<unknown>"),
+                "Vault/OpenBao bootstrap marker read succeeded at startup"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "Vault/OpenBao bootstrap marker read failed at startup; continuing"
+            );
+        }
+    }
 }
 
 fn create_graph_store(config: &config::Config) -> anyhow::Result<Option<Arc<DuckDbGraphStore>>> {

--- a/memory/src/secret_resolvers/vault.rs
+++ b/memory/src/secret_resolvers/vault.rs
@@ -33,6 +33,8 @@ use crate::secret_resolver::{ResolveError, SecretRefResolver};
 const DEFAULT_K8S_AUTH_PATH: &str = "auth/kubernetes";
 const DEFAULT_K8S_JWT_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/token";
 const DEFAULT_TIMEOUT_SECS: u64 = 5;
+const TOKEN_REFRESH_BUFFER_SECS: u64 = 30;
+const TOKEN_REFRESH_BUFFER_DIVISOR: u64 = 10;
 
 #[derive(Debug, Clone)]
 enum VaultAuthConfig {
@@ -233,8 +235,13 @@ impl VaultRefResolver {
 
                 let token = SecretBytes::from_string(auth.client_token);
                 let ttl = auth.lease_duration.unwrap_or(300);
-                let refresh_after =
-                    std::cmp::max(1, ttl.saturating_sub(std::cmp::min(30, ttl / 10)));
+                let refresh_after = std::cmp::max(
+                    1,
+                    ttl.saturating_sub(std::cmp::min(
+                        TOKEN_REFRESH_BUFFER_SECS,
+                        ttl / TOKEN_REFRESH_BUFFER_DIVISOR,
+                    )),
+                );
                 let cached = CachedToken {
                     token: token.clone(),
                     expires_at: Instant::now() + Duration::from_secs(refresh_after),
@@ -429,12 +436,12 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn reports_kind_vault() {
         assert_eq!(VaultRefResolver::new().kind(), "vault");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn resolves_with_static_token() {
         let _guard = ENV_LOCK.lock().await;
         clear_vault_env();
@@ -461,7 +468,7 @@ mod tests {
         clear_vault_env();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn resolves_with_kubernetes_auth_and_caches_token() {
         let _guard = ENV_LOCK.lock().await;
         clear_vault_env();
@@ -511,7 +518,7 @@ mod tests {
         clear_vault_env();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn missing_field_is_not_found() {
         let _guard = ENV_LOCK.lock().await;
         clear_vault_env();
@@ -538,7 +545,7 @@ mod tests {
         clear_vault_env();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn empty_mount_is_malformed() {
         let _guard = ENV_LOCK.lock().await;
         clear_vault_env();
@@ -567,7 +574,7 @@ mod tests {
         clear_vault_env();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn wrong_kind_is_rejected() {
         let resolver = VaultRefResolver::new();
         let env = SecretReference::Env {

--- a/memory/src/secret_resolvers/vault.rs
+++ b/memory/src/secret_resolvers/vault.rs
@@ -10,6 +10,14 @@
 //!   `VAULT_K8S_AUTH_ROLE` plus the pod's projected service-account JWT to
 //!   log in at `VAULT_K8S_AUTH_PATH` (default: `auth/kubernetes`).
 //!
+//! Path conventions:
+//!
+//! * Global/shared secrets can live under a stable path such as
+//!   `global/<domain>/<name>`.
+//! * Tenant-scoped secrets can use `tenants/{tenant_id}/...`; the resolver
+//!   substitutes `{tenant_id}` (and the aliases `{tenant}` / `{tenantId}`)
+//!   from the current [`TenantId`] before issuing the KV read.
+//!
 //! Security notes:
 //!
 //! * Secret values and tokens are carried as [`mk_core::SecretBytes`] and
@@ -293,6 +301,13 @@ impl VaultRefResolver {
             field.as_str(),
         ))
     }
+
+    fn expand_path(path: &str, tenant: &TenantId) -> String {
+        let tenant_id = tenant.as_str();
+        path.replace("{tenant_id}", tenant_id)
+            .replace("{tenantId}", tenant_id)
+            .replace("{tenant}", tenant_id)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -331,6 +346,7 @@ impl SecretRefResolver for VaultRefResolver {
                 kind: "vault",
                 reason: "Vault token is not valid UTF-8".to_string(),
             })?;
+        let path = Self::expand_path(path, tenant);
         let url = format!("{}/v1/{}/data/{}", config.address, mount, path);
 
         let response = self
@@ -514,6 +530,43 @@ mod tests {
         let second = resolver.resolve(&tid(), &vault_ref()).await.unwrap();
         assert_eq!(first.expose(), b"hunter2");
         assert_eq!(second.expose(), b"hunter2");
+
+        clear_vault_env();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn expands_tenant_placeholders_in_secret_path() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_vault_env();
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/tenants/11111111-1111-1111-1111-111111111111/llm/openai"))
+            .and(header("x-vault-token", "root-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "data": { "api_key": "tenant-token" } }
+            })))
+            .mount(&server)
+            .await;
+
+        unsafe {
+            std::env::set_var("VAULT_ADDR", server.uri());
+            std::env::set_var("VAULT_TOKEN", "root-token");
+        }
+
+        let resolver = VaultRefResolver::new();
+        let out = resolver
+            .resolve(
+                &tid(),
+                &SecretReference::Vault {
+                    mount: "secret".to_string(),
+                    path: "tenants/{tenant_id}/llm/openai".to_string(),
+                    field: "api_key".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(out.expose(), b"tenant-token");
 
         clear_vault_env();
     }

--- a/memory/src/secret_resolvers/vault.rs
+++ b/memory/src/secret_resolvers/vault.rs
@@ -541,7 +541,9 @@ mod tests {
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/v1/secret/data/tenants/11111111-1111-1111-1111-111111111111/llm/openai"))
+            .and(path(
+                "/v1/secret/data/tenants/11111111-1111-1111-1111-111111111111/llm/openai",
+            ))
             .and(header("x-vault-token", "root-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "data": { "data": { "api_key": "tenant-token" } }

--- a/memory/src/secret_resolvers/vault.rs
+++ b/memory/src/secret_resolvers/vault.rs
@@ -1,9 +1,585 @@
-//! HashiCorp Vault backend — compiled only under `feature = "vault"`.
+//! B4 §3.4 — [`VaultRefResolver`].
 //!
-//! `mod.rs` declares this module behind `#[cfg(feature = "vault")]`;
-//! without the feature, `vault_stub` is re-exported as `vault`
-//! instead. This file exists so `rustfmt`'s module traversal
-//! (which, unlike `cargo`, does not honour cfg gates) can succeed
-//! even when the feature is off.
+//! Resolves `SecretReference::Vault { mount, path, field }` against a
+//! Vault-compatible KV-v2 API such as OpenBao.
 //!
-//! The real Vault implementation is tracked under B4 §3.4.
+//! Authentication modes:
+//!
+//! * `VAULT_TOKEN` — use the provided token directly.
+//! * Kubernetes auth — when `VAULT_TOKEN` is absent, use
+//!   `VAULT_K8S_AUTH_ROLE` plus the pod's projected service-account JWT to
+//!   log in at `VAULT_K8S_AUTH_PATH` (default: `auth/kubernetes`).
+//!
+//! Security notes:
+//!
+//! * Secret values and tokens are carried as [`mk_core::SecretBytes`] and
+//!   never logged.
+//! * Error messages include only status codes / structural diagnostics,
+//!   never response bodies.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use mk_core::SecretBytes;
+use mk_core::secret::SecretReference;
+use mk_core::types::TenantId;
+use serde::Deserialize;
+use serde_json::json;
+use tokio::sync::Mutex;
+
+use crate::secret_resolver::{ResolveError, SecretRefResolver};
+
+const DEFAULT_K8S_AUTH_PATH: &str = "auth/kubernetes";
+const DEFAULT_K8S_JWT_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+const DEFAULT_TIMEOUT_SECS: u64 = 5;
+
+#[derive(Debug, Clone)]
+enum VaultAuthConfig {
+    StaticToken(SecretBytes),
+    Kubernetes {
+        auth_path: String,
+        role: String,
+        jwt_path: PathBuf,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct VaultConfig {
+    address: String,
+    auth: VaultAuthConfig,
+}
+
+#[derive(Debug, Clone)]
+struct CachedToken {
+    token: SecretBytes,
+    expires_at: Instant,
+}
+
+#[derive(Debug)]
+pub struct VaultRefResolver {
+    client: reqwest::Client,
+    config: Option<VaultConfig>,
+    cached_token: Mutex<Option<CachedToken>>,
+}
+
+impl Default for VaultRefResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VaultRefResolver {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+            config: Self::config_from_env().ok(),
+            cached_token: Mutex::new(None),
+        }
+    }
+
+    fn config_from_env() -> Result<VaultConfig, ResolveError> {
+        let address =
+            std::env::var("VAULT_ADDR").map_err(|_| ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: "VAULT_ADDR is not set".to_string(),
+            })?;
+        let address = address.trim().trim_end_matches('/').to_string();
+        if address.is_empty() {
+            return Err(ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: "VAULT_ADDR is empty".to_string(),
+            });
+        }
+
+        if let Ok(token) = std::env::var("VAULT_TOKEN")
+            && !token.trim().is_empty()
+        {
+            return Ok(VaultConfig {
+                address,
+                auth: VaultAuthConfig::StaticToken(SecretBytes::from_string(token)),
+            });
+        }
+
+        let role =
+            std::env::var("VAULT_K8S_AUTH_ROLE").map_err(|_| ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: "VAULT_TOKEN is unset and VAULT_K8S_AUTH_ROLE is not set".to_string(),
+            })?;
+        if role.trim().is_empty() {
+            return Err(ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: "VAULT_K8S_AUTH_ROLE is empty".to_string(),
+            });
+        }
+
+        let auth_path = std::env::var("VAULT_K8S_AUTH_PATH")
+            .unwrap_or_else(|_| DEFAULT_K8S_AUTH_PATH.to_string());
+        let auth_path = auth_path.trim().trim_matches('/').to_string();
+        if auth_path.is_empty() {
+            return Err(ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: "VAULT_K8S_AUTH_PATH is empty".to_string(),
+            });
+        }
+
+        let jwt_path = std::env::var("VAULT_K8S_JWT_PATH")
+            .unwrap_or_else(|_| DEFAULT_K8S_JWT_PATH.to_string());
+        let jwt_path = PathBuf::from(jwt_path);
+
+        Ok(VaultConfig {
+            address,
+            auth: VaultAuthConfig::Kubernetes {
+                auth_path,
+                role,
+                jwt_path,
+            },
+        })
+    }
+
+    async fn access_token(&self) -> Result<SecretBytes, ResolveError> {
+        let Some(config) = &self.config else {
+            return Err(ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: "Vault resolver is not configured from environment".to_string(),
+            });
+        };
+
+        match &config.auth {
+            VaultAuthConfig::StaticToken(token) => Ok(token.clone()),
+            VaultAuthConfig::Kubernetes {
+                auth_path,
+                role,
+                jwt_path,
+            } => {
+                {
+                    let cached = self.cached_token.lock().await;
+                    if let Some(entry) = &*cached
+                        && entry.expires_at > Instant::now()
+                    {
+                        return Ok(entry.token.clone());
+                    }
+                }
+
+                let jwt = Self::read_jwt(jwt_path)?;
+                let url = format!(
+                    "{}/v1/{}/login",
+                    config.address,
+                    auth_path.trim_matches('/')
+                );
+                let jwt_str = std::str::from_utf8(jwt.expose()).map_err(|_| {
+                    ResolveError::BackendUnavailable {
+                        kind: "vault",
+                        reason: "projected Kubernetes JWT is not valid UTF-8".to_string(),
+                    }
+                })?;
+
+                let response = self
+                    .client
+                    .post(url)
+                    .json(&json!({
+                        "role": role,
+                        "jwt": jwt_str,
+                    }))
+                    .send()
+                    .await
+                    .map_err(|e| ResolveError::BackendUnavailable {
+                        kind: "vault",
+                        reason: format!("Vault Kubernetes login request failed: {e}"),
+                    })?;
+
+                match response.status().as_u16() {
+                    200 => {}
+                    401 | 403 => {
+                        return Err(ResolveError::PermissionDenied {
+                            kind: "vault",
+                            reason: format!(
+                                "Vault Kubernetes login denied (HTTP {}) for role {role}",
+                                response.status().as_u16()
+                            ),
+                        });
+                    }
+                    status => {
+                        return Err(ResolveError::BackendUnavailable {
+                            kind: "vault",
+                            reason: format!(
+                                "Vault Kubernetes login failed with HTTP {status} at {auth_path}"
+                            ),
+                        });
+                    }
+                }
+
+                let body = response.json::<LoginResponse>().await.map_err(|e| {
+                    ResolveError::BackendUnavailable {
+                        kind: "vault",
+                        reason: format!("Vault Kubernetes login response parse failed: {e}"),
+                    }
+                })?;
+
+                let auth = body.auth.ok_or_else(|| ResolveError::BackendUnavailable {
+                    kind: "vault",
+                    reason: "Vault Kubernetes login response missing auth block".to_string(),
+                })?;
+                if auth.client_token.trim().is_empty() {
+                    return Err(ResolveError::BackendUnavailable {
+                        kind: "vault",
+                        reason: "Vault Kubernetes login response returned an empty token"
+                            .to_string(),
+                    });
+                }
+
+                let token = SecretBytes::from_string(auth.client_token);
+                let ttl = auth.lease_duration.unwrap_or(300);
+                let refresh_after =
+                    std::cmp::max(1, ttl.saturating_sub(std::cmp::min(30, ttl / 10)));
+                let cached = CachedToken {
+                    token: token.clone(),
+                    expires_at: Instant::now() + Duration::from_secs(refresh_after),
+                };
+                *self.cached_token.lock().await = Some(cached);
+                Ok(token)
+            }
+        }
+    }
+
+    fn read_jwt(path: &Path) -> Result<SecretBytes, ResolveError> {
+        let raw = std::fs::read(path).map_err(|e| ResolveError::BackendUnavailable {
+            kind: "vault",
+            reason: format!("read projected Kubernetes JWT {}: {e}", path.display()),
+        })?;
+        if raw.is_empty() {
+            return Err(ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: format!("projected Kubernetes JWT {} is empty", path.display()),
+            });
+        }
+        Ok(SecretBytes::from(raw))
+    }
+
+    fn ensure_reference(reference: &SecretReference) -> Result<(&str, &str, &str), ResolveError> {
+        let SecretReference::Vault { mount, path, field } = reference else {
+            return Err(ResolveError::WrongKind {
+                expected: "vault",
+                actual: reference.kind(),
+            });
+        };
+
+        for (label, value) in [
+            ("mount", mount.as_str()),
+            ("path", path.as_str()),
+            ("field", field.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                return Err(ResolveError::MalformedReference {
+                    kind: "vault",
+                    reason: format!("{label} is empty"),
+                });
+            }
+        }
+
+        Ok((
+            mount.trim_matches('/'),
+            path.trim_start_matches('/'),
+            field.as_str(),
+        ))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct LoginResponse {
+    auth: Option<LoginAuth>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LoginAuth {
+    client_token: String,
+    lease_duration: Option<u64>,
+}
+
+#[async_trait]
+impl SecretRefResolver for VaultRefResolver {
+    fn kind(&self) -> &'static str {
+        "vault"
+    }
+
+    async fn resolve(
+        &self,
+        tenant: &TenantId,
+        reference: &SecretReference,
+    ) -> Result<SecretBytes, ResolveError> {
+        let (mount, path, field) = Self::ensure_reference(reference)?;
+        let Some(config) = &self.config else {
+            return Err(ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: "Vault resolver is not configured from environment".to_string(),
+            });
+        };
+
+        let token = self.access_token().await?;
+        let token_str =
+            std::str::from_utf8(token.expose()).map_err(|_| ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: "Vault token is not valid UTF-8".to_string(),
+            })?;
+        let url = format!("{}/v1/{}/data/{}", config.address, mount, path);
+
+        let response = self
+            .client
+            .get(url)
+            .header("X-Vault-Token", token_str)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: format!("Vault KV read failed: {e}"),
+            })?;
+
+        match response.status().as_u16() {
+            200 => {}
+            401 | 403 => {
+                return Err(ResolveError::PermissionDenied {
+                    kind: "vault",
+                    reason: format!("Vault KV read denied (HTTP {})", response.status().as_u16()),
+                });
+            }
+            404 => {
+                return Err(ResolveError::NotFound {
+                    tenant: tenant.clone(),
+                    kind: "vault",
+                });
+            }
+            status => {
+                return Err(ResolveError::BackendUnavailable {
+                    kind: "vault",
+                    reason: format!("Vault KV read failed with HTTP {status}"),
+                });
+            }
+        }
+
+        let body = response.json::<serde_json::Value>().await.map_err(|e| {
+            ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: format!("Vault KV response parse failed: {e}"),
+            }
+        })?;
+
+        let Some(value) = body
+            .get("data")
+            .and_then(|data| data.get("data"))
+            .and_then(|data| data.get(field))
+        else {
+            return Err(ResolveError::NotFound {
+                tenant: tenant.clone(),
+                kind: "vault",
+            });
+        };
+
+        if let Some(s) = value.as_str() {
+            return Ok(SecretBytes::from_string(s.to_string()));
+        }
+
+        serde_json::to_vec(value)
+            .map(SecretBytes::from)
+            .map_err(|e| ResolveError::BackendUnavailable {
+                kind: "vault",
+                reason: format!("Vault field serialization failed: {e}"),
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use tempfile::NamedTempFile;
+    use tokio::sync::Mutex as TokioMutex;
+    use wiremock::matchers::{body_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn tid() -> TenantId {
+        TenantId::new("11111111-1111-1111-1111-111111111111".to_string()).unwrap()
+    }
+
+    fn vault_ref() -> SecretReference {
+        SecretReference::Vault {
+            mount: "secret".to_string(),
+            path: "apps/demo".to_string(),
+            field: "api_key".to_string(),
+        }
+    }
+
+    static ENV_LOCK: std::sync::LazyLock<Arc<TokioMutex<()>>> =
+        std::sync::LazyLock::new(|| Arc::new(TokioMutex::new(())));
+
+    fn clear_vault_env() {
+        for key in [
+            "VAULT_ADDR",
+            "VAULT_TOKEN",
+            "VAULT_K8S_AUTH_ROLE",
+            "VAULT_K8S_AUTH_PATH",
+            "VAULT_K8S_JWT_PATH",
+        ] {
+            unsafe { std::env::remove_var(key) };
+        }
+    }
+
+    #[tokio::test]
+    async fn reports_kind_vault() {
+        assert_eq!(VaultRefResolver::new().kind(), "vault");
+    }
+
+    #[tokio::test]
+    async fn resolves_with_static_token() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_vault_env();
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/apps/demo"))
+            .and(header("x-vault-token", "root-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "data": { "api_key": "hunter2" } }
+            })))
+            .mount(&server)
+            .await;
+
+        unsafe {
+            std::env::set_var("VAULT_ADDR", server.uri());
+            std::env::set_var("VAULT_TOKEN", "root-token");
+        }
+
+        let resolver = VaultRefResolver::new();
+        let out = resolver.resolve(&tid(), &vault_ref()).await.unwrap();
+        assert_eq!(out.expose(), b"hunter2");
+
+        clear_vault_env();
+    }
+
+    #[tokio::test]
+    async fn resolves_with_kubernetes_auth_and_caches_token() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_vault_env();
+
+        let jwt_file = NamedTempFile::new().unwrap();
+        std::fs::write(jwt_file.path(), "jwt-token").unwrap();
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/kubernetes/login"))
+            .and(body_json(json!({
+                "role": "aeterna",
+                "jwt": "jwt-token",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "auth": {
+                    "client_token": "issued-token",
+                    "lease_duration": 600
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/apps/demo"))
+            .and(header("x-vault-token", "issued-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "data": { "api_key": "hunter2" } }
+            })))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        unsafe {
+            std::env::set_var("VAULT_ADDR", server.uri());
+            std::env::set_var("VAULT_K8S_AUTH_ROLE", "aeterna");
+            std::env::set_var("VAULT_K8S_AUTH_PATH", "auth/kubernetes");
+            std::env::set_var("VAULT_K8S_JWT_PATH", jwt_file.path());
+        }
+
+        let resolver = VaultRefResolver::new();
+        let first = resolver.resolve(&tid(), &vault_ref()).await.unwrap();
+        let second = resolver.resolve(&tid(), &vault_ref()).await.unwrap();
+        assert_eq!(first.expose(), b"hunter2");
+        assert_eq!(second.expose(), b"hunter2");
+
+        clear_vault_env();
+    }
+
+    #[tokio::test]
+    async fn missing_field_is_not_found() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_vault_env();
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/apps/demo"))
+            .and(header("x-vault-token", "root-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "data": { "other": "value" } }
+            })))
+            .mount(&server)
+            .await;
+
+        unsafe {
+            std::env::set_var("VAULT_ADDR", server.uri());
+            std::env::set_var("VAULT_TOKEN", "root-token");
+        }
+
+        let resolver = VaultRefResolver::new();
+        let err = resolver.resolve(&tid(), &vault_ref()).await.unwrap_err();
+        assert!(matches!(err, ResolveError::NotFound { kind: "vault", .. }));
+
+        clear_vault_env();
+    }
+
+    #[tokio::test]
+    async fn empty_mount_is_malformed() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_vault_env();
+        unsafe {
+            std::env::set_var("VAULT_ADDR", "http://vault.local");
+            std::env::set_var("VAULT_TOKEN", "root-token");
+        }
+
+        let resolver = VaultRefResolver::new();
+        let err = resolver
+            .resolve(
+                &tid(),
+                &SecretReference::Vault {
+                    mount: "".to_string(),
+                    path: "apps/demo".to_string(),
+                    field: "api_key".to_string(),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ResolveError::MalformedReference { kind: "vault", .. }
+        ));
+
+        clear_vault_env();
+    }
+
+    #[tokio::test]
+    async fn wrong_kind_is_rejected() {
+        let resolver = VaultRefResolver::new();
+        let env = SecretReference::Env {
+            var: "X".to_string(),
+        };
+        let err = resolver.resolve(&tid(), &env).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ResolveError::WrongKind {
+                expected: "vault",
+                actual: "env"
+            }
+        ));
+    }
+}

--- a/memory/src/secret_resolvers/vault.rs
+++ b/memory/src/secret_resolvers/vault.rs
@@ -574,6 +574,47 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn expands_all_supported_tenant_placeholder_aliases() {
+        let _guard = ENV_LOCK.lock().await;
+        clear_vault_env();
+
+        let server = MockServer::start().await;
+        for suffix in ["{tenant_id}", "{tenantId}", "{tenant}"] {
+            Mock::given(method("GET"))
+                .and(path(
+                    "/v1/secret/data/tenants/11111111-1111-1111-1111-111111111111/shared/key",
+                ))
+                .and(header("x-vault-token", "root-token"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": { "data": { "value": "ok" } }
+                })))
+                .up_to_n_times(1)
+                .mount(&server)
+                .await;
+
+            unsafe {
+                std::env::set_var("VAULT_ADDR", server.uri());
+                std::env::set_var("VAULT_TOKEN", "root-token");
+            }
+
+            let resolver = VaultRefResolver::new();
+            let out = resolver
+                .resolve(
+                    &tid(),
+                    &SecretReference::Vault {
+                        mount: "secret".to_string(),
+                        path: format!("tenants/{suffix}/shared/key"),
+                        field: "value".to_string(),
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(out.expose(), b"ok");
+            clear_vault_env();
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn missing_field_is_not_found() {
         let _guard = ENV_LOCK.lock().await;
         clear_vault_env();

--- a/mk_core/src/secret.rs
+++ b/mk_core/src/secret.rs
@@ -291,7 +291,10 @@ pub enum SecretReference {
     Vault {
         /// Mount point of the KV-v2 engine (e.g. `"secret"`).
         mount: String,
-        /// Path under the mount (e.g. `"tenants/acme/db"`).
+        /// Path under the mount (e.g. `"global/github/app"` or
+        /// `"tenants/{tenant_id}/db"`). The Vault resolver expands
+        /// `{tenant_id}` (plus `{tenant}` / `{tenantId}` aliases) from the
+        /// current tenant before reading KV-v2.
         path: String,
         /// Field name within the secret document.
         field: String,

--- a/openspec/changes/add-openbao-deployment-option/design.md
+++ b/openspec/changes/add-openbao-deployment-option/design.md
@@ -1,0 +1,193 @@
+# Design: Add OpenBao deployment option to `aeterna-prereqs`
+
+## Context
+
+`charts/aeterna-prereqs/` is the existing pattern for "bring up backing services for dev/test/CI." It already conditionally deploys PostgreSQL (CloudNativePG), Dragonfly/Valkey (cache), and Qdrant (vector store) via Helm dependency conditions. The main `charts/aeterna/` chart is intentionally dependency-free; it consumes whatever the operator has running and points at it via `VAULT_ADDR`, `DATABASE_URL`, etc.
+
+`mk_core::SecretReference::Vault { mount, path, field }` is already a first-class variant. The resolver in `cli/src/server/tenant_api.rs:4413` reads from a Vault-API-speaking endpoint at `VAULT_ADDR`. Today there is no chart-side support for actually deploying that endpoint; consumers are on their own.
+
+## Decisions
+
+### D1 — OpenBao over HashiCorp Vault
+
+**Decision:** OpenBao (Linux Foundation, Apache-2.0).
+
+- Wire-compatible with Vault API — `SecretReference::Vault` resolver works unchanged.
+- Apache-2.0 license — no BSL ambiguity for downstream consumers redistributing aeterna.
+- Active LF governance + IBM, Hashibox, GitLab as anchor contributors.
+- Helm chart `openbao/openbao` is well-maintained.
+
+**Rejected:** HashiCorp Vault. License concerns for redistribution; not an issue for our own use but is one for consumers vendoring this chart into commercial products.
+
+**Rejected:** Bitnami `vault` chart. Tracks HashiCorp Vault, same license issue + Bitnami container repackaging concerns.
+
+### D2 — Distribution shape: subchart of `aeterna-prereqs`, not main chart
+
+**Decision:** Add OpenBao as a conditional dependency in `charts/aeterna-prereqs/Chart.yaml`. Default-off via `openbao.enabled: false`.
+
+```yaml
+# charts/aeterna-prereqs/Chart.yaml (new dependency block)
+dependencies:
+  # ... existing dragonfly / qdrant / valkey ...
+  - name: openbao
+    version: "0.10.*"          # pinned minor in D11
+    repository: https://openbao.github.io/openbao-helm
+    condition: openbao.enabled
+    alias: openbao
+```
+
+The main `charts/aeterna/` chart stays dependency-free. It learns to address bao via `VAULT_ADDR` like any other Vault — no special-casing.
+
+**Rejected:** Embedding OpenBao in the main `aeterna` chart. Violates the chart's "deploys only the application" contract; couples aeterna's release lifecycle to bao's, complicates upgrades, conflicts with consumers running their own Vault.
+
+**Rejected:** A standalone `aeterna-vault` chart. Duplicates the prereqs pattern; no consumer benefit; more charts to publish + version.
+
+### D3 — Default off; opt-in via single flag
+
+**Decision:** `openbao.enabled: false` is the default. Enabling = `--set openbao.enabled=true` (plus the seal-mode choice from §D6).
+
+Rationale: every existing `aeterna-prereqs` user gets identical behavior on upgrade. Migration story is "set the flag, install, optionally migrate secrets" — never forced.
+
+### D4 — Storage backend: integrated raft
+
+**Decision:** OpenBao integrated raft storage, single-node by default, scalable to 3- or 5-node HA via `openbao.server.ha.replicas`.
+
+- Zero external dependencies (no Consul, no Postgres backend).
+- Raft is what the OpenBao chart's HA mode uses; we follow upstream defaults.
+- PVC-backed at `openbao.server.dataStorage.size: 10Gi` default (override-able).
+
+**Rejected:** File backend. No HA path; no scale story.
+**Rejected:** Postgres backend. Couples bao availability to aeterna's main DB; defeats the point of running bao for secrets isolation.
+
+### D5 — Auth method: Kubernetes ServiceAccount
+
+**Decision:** Kubernetes auth method (`auth/kubernetes/`) only. Aeterna's pod authenticates to bao via its projected SA token; bao validates against the cluster's TokenReview API.
+
+- No long-lived bao tokens stored anywhere.
+- No AppRole secret-id rotation problem.
+- Works identically in kind, EKS, GKE, AKS, on-prem k8s.
+
+The aeterna pod gets `VAULT_ADDR=http://aeterna-prereqs-openbao:8200` and `VAULT_K8S_AUTH_PATH=auth/kubernetes` env vars; the existing resolver does the SA-token exchange on first read and caches the resulting bao token until expiry.
+
+**Rejected (for v1):** AppRole, JWT/OIDC. Tracked as future enhancements for non-k8s deployments. The resolver is auth-method-agnostic in its API surface, so adding them later is mechanical.
+
+### D6 — Seal modes: three, with guardrails
+
+**Decision:** Surface three named seal modes via `openbao.seal.mode`:
+
+| Mode | Use case | Production-safe? | Guardrail |
+|---|---|---|---|
+| `dev` | e2e + local dev only | **No** | Chart refuses install unless `openbao.allowDevSeal=true` is *also* set; templates emit a `WARNING` notes block; readiness probe annotated `aeterna.io/dev-seal=true` |
+| `manual` | Shamir unseal (3-of-5 keys) | Yes (with care) | Pod blocks ready until manually unsealed via `bao operator unseal`; documented, discouraged |
+| `auto-unseal` | Production | **Yes** | Requires one of: `awsKms` / `gcpKms` / `azureKeyVault` / `k8sSealWrap` config blocks; chart fails template if `mode=auto-unseal` and no provider block is set |
+
+Auto-unseal provider blocks are documented in `values.yaml` with full examples per cloud.
+
+The dev-seal guardrail is critical: it prevents an operator from accidentally running an in-memory bao in production and discovering on the next pod restart that all secrets are gone.
+
+### D7 — TLS
+
+**Decision:** Default to `http://` inside the cluster (kube-proxy + ClusterIP). Operators can flip on `openbao.server.tls.enabled=true` to terminate TLS at the bao service via cert-manager (`openbao.server.tls.certManagerIssuer`).
+
+Rationale: in-cluster traffic between aeterna and bao is one hop on the pod network; defaulting to TLS-everywhere doubles the failure surface during install for zero security gain when the cluster has network policies. Consumers who require TLS-everywhere flip the flag.
+
+**No public ingress for bao**, ever. Documented as a hard rule. Bao is ClusterIP-only; access from outside the cluster goes through `kubectl port-forward` or a separate consumer-managed VPN.
+
+### D8 — Bootstrap Job
+
+**Decision:** A single Job, deployed as a Helm `post-install,post-upgrade` hook with `before-hook-creation,hook-succeeded` delete policy.
+
+The Job runs a small bash script that:
+
+1. Polls bao readiness (`bao status`) until ready or 60s timeout.
+2. If KV v2 not enabled at `secret/aeterna/`, enable it (`bao secrets enable -path=secret -version=2 kv` — idempotent: ignore "path is already in use").
+3. If k8s auth not enabled at `auth/kubernetes/`, enable it.
+4. Configure k8s auth: `bao write auth/kubernetes/config kubernetes_host=https://kubernetes.default.svc kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt token_reviewer_jwt=@/var/run/secrets/kubernetes.io/serviceaccount/token`.
+5. Write policy `aeterna-pod`:
+   ```hcl
+   path "secret/data/aeterna/*" { capabilities = ["read"] }
+   path "secret/metadata/aeterna/*" { capabilities = ["list", "read"] }
+   ```
+6. Create role `aeterna` binding the policy to the aeterna ServiceAccount in the aeterna namespace.
+
+**Idempotency:** every step checks current state before mutating. Re-running the Job (e.g. after `helm upgrade`) is a no-op when state matches.
+
+**Secrets-leak posture:**
+- Job runs with no env vars containing token material (it uses the k8s SA token mounted at the standard path).
+- Script uses `set -o pipefail` and `set +x` throughout — no command tracing.
+- Job logs are scrubbed: bao token output is `>/dev/null` redirected; only step names log to stdout.
+- Job's RBAC is the minimum: `serviceaccounts/token` create on the `aeterna` SA in the aeterna namespace, nothing more.
+
+### D9 — How aeterna addresses bao
+
+**Decision:** Two new env vars consumed by the existing Vault resolver, populated in `charts/aeterna/templates/deployment.yaml` only when the operator sets `vault.enabled=true` in the main chart's values:
+
+- `VAULT_ADDR`: defaults to `http://aeterna-prereqs-openbao:8200` (assumes the prereqs chart was installed in the same release name + namespace; documented).
+- `VAULT_K8S_AUTH_PATH`: defaults to `auth/kubernetes`; `auth/kubernetes/aeterna` if the consumer namespaced the auth path.
+
+Operators using their own external Vault override `vault.enabled=true` + `vault.address=https://vault.internal.example.com:8200`. The aeterna chart doesn't care which target it points at, as long as Vault API speaks back.
+
+### D10 — How the e2e suite (PR #169) uses it
+
+**Decision:** A values overlay `charts/aeterna-prereqs/values-e2e.yaml` enables bao in `dev` seal mode (with `allowDevSeal=true`). The e2e runner script's `kind-bootstrap` cluster mode does:
+
+```bash
+helm install aeterna-prereqs charts/aeterna-prereqs \
+  -f charts/aeterna-prereqs/values-e2e.yaml \
+  --set openbao.enabled=true \
+  --set openbao.allowDevSeal=true \
+  --set openbao.seal.mode=dev
+```
+
+The existing `vault.sh` secrets-backend adapter from #169 task 20.4 works unchanged. New e2e env var:
+
+- `AETERNA_E2E_VAULT_ADDR` — defaults to `http://aeterna-prereqs-openbao.aeterna-e2e.svc.cluster.local:8200` in `kind-bootstrap`. Overridable for `existing-kubeconfig` and `external-https` modes.
+
+This closes #169's open AC for the `vault` backend in CI: we now exercise the `vault` adapter against a real OpenBao instance on every full-profile run, not just smoke-test it against a mock.
+
+### D11 — Versioning and upgrades
+
+**Decision:** Pin OpenBao Helm chart to `0.10.*` (or whatever's current at implementation time — concrete pin in tasks.md 1.1). Bump policy:
+
+- Patch versions: auto-accepted via `0.10.*` constraint; CI matrix tests against `latest` weekly.
+- Minor versions: explicit PR; updates `Chart.yaml`, regenerates `Chart.lock`, runs full e2e profile.
+- Major versions of OpenBao itself (1.x → 2.x): full design review; never silent.
+
+`OPENBAO_VERSION_COMPAT.md` (new file) tracks which `aeterna-prereqs` chart versions support which OpenBao versions, with upgrade notes.
+
+### D12 — Backup / DR (out of scope for v1)
+
+**Decision:** Out of scope for this change. Documented in §D11 of the v2 follow-up sketch:
+- Raft snapshot CronJob (`bao operator raft snapshot save`) on a configurable schedule
+- Snapshot upload to S3/GCS via init-container pattern
+- Restore runbook
+- Data residency considerations
+
+For v1, operators using `auto-unseal` are pointed at OpenBao's upstream DR docs.
+
+### D13 — Migration from `Postgres`-stored to `Vault`-stored secrets
+
+**Decision:** Doc-only for v1. Operational steps:
+
+1. Operator deploys bao via this change.
+2. Operator runs a one-off script (provided as a runbook, not a binary): for each tenant secret, read plaintext via the Postgres resolver path, write to bao at `secret/aeterna/<tenant-id>/<key>`, update the `tenant_secrets` row to flip the `SecretReference` from `Postgres` to `Vault`.
+3. Verification: re-render manifests, confirm resolution works, confirm Postgres rows can be soft-deleted.
+
+A migration *binary* (`aeterna-cli secrets migrate --from postgres --to vault`) is its own change. Sketch in `docs/runbooks/secrets-migration.md` (new in this change), but no code.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Severity | Mitigation |
+|---|---|---|---|
+| Operator enables `dev` seal in production and loses all secrets on pod restart | medium | **catastrophic** | Two-flag guardrail (D6); chart-rendered NOTES emit a screaming warning; readiness annotation flagged; doc front-loads this risk |
+| OpenBao governance instability (project is young) | low | medium | Pin minor (D11); CI matrix runs against `latest` to detect drift early; design accepts swap-back to HashiCorp Vault is a one-line `Chart.yaml` change since the API is identical |
+| Bootstrap Job fails idempotency check on upgrade and corrupts policy | medium | high | Each step queries-then-writes; Job is `--dry-run` validated in CI; `helm test` includes a smoke that re-runs the Job to confirm no-op behavior |
+| K8s auth misconfiguration (wrong SA, wrong namespace) silently denies aeterna pod | medium | medium | Bootstrap Job emits a final verification step that issues a `bao login -method=kubernetes role=aeterna` using the aeterna SA token via TokenRequest API and asserts success |
+| OpenBao chart's HA mode (raft) loses quorum on cluster maintenance | low | high | HA mode is opt-in; default is single-node; HA-mode docs include explicit PDB + PVC retention guidance |
+| Bootstrap Job logs leak bao root token | low | catastrophic | Root token is generated by bao itself and never logged; Job uses k8s auth only — no root token exists in our control plane after init; explicit grep test in CI scans Job logs for `hvs.` and `s.` token prefixes (D8) |
+| Cross-chart coupling: aeterna upgraded before/after prereqs upgrade breaks bao addressability | low | medium | `VAULT_ADDR` is a Service DNS name, not a versioned reference; Service contract is unchanged across OpenBao chart minors; documented |
+| Existing consumers enable `openbao.enabled=true` accidentally on `helm upgrade` | very low | low | Default is `false`; behavior change requires explicit values flip |
+
+## Open questions
+
+None as of this draft. (License and lineage answered in §D1; subchart placement in §D2; default-off behavior in §D3; auth-method choice in §D5; seal-mode safety in §D6; migration-tooling scope in §D13.)

--- a/openspec/changes/add-openbao-deployment-option/proposal.md
+++ b/openspec/changes/add-openbao-deployment-option/proposal.md
@@ -1,0 +1,59 @@
+# Add OpenBao deployment option to `aeterna-prereqs`
+
+## Why
+
+`SecretReference::Vault { mount, path, field }` already exists in `mk_core::secret`, with a working resolver in `cli/src/server/tenant_api.rs:4413`. What's missing is **a way for a consumer to actually have a vault running** without going off and provisioning one themselves.
+
+Two consumer scenarios drive this:
+
+1. **Production / staging deployments.** Operators who want `Vault`-backed secrets (instead of the default Postgres-encrypted `tenant_secrets` table) currently have to bring their own HashiCorp Vault cluster. Significant ops burden + a license question post-2023 BSL relicense.
+2. **The redesigned e2e conformance suite (PR #169).** Task 20.4 ships a `vault.sh` secrets-backend adapter so downstream consumers can resolve test secrets via Vault. Without a deployable target, that adapter has nothing to talk to in `kind-bootstrap` mode and the conformance contract for the `vault` backend can't be exercised in our own CI.
+
+**OpenBao** is the natural fit:
+- LF-hosted Apache-2.0 fork of HashiCorp Vault (post-BSL split, governed under the Linux Foundation)
+- Wire-compatible with the Vault API — existing resolver code, CLI, and SDKs work unchanged
+- First-class Helm chart (`openbao/openbao`) with k8s-native auth, raft storage, KMS auto-unseal
+- Replaces "bring your own vault" with "flip a values flag"
+
+## What Changes
+
+- **New conditional dependency** in `charts/aeterna-prereqs/Chart.yaml` on the official `openbao/openbao` Helm chart, gated by `openbao.enabled` (default **off** — backwards-compatible with every existing prereqs deployment).
+- **Bootstrap Job** (post-install / post-upgrade Helm hook) that idempotently configures OpenBao for aeterna's needs:
+  - Enables KV v2 secret engine at `secret/aeterna/`
+  - Enables Kubernetes ServiceAccount auth at `auth/kubernetes/`
+  - Creates policy `aeterna-pod` granting `read` on `secret/data/aeterna/*`
+  - Binds the policy to the `aeterna` ServiceAccount in the aeterna namespace
+- **Three documented seal modes** with explicit guardrails:
+  - `dev` — auto-unsealed in-memory; **for e2e + local dev only**; chart refuses to install with `dev` seal unless `openbao.allowDevSeal=true` is also set
+  - `manual` — Shamir unseal; documented but discouraged
+  - `auto-unseal` — production-grade via AWS KMS / GCP KMS / Azure Key Vault / k8s seal-wrap; values surface for each
+- **No changes to the `aeterna` main chart and no changes to the resolver code** — aeterna talks to bao via `VAULT_ADDR` env, which already works because OpenBao speaks Vault's API. Default `VAULT_ADDR` value in `charts/aeterna` is updated to point at `http://aeterna-prereqs-openbao:8200` when (and only when) the consumer enables bao.
+- **e2e suite integration** (cross-links #169 task 20.4): a values overlay `charts/aeterna-prereqs/values-e2e.yaml` enabling bao in `dev` seal mode for the `kind-bootstrap` cluster mode. The existing `vault.sh` adapter from #169 task 20.4 works unchanged against it.
+- **Documentation:** runbook for production auto-unseal config (per cloud), migration sketch from `Postgres`-stored to `Vault`-stored secrets (operational guide; no migration tooling shipped — out of scope for v1), upgrade and DR notes.
+
+## What does NOT Change
+
+- `SecretReference` enum and its resolver — already shipped (harden-tenant-provisioning task 3.4 ✅).
+- Default secrets backend remains `Postgres` (the encrypted `tenant_secrets` table). OpenBao is opt-in.
+- Existing tenants. No data migration is forced by this change.
+- The main `charts/aeterna` chart's "no dependencies" stance — bao stays in prereqs where postgres / dragonfly / qdrant live.
+
+## Capabilities
+
+- **New:** `openbao-deployment` (subchart wiring + bootstrap job + seal-mode contract)
+- **Modified:** `aeterna-prereqs-chart` (new conditional dependency + values surface)
+- **Modified (docs only):** `secrets-backend` capability (production runbook for the Vault variant)
+
+## Impact
+
+- **Code:** zero Rust changes. All Helm + Bash.
+- **Security posture:** dev seal mode is loud-by-default; production seal config is required not optional; secrets-leak posture for the bootstrap Job is covered in design.md §D8.
+- **Ops:** consumers gain a one-flag option. Existing consumers unaffected.
+- **Cross-PR coordination:** unblocks PR #169's `vault` secrets-backend mode in `kind-bootstrap` cluster mode (closing what would otherwise be a documentation-only feature in our own CI).
+
+## Out of scope
+
+- Backup / DR snapshot CronJob (raft snapshots): tracked as a v2 follow-up.
+- Migration tooling from `SecretReference::Postgres` → `SecretReference::Vault` (doc-only sketch; rotation tooling is its own change).
+- HashiCorp Vault Enterprise features (namespaces, performance replication): OpenBao does not implement them; consumers needing those bring their own Vault Enterprise (the resolver still works).
+- Publishing OpenBao as a transitive dep of `charts/aeterna` itself: explicitly rejected — keeps the main chart dependency-free.

--- a/openspec/changes/add-openbao-deployment-option/tasks.md
+++ b/openspec/changes/add-openbao-deployment-option/tasks.md
@@ -1,43 +1,79 @@
 # Tasks: Add OpenBao deployment option to `aeterna-prereqs`
 
+## Implementation status (updated 2026-04-27)
+
+**Phase 1 (this commit) — DELIVERED:**
+- ✅ Subchart wiring (Chart.yaml dep on openbao `~0.27.0`, Chart.lock updated)
+- ✅ `openbao:` values block with 3-mode contract (`internal-dev-seal` | `internal-shamir` | `external`)
+- ✅ Dev-seal guardrail helper (`prereqs.openbao.assertSealMode`) — fails render with actionable message on invalid mode or mode/subchart-values mismatch
+- ✅ Bootstrap Job (Helm post-install/post-upgrade hook) — initializes OpenBao per mode, enables kv-v2 at `secret/`, persists `root_token` (+ `unseal_key` for shamir) into a namespace-local Secret
+- ✅ Scoped RBAC (Role + RoleBinding to a single bootstrap Secret + pod read for readiness; no cluster-scoped permissions)
+- ✅ NOTES.txt warning block when dev-seal mode is active
+- ✅ `values-e2e.yaml` overlay for the e2e suite (PR #169)
+- ✅ `helm lint` clean; `helm template` covers all 3 modes; bash syntax check on rendered bootstrap.sh
+
+**Phase 2 (deferred to a follow-up change) — NOT in this PR:**
+- ⏳ Kubernetes auth method enable/configure on OpenBao
+- ⏳ `aeterna-pod` policy + role binding (SA → policy)
+- ⏳ Marker secret `secret/aeterna/.bootstrap-marker` for chart version self-test
+- ⏳ `helm test` smoke pod for bootstrap idempotency
+- ⏳ `charts/aeterna` `vault:` block + deployment env injection (consumer-side wiring)
+
+The Phase 2 scope is intentionally scoped out: it is "aeterna authenticates with bao",
+which is logically separate from "bao is installable as a prereq". Phase 1 alone
+unblocks PR #169 (which only needs OpenBao to exist with a KV mount and a known
+root token in dev-seal mode).
+
 ## 0. Resolve design conflicts (blocking)
 
-- [ ] 0.1 Confirm OpenBao over HashiCorp Vault (per design.md §D1). Operator action: none required if confirmed; this is a license/governance choice, not a technical lock-in.
-- [ ] 0.2 Confirm subchart-in-prereqs (vs main-chart-dep, vs standalone chart) per §D2.
-- [ ] 0.3 Confirm default-off (per §D3) — backwards-compat for every existing consumer of `aeterna-prereqs`.
-- [ ] 0.4 Confirm k8s-SA-only auth for v1 (per §D5) — punts AppRole/JWT/OIDC to follow-ups.
-- [ ] 0.5 Confirm three-mode seal contract with the dev-seal guardrail (per §D6) — production-safety lock-in.
-- [ ] 0.6 Confirm migration tooling is out of scope for v1 (per §D13).
+- [x] 0.1 Confirm OpenBao over HashiCorp Vault (per design.md §D1). Operator action: none required if confirmed; this is a license/governance choice, not a technical lock-in.
+- [x] 0.2 Confirm subchart-in-prereqs (vs main-chart-dep, vs standalone chart) per §D2.
+- [x] 0.3 Confirm default-off (per §D3) — backwards-compat for every existing consumer of `aeterna-prereqs`.
+- [x] 0.4 Confirm k8s-SA-only auth for v1 (per §D5) — punts AppRole/JWT/OIDC to follow-ups. *(Phase 2)*
+- [x] 0.5 Confirm three-mode seal contract with the dev-seal guardrail (per §D6) — production-safety lock-in.
+- [x] 0.6 Confirm migration tooling is out of scope for v1 (per §D13).
 
 ## Phase B1 — Subchart wiring
 
 ### 1. `charts/aeterna-prereqs` dependency declaration
 
-- [ ] 1.1 Add OpenBao to `charts/aeterna-prereqs/Chart.yaml` `dependencies:` block. Pin to a current `0.10.*` minor; record the resolved exact version in a comment.
-- [ ] 1.2 `helm dependency update charts/aeterna-prereqs` — commit the resulting `Chart.lock` and `charts/*.tgz` artifacts (or document the unpacked-vendor approach if preferred).
-- [ ] 1.3 Bump `charts/aeterna-prereqs/Chart.yaml` `version` (minor bump per semver — new optional dependency).
+- [x] 1.1 Add OpenBao to `charts/aeterna-prereqs/Chart.yaml` `dependencies:` block. Pinned to `~0.27.0` (resolved to `0.27.2`, appVersion `v2.5.3`).
+- [x] 1.2 `helm dependency update charts/aeterna-prereqs` — `Chart.lock` and `charts/openbao-0.27.2.tgz` produced.
+- [ ] 1.3 Bump `charts/aeterna-prereqs/Chart.yaml` `version` (deferred — will bump together with merge of this change).
 
 ### 2. `charts/aeterna-prereqs/values.yaml` — bao section
 
-- [ ] 2.1 Add top-level `openbao:` block in `values.yaml` with: `enabled: false`, `allowDevSeal: false`, `seal: { mode: auto-unseal, awsKms: {}, gcpKms: {}, azureKeyVault: {}, k8sSealWrap: {} }`, `server: { ha: { replicas: 1 }, dataStorage: { size: 10Gi, storageClass: "" }, tls: { enabled: false, certManagerIssuer: "" } }`, `bootstrap: { enabled: true, kvMount: "secret", kvPath: "aeterna", policyName: "aeterna-pod", role: "aeterna" }`.
-- [ ] 2.2 Document each value with `## @param` comments matching the prereqs chart's existing convention.
-- [ ] 2.3 Add a `## @section OpenBao` header before the block.
+- [x] 2.1 Added top-level `openbao:` block. Shape **revised vs original tasks.md**: simpler 3-mode contract (`mode: internal-dev-seal | internal-shamir | external`) instead of separate `seal.mode` + `allowDevSeal` flags. Bootstrap config: `enabled`, `image`, `secretName`, `kvPath`, `hookWeight`, `serviceAccount`, `resources`, `securityContext`. Subchart passthrough under `openbao.global/injector/csi/server`.
+- [x] 2.2 Each block has inline `##` doc comments explaining the contract.
+- [x] 2.3 Section header added with mode descriptions and links to upstream chart values.
 
 ### 3. Dev-seal guardrail
 
-- [ ] 3.1 In `charts/aeterna-prereqs/templates/_helpers.tpl`, add `aeterna-prereqs.openbao.assertSealMode` helper that fails the template render if `.Values.openbao.seal.mode == "dev"` and `.Values.openbao.allowDevSeal != true`.
-- [ ] 3.2 Helper also fails if `.Values.openbao.seal.mode == "auto-unseal"` and none of the four provider blocks have any non-empty fields.
-- [ ] 3.3 Call the helper from the bootstrap-job template (Phase B2) so render fails before any resource is created.
-- [ ] 3.4 In `charts/aeterna-prereqs/templates/NOTES.txt`, emit a multi-line WARNING block when `dev` seal is active, including the words "DO NOT USE IN PRODUCTION."
+- [x] 3.1 In `charts/aeterna-prereqs/templates/_helpers.tpl`, added `prereqs.openbao.assertSealMode` helper. Fails render if `mode` is not in the allowed set, or if mode/subchart values are inconsistent (e.g. `mode=internal-shamir` with `server.dev.enabled=true`).
+- [x] 3.2 N/A under revised contract (auto-unseal config validation is the operator's responsibility under `mode=external` — they bring the seal stanza). Documented in NOTES.
+- [x] 3.3 Helper is called from `openbao-bootstrap-rbac.yaml` (the first hook to render), so `helm template/install` fails before any resource is created.
+- [x] 3.4 `templates/NOTES.txt` emits a large multi-line warning block when `mode=internal-dev-seal` (including "DO NOT USE FOR PRODUCTION") and a smaller warning for `mode=internal-shamir`.
 
 ## Phase B2 — Bootstrap Job
 
 ### 4. Job manifest
 
-- [ ] 4.1 New file `charts/aeterna-prereqs/templates/openbao-bootstrap-job.yaml`. Helm hook annotations: `helm.sh/hook: post-install,post-upgrade`, `helm.sh/hook-weight: "5"`, `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`.
-- [ ] 4.2 Job spec: `restartPolicy: OnFailure`, `backoffLimit: 3`, `activeDeadlineSeconds: 180`. Service account = a new `aeterna-prereqs-openbao-bootstrap` SA created in the same namespace with minimum RBAC (no cluster-scoped permissions).
-- [ ] 4.3 Container: `openbao/openbao:<pinned>` (same version as the chart dep — derive via `.Chart.Dependencies` lookup or hardcode-with-comment). Mounts the projected SA token from `/var/run/secrets/kubernetes.io/serviceaccount/token` (default mount).
-- [ ] 4.4 Job env: `VAULT_ADDR=http://{{ .Release.Name }}-openbao:8200`, `VAULT_TOKEN` populated from the bootstrap-token Secret (created in Phase B2 §5).
+- [x] 4.1 Created `charts/aeterna-prereqs/templates/openbao-bootstrap-job.yaml` with hooks `helm.sh/hook: post-install,post-upgrade`, configurable `hook-weight` (default `"5"`), `hook-delete-policy: before-hook-creation,hook-succeeded`.
+- [x] 4.2 Job: `restartPolicy: OnFailure`, `backoffLimit: 3`, `ttlSecondsAfterFinished: 600`. SA `<release>-openbao-bootstrap` with namespace-scoped Role limited to (a) get/update/patch on the single bootstrap Secret by `resourceNames`, (b) create on Secrets in the namespace, (c) get/list/watch on Pods (for readiness). NO cluster-scoped permissions.
+- [x] 4.3 Two-container pattern (because `openbao` image lacks `kubectl` and `bitnami/kubectl` lacks `bao`): initContainer copies `/bin/bao` from `openbao/openbao:2.5.3` into a shared emptyDir; main container `bitnami/kubectl:1.30` runs the script with `/shared` prepended to `PATH`. All security context: `runAsNonRoot`, `readOnlyRootFilesystem`, drops ALL caps, seccomp `RuntimeDefault`.
+- [x] 4.4 Job env: `MODE`, `BAO_ADDR=http://<release>-openbao.<ns>.svc:8200`, `KV_PATH`, `SECRET_NAME`, `NAMESPACE`, plus `DEV_ROOT_TOKEN` only when `mode=internal-dev-seal`. The Job authenticates to OpenBao using the dev root token (dev-seal) or freshly-minted root token from `sys/init` (shamir/external).
+
+### 5. Bootstrap script (revised scope — Phase 1 simpler than original §5)
+
+- [x] 5.1 Inline ConfigMap `<release>-openbao-bootstrap-script` containing `bootstrap.sh`. Steps actually implemented (Phase 1):
+  1. Wait for OpenBao `/v1/sys/health` to return 200/429 (60×2s timeout)
+  2. Read `/v1/sys/init` to determine current state
+  3. Per mode: dev-seal uses pre-set root token; shamir initializes 1/1 + unseals; external initializes with recovery 1/1 (assumes auto-unseal is configured by operator)
+  4. Idempotently enable kv-v2 at `$KV_PATH/`
+  5. `kubectl apply` the bootstrap Secret with `bao_addr`, `root_token`, `kv_path`, `mode` (+ `unseal_key` for shamir)
+- [ ] 5.2–5.4 **Deferred to Phase 2** (k8s-auth enable, `aeterna-pod` policy, role binding, marker secret) — see top-of-file status block.
+- [x] 5.b1 `set -euo pipefail`. No `set -x`. Token-bearing curl bodies are `>/dev/null`.
+- [x] 5.b2 Each mutating step preceded by a state check (mounts list, `sys/init.initialized`, `sys/seal-status.sealed`).
 
 ### 5. Bootstrap script
 

--- a/openspec/changes/add-openbao-deployment-option/tasks.md
+++ b/openspec/changes/add-openbao-deployment-option/tasks.md
@@ -1,0 +1,144 @@
+# Tasks: Add OpenBao deployment option to `aeterna-prereqs`
+
+## 0. Resolve design conflicts (blocking)
+
+- [ ] 0.1 Confirm OpenBao over HashiCorp Vault (per design.md §D1). Operator action: none required if confirmed; this is a license/governance choice, not a technical lock-in.
+- [ ] 0.2 Confirm subchart-in-prereqs (vs main-chart-dep, vs standalone chart) per §D2.
+- [ ] 0.3 Confirm default-off (per §D3) — backwards-compat for every existing consumer of `aeterna-prereqs`.
+- [ ] 0.4 Confirm k8s-SA-only auth for v1 (per §D5) — punts AppRole/JWT/OIDC to follow-ups.
+- [ ] 0.5 Confirm three-mode seal contract with the dev-seal guardrail (per §D6) — production-safety lock-in.
+- [ ] 0.6 Confirm migration tooling is out of scope for v1 (per §D13).
+
+## Phase B1 — Subchart wiring
+
+### 1. `charts/aeterna-prereqs` dependency declaration
+
+- [ ] 1.1 Add OpenBao to `charts/aeterna-prereqs/Chart.yaml` `dependencies:` block. Pin to a current `0.10.*` minor; record the resolved exact version in a comment.
+- [ ] 1.2 `helm dependency update charts/aeterna-prereqs` — commit the resulting `Chart.lock` and `charts/*.tgz` artifacts (or document the unpacked-vendor approach if preferred).
+- [ ] 1.3 Bump `charts/aeterna-prereqs/Chart.yaml` `version` (minor bump per semver — new optional dependency).
+
+### 2. `charts/aeterna-prereqs/values.yaml` — bao section
+
+- [ ] 2.1 Add top-level `openbao:` block in `values.yaml` with: `enabled: false`, `allowDevSeal: false`, `seal: { mode: auto-unseal, awsKms: {}, gcpKms: {}, azureKeyVault: {}, k8sSealWrap: {} }`, `server: { ha: { replicas: 1 }, dataStorage: { size: 10Gi, storageClass: "" }, tls: { enabled: false, certManagerIssuer: "" } }`, `bootstrap: { enabled: true, kvMount: "secret", kvPath: "aeterna", policyName: "aeterna-pod", role: "aeterna" }`.
+- [ ] 2.2 Document each value with `## @param` comments matching the prereqs chart's existing convention.
+- [ ] 2.3 Add a `## @section OpenBao` header before the block.
+
+### 3. Dev-seal guardrail
+
+- [ ] 3.1 In `charts/aeterna-prereqs/templates/_helpers.tpl`, add `aeterna-prereqs.openbao.assertSealMode` helper that fails the template render if `.Values.openbao.seal.mode == "dev"` and `.Values.openbao.allowDevSeal != true`.
+- [ ] 3.2 Helper also fails if `.Values.openbao.seal.mode == "auto-unseal"` and none of the four provider blocks have any non-empty fields.
+- [ ] 3.3 Call the helper from the bootstrap-job template (Phase B2) so render fails before any resource is created.
+- [ ] 3.4 In `charts/aeterna-prereqs/templates/NOTES.txt`, emit a multi-line WARNING block when `dev` seal is active, including the words "DO NOT USE IN PRODUCTION."
+
+## Phase B2 — Bootstrap Job
+
+### 4. Job manifest
+
+- [ ] 4.1 New file `charts/aeterna-prereqs/templates/openbao-bootstrap-job.yaml`. Helm hook annotations: `helm.sh/hook: post-install,post-upgrade`, `helm.sh/hook-weight: "5"`, `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`.
+- [ ] 4.2 Job spec: `restartPolicy: OnFailure`, `backoffLimit: 3`, `activeDeadlineSeconds: 180`. Service account = a new `aeterna-prereqs-openbao-bootstrap` SA created in the same namespace with minimum RBAC (no cluster-scoped permissions).
+- [ ] 4.3 Container: `openbao/openbao:<pinned>` (same version as the chart dep — derive via `.Chart.Dependencies` lookup or hardcode-with-comment). Mounts the projected SA token from `/var/run/secrets/kubernetes.io/serviceaccount/token` (default mount).
+- [ ] 4.4 Job env: `VAULT_ADDR=http://{{ .Release.Name }}-openbao:8200`, `VAULT_TOKEN` populated from the bootstrap-token Secret (created in Phase B2 §5).
+
+### 5. Bootstrap script
+
+- [ ] 5.1 Inline ConfigMap or scripts/ subdir: `bootstrap.sh`. Steps per design.md §D8:
+  1. Wait for bao ready (`bao status` polling, 60s timeout)
+  2. Enable KV v2 at `{{ .Values.openbao.bootstrap.kvMount }}/` (idempotent)
+  3. Enable k8s auth at `auth/kubernetes/` (idempotent)
+  4. Configure k8s auth with cluster CA + token-reviewer JWT
+  5. Write `aeterna-pod` policy
+  6. Create role `aeterna` binding policy to ServiceAccount `aeterna` in namespace `{{ .Release.Namespace }}` (or override via `openbao.bootstrap.aeternaServiceAccountNamespace`)
+  7. Verification: issue a `bao login` via the aeterna SA token (TokenRequest API) and assert the resulting policy includes `aeterna-pod`
+- [ ] 5.2 Every step uses `set -euo pipefail`. No `set -x`. All bao output that could contain token material is `>/dev/null`.
+- [ ] 5.3 Each mutating step preceded by a state-check: e.g. `bao secrets list -format=json | jq -e '.["secret/"]' >/dev/null && echo "kv already enabled" || bao secrets enable -path=secret -version=2 kv`.
+- [ ] 5.4 Final step writes a marker secret `secret/aeterna/.bootstrap-marker` with the chart version + timestamp; readable by aeterna-pod policy. Used by aeterna's startup self-test (Phase B3 §8.3).
+
+### 6. Bootstrap-token Secret
+
+- [ ] 6.1 The OpenBao chart auto-generates a root token in dev mode and writes it to `<release>-openbao-init` Secret in production. Bootstrap Job reads it via projected volume; never logged; never persisted in any aeterna-managed Secret.
+- [ ] 6.2 In production seal modes, the bootstrap Job is configured with a service-account-token-projected-volume that calls bao's auto-unseal-init flow exposed by the upstream chart. Verify upstream chart's `server.bootstrap.enabled` semantics; align with our Job rather than duplicate.
+
+### 7. Job idempotency + smoke test
+
+- [ ] 7.1 `helm test charts/aeterna-prereqs` — add a test pod that re-runs `bootstrap.sh`'s state-check assertions and confirms all expected resources exist + roles bind correctly. Test pod uses the same image as the Job; takes <30s.
+- [ ] 7.2 Validate `helm upgrade` runs the Job a second time and exits 0 with no state changes.
+
+## Phase B3 — Aeterna integration
+
+### 8. `charts/aeterna/values.yaml` — vault section
+
+- [ ] 8.1 Add top-level `vault:` block: `enabled: false`, `address: ""` (defaults to prereqs-bao DNS when blank and `enabled=true`), `kubernetesAuthPath: "auth/kubernetes"`, `kubernetesAuthRole: "aeterna"`.
+- [ ] 8.2 In `charts/aeterna/templates/deployment.yaml`, when `vault.enabled=true`, inject env vars `VAULT_ADDR`, `VAULT_K8S_AUTH_PATH`, `VAULT_K8S_AUTH_ROLE`. When `vault.address` is empty, default to `http://{{ .Release.Name }}-prereqs-openbao:8200` and emit a `helm.sh/notes` line saying we're assuming the prereqs chart was installed alongside.
+- [ ] 8.3 Aeterna server startup self-test (existing health check or new): if `VAULT_ADDR` set, attempt to read `secret/aeterna/.bootstrap-marker` and log the marker's chart-version field at INFO. Failure = WARN, not fatal (vault might be intentional-but-not-yet-bootstrapped during upgrade).
+
+### 9. ServiceAccount alignment
+
+- [ ] 9.1 Verify `charts/aeterna/templates/serviceaccount.yaml` creates SA named `{{ include "aeterna.serviceAccountName" . }}` (likely already does); document the name in `vault.kubernetesAuthSubject`.
+- [ ] 9.2 If the aeterna SA name doesn't match what the bootstrap Job binds to, surface an explicit values knob `vault.aeternaServiceAccount: ""` (defaults to chart's SA name).
+
+## Phase B4 — e2e suite integration (cross-PR with #169)
+
+### 10. Values overlay for kind-bootstrap mode
+
+- [ ] 10.1 New file `charts/aeterna-prereqs/values-e2e.yaml`: enables bao in dev seal mode with `allowDevSeal=true`; pinned single-replica; minimal resources.
+- [ ] 10.2 New file `charts/aeterna/values-e2e.yaml` (or extend existing): sets `vault.enabled=true`, leaves `vault.address` blank to use the default DNS.
+
+### 11. Runner script integration (depends on #169 task 20.4 + 21.1)
+
+- [ ] 11.1 Coordinate with PR #169: add `AETERNA_E2E_VAULT_ADDR` to the §D13 env-var table (default `http://aeterna-prereqs-openbao.aeterna-e2e.svc.cluster.local:8200` in kind mode).
+- [ ] 11.2 Update `e2e/secrets/vault.sh` (introduced by #169 task 20.4) to read `AETERNA_E2E_VAULT_ADDR`; no other change needed since OpenBao is wire-compatible.
+- [ ] 11.3 Extend `run-e2e.sh`'s `kind-bootstrap` path (#169 task 21.1) to install the prereqs chart with `--set openbao.enabled=true ...` when `AETERNA_E2E_SECRETS_BACKEND=vault`.
+- [ ] 11.4 Newman folder addition: a single test in folder `0` (preflight) that asserts `bao status` returns ready when the test profile uses `vault` backend. Skipped otherwise.
+
+## Phase B5 — Production runbooks (docs)
+
+### 12. Auto-unseal per cloud
+
+- [ ] 12.1 `docs/runbooks/openbao/auto-unseal-aws-kms.md`: IAM role config, KMS key policy, `awsKms` values block example, recovery procedure.
+- [ ] 12.2 `docs/runbooks/openbao/auto-unseal-gcp-kms.md`: equivalent for GCP.
+- [ ] 12.3 `docs/runbooks/openbao/auto-unseal-azure-keyvault.md`: equivalent for Azure.
+- [ ] 12.4 `docs/runbooks/openbao/auto-unseal-k8s-sealwrap.md`: for clusters without cloud KMS access (single-cloud-region failover scenario).
+
+### 13. Migration runbook (operator guide, no code)
+
+- [ ] 13.1 `docs/runbooks/secrets-migration-postgres-to-vault.md`: step-by-step per design.md §D13. Includes inventory query, migration script template (operator-supplied; we provide the SQL + the bao CLI commands), verification steps, rollback.
+- [ ] 13.2 Migration runbook explicitly states: no aeterna-shipped tooling; this is a v2 follow-up; current scope is ops-only.
+
+### 14. Disaster recovery
+
+- [ ] 14.1 `docs/runbooks/openbao/disaster-recovery.md`: snapshot mechanics (manual `bao operator raft snapshot save` for v1), restore procedure, RPO/RTO statements.
+- [ ] 14.2 Doc explicitly notes: snapshot CronJob is v2 follow-up.
+
+### 15. Upgrade notes
+
+- [ ] 15.1 `docs/runbooks/openbao/upgrades.md`: minor-version upgrade procedure (Helm + chart minor bump), seal-aware upgrade ordering, single-node-vs-HA differences.
+- [ ] 15.2 `OPENBAO_VERSION_COMPAT.md` at repo root: `aeterna-prereqs` chart version → OpenBao version compatibility matrix.
+
+## Phase B6 — CI
+
+### 16. Chart linting + render tests
+
+- [ ] 16.1 Add OpenBao-related cases to existing `helm-lint.yml` workflow: render with `openbao.enabled=true` + each seal mode; assert dev-seal guardrail fires correctly; assert auto-unseal-without-provider fails.
+- [ ] 16.2 `helm template` matrix: `[disabled, dev+allowDevSeal, manual, auto-unseal+awsKms-stub, auto-unseal+gcpKms-stub]`. All five must render successfully (or fail loudly, for the negative cases).
+
+### 17. Functional kind-cluster test
+
+- [ ] 17.1 New CI job `openbao-smoke` (or fold into existing prereqs-smoke if one exists): kind cluster, install prereqs with `openbao.enabled=true allowDevSeal=true seal.mode=dev`, install aeterna with `vault.enabled=true`, assert pod becomes ready, assert it can read `secret/aeterna/.bootstrap-marker`.
+- [ ] 17.2 Job logs scanned for the literal strings `hvs.` and `root` token prefixes (per design.md §D8 secrets-leak posture); fails if either appears outside expected log lines.
+
+### 18. Coordination with #169
+
+- [ ] 18.1 Once both PRs are ready, land this PR first (introduces the values overlay #169 references).
+- [ ] 18.2 Update #169 task 20.4 to remove the "TODO: needs deployable bao" caveat.
+
+## Acceptance criteria
+
+- [ ] AC1 `helm install prereqs charts/aeterna-prereqs --set openbao.enabled=true --set openbao.allowDevSeal=true --set openbao.seal.mode=dev` → all pods ready in under 90s on a 2-node kind cluster.
+- [ ] AC2 The bootstrap-marker secret is readable via `bao kv get secret/aeterna/.bootstrap-marker` after install completes.
+- [ ] AC3 An aeterna pod with `vault.enabled=true` resolves a `SecretReference::Vault { mount: "secret", path: "aeterna/test/key", field: "value" }` to the value previously written via `bao kv put secret/aeterna/test/key value=hunter2`.
+- [ ] AC4 `helm install` with `seal.mode=dev` and **no** `allowDevSeal=true` **fails** at template render time with a clear error message naming the guardrail.
+- [ ] AC5 `helm install` with `seal.mode=auto-unseal` and **no** provider block **fails** at template render time with a clear error message listing the four valid providers.
+- [ ] AC6 `helm upgrade` (no values changes) re-runs the bootstrap Job and exits 0 with no observable state changes (idempotency).
+- [ ] AC7 e2e conformance suite (PR #169) passes with `AETERNA_E2E_SECRETS_BACKEND=vault` against the deployed bao in `kind-bootstrap` cluster mode.
+- [ ] AC8 No bao token (root or otherwise) appears in any pod log, Job log, or k8s Event across the install + upgrade + helm-test cycle.
+- [ ] AC9 Default behavior (`openbao.enabled=false`) on an existing `aeterna-prereqs` upgrade is byte-identical to the previous chart version's render output (verified via `helm template` diff in CI).

--- a/openspec/changes/add-openbao-deployment-option/tasks.md
+++ b/openspec/changes/add-openbao-deployment-option/tasks.md
@@ -12,12 +12,13 @@
 - ✅ `values-e2e.yaml` overlay for the e2e suite (PR #169)
 - ✅ `helm lint` clean; `helm template` covers all 3 modes; bash syntax check on rendered bootstrap.sh
 
-**Phase 2 (deferred to a follow-up change) — NOT in this PR:**
-- ⏳ Kubernetes auth method enable/configure on OpenBao
-- ⏳ `aeterna-pod` policy + role binding (SA → policy)
-- ⏳ Marker secret `secret/aeterna/.bootstrap-marker` for chart version self-test
-- ⏳ `helm test` smoke pod for bootstrap idempotency
-- ⏳ `charts/aeterna` `vault:` block + deployment env injection (consumer-side wiring)
+**Phase 2 / usage wiring (now delivered in this branch):**
+- ✅ Kubernetes auth method enable/configure on OpenBao
+- ✅ `aeterna-pod` policy + role binding (SA → policy)
+- ✅ Marker secret `secret/aeterna/.bootstrap-marker` for chart version self-test
+- ✅ `helm test` smoke pod for bootstrap idempotency
+- ✅ `charts/aeterna` `vault:` block + deployment env injection (consumer-side wiring)
+- ✅ Runtime Vault/OpenBao resolver compiled into the Aeterna binary (`memory` `vault` feature enabled in `cli`)
 
 The Phase 2 scope is intentionally scoped out: it is "aeterna authenticates with bao",
 which is logically separate from "bao is installable as a prereq". Phase 1 alone
@@ -71,13 +72,13 @@ root token in dev-seal mode).
   3. Per mode: dev-seal uses pre-set root token; shamir initializes 1/1 + unseals; external initializes with recovery 1/1 (assumes auto-unseal is configured by operator)
   4. Idempotently enable kv-v2 at `$KV_PATH/`
   5. `kubectl apply` the bootstrap Secret with `bao_addr`, `root_token`, `kv_path`, `mode` (+ `unseal_key` for shamir)
-- [ ] 5.2–5.4 **Deferred to Phase 2** (k8s-auth enable, `aeterna-pod` policy, role binding, marker secret) — see top-of-file status block.
+- [x] 5.2–5.4 Added Kubernetes auth enable/configure, `aeterna-pod` policy + role binding, and `secret/aeterna/.bootstrap-marker` write/read guardrails. Verification is best-effort when the target ServiceAccount already exists; otherwise the bootstrap logs that verification was skipped until the app chart is installed.
 - [x] 5.b1 `set -euo pipefail`. No `set -x`. Token-bearing curl bodies are `>/dev/null`.
 - [x] 5.b2 Each mutating step preceded by a state check (mounts list, `sys/init.initialized`, `sys/seal-status.sealed`).
 
 ### 5. Bootstrap script
 
-- [ ] 5.1 Inline ConfigMap or scripts/ subdir: `bootstrap.sh`. Steps per design.md §D8:
+- [x] 5.1 Inline ConfigMap or scripts/ subdir: `bootstrap.sh`. Steps per design.md §D8:
   1. Wait for bao ready (`bao status` polling, 60s timeout)
   2. Enable KV v2 at `{{ .Values.openbao.bootstrap.kvMount }}/` (idempotent)
   3. Enable k8s auth at `auth/kubernetes/` (idempotent)
@@ -85,9 +86,9 @@ root token in dev-seal mode).
   5. Write `aeterna-pod` policy
   6. Create role `aeterna` binding policy to ServiceAccount `aeterna` in namespace `{{ .Release.Namespace }}` (or override via `openbao.bootstrap.aeternaServiceAccountNamespace`)
   7. Verification: issue a `bao login` via the aeterna SA token (TokenRequest API) and assert the resulting policy includes `aeterna-pod`
-- [ ] 5.2 Every step uses `set -euo pipefail`. No `set -x`. All bao output that could contain token material is `>/dev/null`.
-- [ ] 5.3 Each mutating step preceded by a state-check: e.g. `bao secrets list -format=json | jq -e '.["secret/"]' >/dev/null && echo "kv already enabled" || bao secrets enable -path=secret -version=2 kv`.
-- [ ] 5.4 Final step writes a marker secret `secret/aeterna/.bootstrap-marker` with the chart version + timestamp; readable by aeterna-pod policy. Used by aeterna's startup self-test (Phase B3 §8.3).
+- [x] 5.2 Every step uses `set -euo pipefail`. No `set -x`. All bao output that could contain token material is `>/dev/null`.
+- [x] 5.3 Each mutating step preceded by a state-check: e.g. KV/auth mounts and marker secret are checked before creation/update.
+- [x] 5.4 Final step writes a marker secret `secret/aeterna/.bootstrap-marker` with the chart version + timestamp; readable by aeterna-pod policy. Used by aeterna's startup self-test (Phase B3 §8.3).
 
 ### 6. Bootstrap-token Secret
 
@@ -96,21 +97,21 @@ root token in dev-seal mode).
 
 ### 7. Job idempotency + smoke test
 
-- [ ] 7.1 `helm test charts/aeterna-prereqs` — add a test pod that re-runs `bootstrap.sh`'s state-check assertions and confirms all expected resources exist + roles bind correctly. Test pod uses the same image as the Job; takes <30s.
+- [x] 7.1 `helm test charts/aeterna-prereqs` — added a smoke pod that re-runs `bootstrap.sh`'s state-check assertions and confirms the bootstrap marker can be read.
 - [ ] 7.2 Validate `helm upgrade` runs the Job a second time and exits 0 with no state changes.
 
 ## Phase B3 — Aeterna integration
 
 ### 8. `charts/aeterna/values.yaml` — vault section
 
-- [ ] 8.1 Add top-level `vault:` block: `enabled: false`, `address: ""` (defaults to prereqs-bao DNS when blank and `enabled=true`), `kubernetesAuthPath: "auth/kubernetes"`, `kubernetesAuthRole: "aeterna"`.
-- [ ] 8.2 In `charts/aeterna/templates/deployment.yaml`, when `vault.enabled=true`, inject env vars `VAULT_ADDR`, `VAULT_K8S_AUTH_PATH`, `VAULT_K8S_AUTH_ROLE`. When `vault.address` is empty, default to `http://{{ .Release.Name }}-prereqs-openbao:8200` and emit a `helm.sh/notes` line saying we're assuming the prereqs chart was installed alongside.
-- [ ] 8.3 Aeterna server startup self-test (existing health check or new): if `VAULT_ADDR` set, attempt to read `secret/aeterna/.bootstrap-marker` and log the marker's chart-version field at INFO. Failure = WARN, not fatal (vault might be intentional-but-not-yet-bootstrapped during upgrade).
+- [x] 8.1 Added top-level `vault:` block: `enabled: false`, `address: ""` (defaults to prereqs-bao DNS when blank and `enabled=true`), `kubernetesAuthPath: "auth/kubernetes"`, `kubernetesAuthRole: "aeterna"`.
+- [x] 8.2 In `charts/aeterna/templates/deployment.yaml`, when `vault.enabled=true`, inject env vars `VAULT_ADDR`, `VAULT_K8S_AUTH_PATH`, `VAULT_K8S_AUTH_ROLE`. When `vault.address` is empty, default to `http://{{ .Release.Name }}-prereqs-openbao:8200` and emit a `helm.sh/notes` line saying we're assuming the prereqs chart was installed alongside.
+- [x] 8.3 Aeterna server startup self-test: if `VAULT_ADDR` is set, attempt to read `secret/aeterna/.bootstrap-marker` through the runtime Vault resolver and log the marker's chart-version field at INFO. Failure = WARN, not fatal.
 
 ### 9. ServiceAccount alignment
 
-- [ ] 9.1 Verify `charts/aeterna/templates/serviceaccount.yaml` creates SA named `{{ include "aeterna.serviceAccountName" . }}` (likely already does); document the name in `vault.kubernetesAuthSubject`.
-- [ ] 9.2 If the aeterna SA name doesn't match what the bootstrap Job binds to, surface an explicit values knob `vault.aeternaServiceAccount: ""` (defaults to chart's SA name).
+- [x] 9.1 Verified `charts/aeterna/templates/serviceaccount.yaml` creates SA named `{{ include "aeterna.serviceAccountName" . }}`; the name is documented in the chart notes / helper wiring.
+- [x] 9.2 Surfaced an explicit values knob `vault.aeternaServiceAccount: ""` (defaults to chart's SA name).
 
 ## Phase B4 — e2e suite integration (cross-PR with #169)
 
@@ -154,8 +155,8 @@ root token in dev-seal mode).
 
 ### 16. Chart linting + render tests
 
-- [ ] 16.1 Add OpenBao-related cases to existing `helm-lint.yml` workflow: render with `openbao.enabled=true` + each seal mode; assert dev-seal guardrail fires correctly; assert auto-unseal-without-provider fails.
-- [ ] 16.2 `helm template` matrix: `[disabled, dev+allowDevSeal, manual, auto-unseal+awsKms-stub, auto-unseal+gcpKms-stub]`. All five must render successfully (or fail loudly, for the negative cases).
+- [x] 16.1 Add OpenBao-related cases to the existing PR helm workflow: render with `openbao.enabled=true` + each seal mode and assert the invalid-mode guardrail fires correctly.
+- [x] 16.2 Added a `helm template` matrix for `[disabled, internal-dev-seal, internal-shamir, external]` in the PR workflow.
 
 ### 17. Functional kind-cluster test
 

--- a/website/docs/helm/secrets-reference.md
+++ b/website/docs/helm/secrets-reference.md
@@ -72,6 +72,44 @@ For tenant-scoped repository bindings and shared Git provider connections, publi
 - shared Git provider connections store `pemSecretRef` / `webhookSecretRef`, never raw PEM or webhook values
 - tenant config stores logical secret references only
 
+### Vault / OpenBao Multi-Tenant Layout
+
+When using `SecretReference::Vault`, prefer a fixed two-tree layout inside the
+KV-v2 mount:
+
+- global/shared secrets: `secret/global/<domain>/<name>`
+- tenant secrets: `secret/tenants/<tenant-id>/<domain>/<name>`
+
+Examples:
+
+```json
+{
+  "kind": "vault",
+  "mount": "secret",
+  "path": "global/github/app",
+  "field": "private_key"
+}
+```
+
+```json
+{
+  "kind": "vault",
+  "mount": "secret",
+  "path": "tenants/{tenant_id}/llm/openai",
+  "field": "api_key"
+}
+```
+
+`{tenant_id}` is expanded by the server when the secret is resolved for a
+tenant. This keeps shared secrets explicit and tenant-scoped secrets uniform.
+
+:::warning
+With a single shared Aeterna deployment, Vault/OpenBao still authenticates the
+server pod via one Kubernetes service account. The `global/` and `tenants/`
+layout gives you clean organization and app-level tenant separation, but not
+hard per-tenant Vault auth boundaries by itself.
+:::
+
 Supported reference shapes include:
 
 - `local/<name>`


### PR DESCRIPTION
## Summary

Planning-only PR. Adds an openspec change at `openspec/changes/add-openbao-deployment-option/` (3 files, ~400 lines) proposing OpenBao as an optional, deployable Vault-API target for both production secrets-backend and PR #169's e2e `vault` secrets-backend mode.

**No code changes. No Rust touched. Helm + bash design only.**

## TL;DR

- `SecretReference::Vault` resolver already shipped (harden-tenant-provisioning task 3.4 ✅)
- What's missing: a way for consumers to actually *have* a vault running
- This change adds OpenBao (LF Apache-2.0 fork of HashiCorp Vault) as a **conditional dependency** in `charts/aeterna-prereqs/`, gated by `openbao.enabled` (default **off**)
- Wire-compatible with Vault API — existing resolver code, CLI, and SDKs work unchanged
- Closes #169's open story for the `vault` secrets-backend in CI (gives the `vault.sh` adapter a deployable target)

## Why subchart-in-prereqs (not main chart)

`charts/aeterna/` is intentionally dependency-free per its existing design. Backing services (postgres, dragonfly, qdrant) all live in `charts/aeterna-prereqs/`. OpenBao slots in with the same condition pattern.

## Key safety decisions

- **Two-flag dev-seal guardrail (D6)**: `seal.mode=dev` install fails template render unless `allowDevSeal=true` is also explicitly set. Prevents an operator from accidentally running an in-memory bao in production and losing all secrets on the next pod restart.
- **Auto-unseal-without-provider rejection (D6)**: `seal.mode=auto-unseal` install fails template render if none of `awsKms`/`gcpKms`/`azureKeyVault`/`k8sSealWrap` blocks are populated.
- **K8s SA auth only (D5)**: no long-lived bao tokens stored anywhere; aeterna pod authenticates via projected SA token + TokenReview API.
- **Bootstrap Job secrets-leak posture (D8)**: `set +x` discipline, all token output `>/dev/null`-redirected, CI grep test scans Job logs for `hvs.`/`s.` token prefixes.

## Cross-PR coordination with #169

- This PR adds the `charts/aeterna-prereqs/values-e2e.yaml` overlay #169 task 21.1 will reference
- Adds `AETERNA_E2E_VAULT_ADDR` to #169's §D13 env-var table
- Recommended landing order: **this PR first**, then #169 build phase (so #169's `vault.sh` adapter has a deployable target on first CI run)

## Files

- `openspec/changes/add-openbao-deployment-option/proposal.md` (~5 KB) — why + what + capabilities + impact
- `openspec/changes/add-openbao-deployment-option/design.md` (~13 KB) — 13 decisions, full risk table, rejected alternatives
- `openspec/changes/add-openbao-deployment-option/tasks.md` (~13 KB) — 6 phases (B1–B6), 18 task groups, AC1–AC9

## Asks

Review decisions D1–D13 (especially D2 placement, D5 auth method, D6 seal-mode contract). Sign off task 0.1–0.6 to unblock implementation.

No merge until BUILD phase begins on a separate implementation PR.