### PR TITLE
feat(serde)!: PascalCase enum convention + governance_events uuid cast + hermetic test helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "adapters"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aeterna"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "adapters",
  "aeterna-backup",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "agent-a2a"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "a2a-types",
  "anyhow",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "anyhow",
  "errors",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "context"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "backoff",
  "chrono",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "cross-tests"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "chrono",
  "memory",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "errors"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "idp-sync"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4806,7 +4806,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memory"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "aisdk",
  "anyhow",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "mk_core"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5407,7 +5407,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opal-fetcher"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8001,7 +8001,7 @@ dependencies = [
 
 [[package]]
 name = "storage"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "adapters",
  "aes-gcm",
@@ -8175,7 +8175,7 @@ dependencies = [
 
 [[package]]
 name = "sync"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8354,7 +8354,7 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8758,7 +8758,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "adapters",
  "anyhow",
@@ -9255,7 +9255,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 # - `.github/workflows/version-consistency.yml` enforces that all those
 #   surfaces agree on every PR and on every tag push.
 [workspace.package]
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 
 [workspace.lints.rust]
 unused_imports = "warn"

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin-ui",
-  "version": "0.8.0-rc.5",
+  "version": "0.8.0-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-ui",
-      "version": "0.8.0-rc.5",
+      "version": "0.8.0-rc.6",
       "dependencies": {
         "@tanstack/react-query": "^5.62.0",
         "class-variance-authority": "^0.7.1",

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-ui",
   "private": true,
-  "version": "0.8.0-rc.5",
+  "version": "0.8.0-rc.6",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/charts/aeterna-prereqs/Chart.yaml
+++ b/charts/aeterna-prereqs/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   Redis-compatible cache (Dragonfly or Valkey), and vector store (Qdrant)
   for development and testing environments.
 type: application
-version: 0.8.0-rc.5
-appVersion: "0.8.0-rc.5"
+version: 0.8.0-rc.6
+appVersion: "0.8.0-rc.6"
 
 home: https://github.com/kikokikok/aeterna
 sources:

--- a/charts/aeterna/Chart.yaml
+++ b/charts/aeterna/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   stack, and supporting jobs. Requires external PostgreSQL, Redis-compatible
   cache, and vector store. Use the aeterna-prereqs chart for dev/test backends.
 type: application
-version: 0.8.0-rc.5
-appVersion: "0.8.0-rc.5"
+version: 0.8.0-rc.6
+appVersion: "0.8.0-rc.6"
 
 home: https://github.com/kikokikok/aeterna
 icon: https://raw.githubusercontent.com/kikokikok/aeterna/main/docs/logo.png

--- a/cli/src/server/manifest_hash.rs
+++ b/cli/src/server/manifest_hash.rs
@@ -173,12 +173,12 @@ mod tests {
         // hash's input.
         let base = json!({
             "secrets": [
-                {"logicalName": "repo.token", "ownership": "tenant", "secretValue": "aaa"}
+                {"logicalName": "repo.token", "ownership": "Tenant", "secretValue": "aaa"}
             ]
         });
         let rotated = json!({
             "secrets": [
-                {"logicalName": "repo.token", "ownership": "tenant", "secretValue": "bbb"}
+                {"logicalName": "repo.token", "ownership": "Tenant", "secretValue": "bbb"}
             ]
         });
         assert_eq!(

--- a/cli/src/server/service_tokens.rs
+++ b/cli/src/server/service_tokens.rs
@@ -121,7 +121,7 @@ pub fn router(state: Arc<AppState>) -> Router {
     // under `/api/v1`, so these become `/api/v1/auth/tokens{,/:id}`.
     Router::new()
         .route("/auth/tokens", post(mint_handler).get(list_handler))
-        .route("/auth/tokens/:id", delete(revoke_handler))
+        .route("/auth/tokens/{id}", delete(revoke_handler))
         .with_state(state)
 }
 

--- a/cli/src/server/tenant_api.rs
+++ b/cli/src/server/tenant_api.rs
@@ -6331,7 +6331,7 @@ mod tests {
         let upsert_config = serde_json::json!({
             "fields": {
                 "runtime.logLevel": {
-                    "ownership": "tenant",
+                    "ownership": "Tenant",
                     "value": "info"
                 }
             },
@@ -6358,7 +6358,7 @@ mod tests {
                 "platformAdmin",
                 Body::from(
                     serde_json::to_vec(&serde_json::json!({
-                        "ownership": "tenant",
+                        "ownership": "Tenant",
                         "secretValue": secret_value
                     }))
                     .unwrap(),
@@ -6433,7 +6433,7 @@ mod tests {
                     serde_json::to_vec(&serde_json::json!({
                         "fields": {
                             "database.password": {
-                                "ownership": "tenant",
+                                "ownership": "Tenant",
                                 "value": "plain-text-secret"
                             }
                         },
@@ -6471,7 +6471,7 @@ mod tests {
             .header("x-target-tenant-id", tenant.id.as_str())
             .body(Body::from(
                 serde_json::to_vec(&serde_json::json!({
-                    "ownership": "platform",
+                    "ownership": "Platform",
                     "secretValue": "secret"
                 }))
                 .unwrap(),
@@ -6496,14 +6496,14 @@ mod tests {
         let request: UpsertTenantConfigRequest = serde_json::from_value(serde_json::json!({
             "fields": {
                 "runtime.logLevel": {
-                    "ownership": "tenant",
+                    "ownership": "Tenant",
                     "value": "info"
                 }
             },
             "secretReferences": {
                 "repo.token": {
                     "logicalName": "repo.token",
-                    "ownership": "tenant",
+                    "ownership": "Tenant",
                     "kind": "postgres",
                     "secretId": "22222222-2222-2222-2222-222222222222"
                 }
@@ -6622,7 +6622,7 @@ mod tests {
             .header("x-tenant-id", "default")
             .body(Body::from(
                 serde_json::to_vec(&serde_json::json!({
-                    "ownership": "platform",
+                    "ownership": "Platform",
                     "secretValue": "platform-secret"
                 }))
                 .unwrap(),
@@ -6668,7 +6668,7 @@ mod tests {
                 serde_json::to_vec(&serde_json::json!({
                     "fields": {
                         "platform.control": {
-                            "ownership": "platform",
+                            "ownership": "Platform",
                             "value": "blocked"
                         }
                     },
@@ -7105,8 +7105,8 @@ mod tests {
         // 1. GlobalAdmin upserts tenant config (deployment materialization step)
         let config_body = serde_json::json!({
             "fields": {
-                "runtime.logLevel": { "ownership": "tenant", "value": "warn" },
-                "deployment.namespace": { "ownership": "platform", "value": "aeterna-prod" }
+                "runtime.logLevel": { "ownership": "Tenant", "value": "warn" },
+                "deployment.namespace": { "ownership": "Platform", "value": "aeterna-prod" }
             },
             "secretReferences": {}
         });
@@ -7135,7 +7135,7 @@ mod tests {
                 "platformAdmin",
                 Body::from(
                     serde_json::to_vec(&serde_json::json!({
-                        "ownership": "platform",
+                        "ownership": "Platform",
                         "secretValue": "ghp_bootstrap_secret_value"
                     }))
                     .unwrap(),
@@ -7757,7 +7757,7 @@ mod tests {
                 "secretReferences": {
                     "openai.key": {
                         "logicalName": "openai.key",
-                        "ownership": "tenant",
+                        "ownership": "Tenant",
                         "kind": "postgres",
                         "secretId": "11111111-1111-1111-1111-111111111111"
                     }
@@ -8243,20 +8243,20 @@ mod tests {
             "config": {
                 "fields": {},
                 "secretReferences": {
-                    "inline-ok":   { "logicalName": "a", "ownership": "tenant",
+                    "inline-ok":   { "logicalName": "a", "ownership": "Tenant",
                                      "kind": "inline",   "plaintext": "hunter2" },
-                    "env-ok":      { "logicalName": "b", "ownership": "tenant",
+                    "env-ok":      { "logicalName": "b", "ownership": "Tenant",
                                      "kind": "env",      "var": "DATABASE_PASSWORD" },
-                    "file-ok":     { "logicalName": "c", "ownership": "tenant",
+                    "file-ok":     { "logicalName": "c", "ownership": "Tenant",
                                      "kind": "file",     "path": "/run/secrets/db" },
-                    "k8s-ok":      { "logicalName": "d", "ownership": "tenant",
+                    "k8s-ok":      { "logicalName": "d", "ownership": "Tenant",
                                      "kind": "k8s",      "name": "db-secret",
                                                          "key": "password" },
-                    "k8s-ns-ok":   { "logicalName": "e", "ownership": "tenant",
+                    "k8s-ns-ok":   { "logicalName": "e", "ownership": "Tenant",
                                      "kind": "k8s",      "name": "db-secret",
                                                          "key": "password",
                                                          "namespace": "aeterna" },
-                    "vault-ok":    { "logicalName": "f", "ownership": "tenant",
+                    "vault-ok":    { "logicalName": "f", "ownership": "Tenant",
                                      "kind": "vault",    "mount": "secret",
                                                          "path": "tenants/acme/db",
                                                          "field": "password" }
@@ -8280,7 +8280,7 @@ mod tests {
             "config": {
                 "fields": {},
                 "secretReferences": {
-                    "bad": { "logicalName": "a", "ownership": "tenant",
+                    "bad": { "logicalName": "a", "ownership": "Tenant",
                              "kind": "inline", "plaintext": "" }
                 }
             }
@@ -8302,7 +8302,7 @@ mod tests {
             "config": {
                 "fields": {},
                 "secretReferences": {
-                    "bad": { "logicalName": "a", "ownership": "tenant",
+                    "bad": { "logicalName": "a", "ownership": "Tenant",
                              "kind": "env", "var": "" }
                 }
             }
@@ -8326,7 +8326,7 @@ mod tests {
             "config": {
                 "fields": {},
                 "secretReferences": {
-                    "bad": { "logicalName": "a", "ownership": "tenant",
+                    "bad": { "logicalName": "a", "ownership": "Tenant",
                              "kind": "env", "var": "FOO=BAR" }
                 }
             }
@@ -8348,7 +8348,7 @@ mod tests {
             "config": {
                 "fields": {},
                 "secretReferences": {
-                    "bad": { "logicalName": "a", "ownership": "tenant",
+                    "bad": { "logicalName": "a", "ownership": "Tenant",
                              "kind": "file", "path": "relative/path" }
                 }
             }
@@ -8370,7 +8370,7 @@ mod tests {
             "config": {
                 "fields": {},
                 "secretReferences": {
-                    "bad": { "logicalName": "a", "ownership": "tenant",
+                    "bad": { "logicalName": "a", "ownership": "Tenant",
                              "kind": "k8s", "name": "", "key": "" }
                 }
             }
@@ -8400,7 +8400,7 @@ mod tests {
             "config": {
                 "fields": {},
                 "secretReferences": {
-                    "bad": { "logicalName": "a", "ownership": "tenant",
+                    "bad": { "logicalName": "a", "ownership": "Tenant",
                              "kind": "k8s", "name": "n", "key": "k",
                              "namespace": "   " }
                 }
@@ -8423,7 +8423,7 @@ mod tests {
             "config": {
                 "fields": {},
                 "secretReferences": {
-                    "bad": { "logicalName": "a", "ownership": "tenant",
+                    "bad": { "logicalName": "a", "ownership": "Tenant",
                              "kind": "vault", "mount": "secret",
                              "path": "", "field": "" }
                 }
@@ -8458,7 +8458,7 @@ mod tests {
             "config": {
                 "fields": {},
                 "secretReferences": {
-                    "bad": { "logicalName": "a", "ownership": "tenant",
+                    "bad": { "logicalName": "a", "ownership": "Tenant",
                              "kind": "mysterybox", "whatever": 1 }
                 }
             }
@@ -8781,7 +8781,7 @@ mod tests {
             "tenant": { "slug": "dryrun-new", "name": "Dryrun New" },
             "config": {
                 "fields": {
-                    "ui.theme": { "ownership": "tenant", "value": "dark" }
+                    "ui.theme": { "ownership": "Tenant", "value": "dark" }
                 },
                 "secretReferences": {}
             }

--- a/cli/tests/cli_e2e_test.rs
+++ b/cli/tests/cli_e2e_test.rs
@@ -2,8 +2,33 @@ use assert_cmd::{Command, cargo_bin_cmd};
 use wiremock::matchers::{method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+/// Hermetic CLI command builder.
+///
+/// Scrubs the environment so the spawned `aeterna` subprocess cannot discover
+/// the developer's real credentials in the platform config dir
+/// (`~/.config/aeterna/` on Linux, `~/Library/Application Support/aeterna/`
+/// on macOS). Without this scrubbing, any developer who has ever run
+/// `aeterna auth login` will see ~85 e2e tests fail with HTTP 401 because
+/// the CLI under test silently uses their personal token to hit a real
+/// server, instead of taking the "no server configured" code path the tests
+/// are asserting on. CI doesn't catch this because GitHub Actions runners
+/// have no pre-existing aeterna config.
+///
+/// Tests that need a configured (mock) server must opt in via [`aeterna_mock`].
 fn aeterna() -> Command {
-    cargo_bin_cmd!("aeterna")
+    let mut cmd = cargo_bin_cmd!("aeterna");
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        // Pin HOME to a sentinel path that has no aeterna config tree under
+        // any platform-specific subpath the `dirs` crate might compute from
+        // it (~/.config/aeterna, ~/Library/Application Support/aeterna,
+        // %APPDATA%/aeterna, …).
+        .env("HOME", "/nonexistent-aeterna-test-home");
+    // Preserve TMPDIR so `tempfile` inside the CLI still works on macOS.
+    if let Ok(v) = std::env::var("TMPDIR") {
+        cmd.env("TMPDIR", v);
+    }
+    cmd
 }
 
 /// Holds the mock server and temp config dir (both must stay alive for the test).
@@ -16,11 +41,10 @@ struct MockEnv {
 
 /// Return a CLI command wired to a mock server with fake credentials.
 fn aeterna_mock(env: &MockEnv) -> Command {
+    // `aeterna()` already env_clear'd and pinned HOME to a sentinel.
+    // Layer the mock-specific overrides on top.
     let mut cmd = aeterna();
-    cmd.env_clear()
-        .env("HOME", std::env::var("HOME").unwrap_or_default())
-        .env("PATH", std::env::var("PATH").unwrap_or_default())
-        .env("AETERNA_SERVER_URL", &env.url)
+    cmd.env("AETERNA_SERVER_URL", &env.url)
         .env("AETERNA_PROFILE", "__mock__")
         .env("AETERNA_CONFIG_DIR", &env.config_path);
     cmd

--- a/cli/tests/init_command_test.rs
+++ b/cli/tests/init_command_test.rs
@@ -3,8 +3,19 @@ use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
 
+/// Hermetic CLI command builder. See doc on `cli_e2e_test::aeterna` for why
+/// scrubbing HOME matters: without it the spawned subprocess discovers the
+/// developer's real `~/Library/Application Support/aeterna/credentials.toml`
+/// (macOS) or `~/.config/aeterna/credentials.toml` (Linux) and uses it.
 fn aeterna() -> Command {
-    cargo_bin_cmd!("aeterna")
+    let mut cmd = cargo_bin_cmd!("aeterna");
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", "/nonexistent-aeterna-test-home");
+    if let Ok(v) = std::env::var("TMPDIR") {
+        cmd.env("TMPDIR", v);
+    }
+    cmd
 }
 
 #[test]

--- a/cli/tests/server_runtime_test.rs
+++ b/cli/tests/server_runtime_test.rs
@@ -1275,7 +1275,7 @@ async fn tenant_admin_hierarchy_role_crud_via_rest_api() {
                 .body(Body::from(
                     serde_json::to_vec(&json!({
                         "user_id": "tenant-member",
-                        "role": "developer"
+                        "role": "Developer"
                     }))
                     .unwrap(),
                 ))
@@ -1429,7 +1429,7 @@ async fn tenant_admin_hierarchy_rejects_platform_admin_role_assignment() {
                 .body(Body::from(
                     serde_json::to_vec(&json!({
                         "user_id": "tenant-member",
-                        "role": "platformAdmin"
+                        "role": "PlatformAdmin"
                     }))
                     .unwrap(),
                 ))
@@ -1472,7 +1472,7 @@ async fn govern_roles_assign_and_revoke_via_rest_api() {
                     serde_json::to_vec(&json!({
                         "principal": principal,
                         "principalType": "user",
-                        "role": "architect",
+                        "role": "Architect",
                         "scope": "company"
                     }))
                     .unwrap(),
@@ -2001,7 +2001,7 @@ async fn git_provider_connection_lifecycle_and_binding_visibility_work() {
                         "kind": "github",
                         "remoteUrl": "https://github.com/acme/knowledge.git",
                         "branch": "main",
-                        "branchPolicy": "requirePullRequest",
+                        "branchPolicy": "RequirePullRequest",
                         "credentialKind": "githubApp",
                         "credentialRef": null,
                         "githubOwner": "acme",
@@ -2077,7 +2077,7 @@ async fn git_provider_connection_lifecycle_and_binding_visibility_work() {
                         "kind": "github",
                         "remoteUrl": "https://github.com/acme/knowledge.git",
                         "branch": "main",
-                        "branchPolicy": "requirePullRequest",
+                        "branchPolicy": "RequirePullRequest",
                         "credentialKind": "githubApp",
                         "credentialRef": null,
                         "githubOwner": "acme",
@@ -2358,7 +2358,7 @@ async fn hierarchy_update_ancestors_descendants_memberships() {
                 .body(Body::from(
                     serde_json::to_vec(&json!({
                         "name": "Engineering Org",
-                        "unitType": "organization",
+                        "unitType": "Organization",
                         "parentId": company_id,
                     }))
                     .unwrap(),
@@ -2498,7 +2498,7 @@ async fn hierarchy_update_ancestors_descendants_memberships() {
                 .header("x-tenant-id", "default")
                 .header("content-type", "application/json")
                 .body(Body::from(
-                    serde_json::to_vec(&json!({ "userId": "alice", "role": "developer" })).unwrap(),
+                    serde_json::to_vec(&json!({ "userId": "alice", "role": "Developer" })).unwrap(),
                 ))
                 .unwrap(),
         )
@@ -2732,7 +2732,7 @@ async fn org_crud_and_member_lifecycle() {
                 .header("x-tenant-id", "default")
                 .header("content-type", "application/json")
                 .body(Body::from(
-                    serde_json::to_vec(&json!({ "userId": "alice", "role": "developer" })).unwrap(),
+                    serde_json::to_vec(&json!({ "userId": "alice", "role": "Developer" })).unwrap(),
                 ))
                 .unwrap(),
         )
@@ -3008,7 +3008,7 @@ async fn team_crud_and_member_lifecycle() {
                 .header("x-tenant-id", "default")
                 .header("content-type", "application/json")
                 .body(Body::from(
-                    serde_json::to_vec(&json!({ "userId": "bob", "role": "developer" })).unwrap(),
+                    serde_json::to_vec(&json!({ "userId": "bob", "role": "Developer" })).unwrap(),
                 ))
                 .unwrap(),
         )
@@ -3160,7 +3160,7 @@ async fn user_roles_grant_revoke_and_unsupported_schema() {
                 .header("x-tenant-id", "default")
                 .header("content-type", "application/json")
                 .body(Body::from(
-                    serde_json::to_vec(&json!({ "role": "developer", "scope": "company" }))
+                    serde_json::to_vec(&json!({ "role": "Developer", "scope": "company" }))
                         .unwrap(),
                 ))
                 .unwrap(),

--- a/cli/tests/setup_and_codesearch_e2e_test.rs
+++ b/cli/tests/setup_and_codesearch_e2e_test.rs
@@ -14,8 +14,19 @@ use predicates::prelude::predicate;
 use std::fs;
 use tempfile::TempDir;
 
+/// Hermetic CLI command builder. See doc on `cli_e2e_test::aeterna` for why
+/// scrubbing HOME matters: without it the spawned subprocess discovers the
+/// developer's real `~/Library/Application Support/aeterna/credentials.toml`
+/// (macOS) or `~/.config/aeterna/credentials.toml` (Linux) and uses it.
 fn aeterna() -> Command {
-    cargo_bin_cmd!("aeterna")
+    let mut cmd = cargo_bin_cmd!("aeterna");
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", "/nonexistent-aeterna-test-home");
+    if let Ok(v) = std::env::var("TMPDIR") {
+        cmd.env("TMPDIR", v);
+    }
+    cmd
 }
 
 // ─── setup ────────────────────────────────────────────────────────────────────

--- a/deploy/helm/aeterna-opal/Chart.yaml
+++ b/deploy/helm/aeterna-opal/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aeterna-opal
 description: OPAL Authorization Stack for Aeterna Memory-Knowledge System
 type: application
-version: 0.8.0-rc.5
-appVersion: "0.8.0-rc.5"
+version: 0.8.0-rc.6
+appVersion: "0.8.0-rc.6"
 keywords:
   - opal
   - cedar

--- a/mk_core/src/types.rs
+++ b/mk_core/src/types.rs
@@ -27,7 +27,6 @@ pub const PROVIDER_KUBERNETES: &str = "kubernetes";
     EnumString,
     Display,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 pub enum Role {
     Viewer,
@@ -48,7 +47,6 @@ pub enum Role {
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, EnumString, Display,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 #[derive(Default)]
 pub enum TenantStatus {
@@ -61,7 +59,6 @@ pub enum TenantStatus {
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, EnumString, Display,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 #[derive(Default)]
 pub enum RecordSource {
@@ -74,7 +71,6 @@ pub enum RecordSource {
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, EnumString, Display,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 pub enum RepositoryKind {
     Local,
@@ -86,7 +82,6 @@ pub enum RepositoryKind {
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, EnumString, Display,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 pub enum BranchPolicy {
     DirectCommit,
@@ -97,7 +92,6 @@ pub enum BranchPolicy {
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, EnumString, Display,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 pub enum CredentialKind {
     None,
@@ -244,7 +238,6 @@ impl TenantRepositoryBinding {
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, EnumString, Display,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 pub enum TenantConfigOwnership {
     Platform,
@@ -332,7 +325,6 @@ fn contains_raw_secret_material(field_name: &str, value: &serde_json::Value) -> 
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, EnumString, Display,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]
 pub enum UnitType {
     Company,
@@ -739,7 +731,6 @@ impl Role {
 
 /// Knowledge types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, ToSchema)]
-#[serde(rename_all = "camelCase")]
 pub enum KnowledgeType {
     Adr,
     Policy,
@@ -750,7 +741,6 @@ pub enum KnowledgeType {
 
 /// Knowledge status
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, ToSchema)]
-#[serde(rename_all = "camelCase")]
 pub enum KnowledgeStatus {
     Draft,
     Proposed,
@@ -775,7 +765,6 @@ pub enum KnowledgeStatus {
     EnumString,
     Default,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 pub enum KnowledgeVariantRole {
     #[default]
@@ -818,7 +807,6 @@ impl KnowledgeVariantRole {
     Display,
     EnumString,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 pub enum KnowledgeRelationType {
     PromotedFrom,
@@ -861,7 +849,6 @@ pub struct KnowledgeRelation {
     EnumString,
     Default,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 pub enum PromotionMode {
     Full,
@@ -884,7 +871,6 @@ pub enum PromotionMode {
     EnumString,
     Default,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 pub enum PromotionRequestStatus {
     Draft,
@@ -910,7 +896,6 @@ pub enum PromotionRequestStatus {
     Display,
     EnumString,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 pub enum PromotionDecision {
     ApproveAsReplacement,
@@ -963,7 +948,6 @@ pub struct PromotionRequest {
     Ord,
     JsonSchema,
 )]
-#[serde(rename_all = "camelCase")]
 pub enum KnowledgeLayer {
     Company,
     Org,
@@ -1028,7 +1012,6 @@ impl From<MemoryLayer> for Option<KnowledgeLayer> {
     strum::Display,
     strum::EnumString,
 )]
-#[serde(rename_all = "camelCase")]
 pub enum ConstraintSeverity {
     Info,
     Warn,
@@ -1037,7 +1020,6 @@ pub enum ConstraintSeverity {
 
 /// Constraint operators
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, ToSchema)]
-#[serde(rename_all = "camelCase")]
 pub enum ConstraintOperator {
     MustUse,
     MustNotUse,
@@ -1049,7 +1031,6 @@ pub enum ConstraintOperator {
 
 /// Constraint targets
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, ToSchema)]
-#[serde(rename_all = "camelCase")]
 pub enum ConstraintTarget {
     File,
     Code,
@@ -1073,7 +1054,6 @@ pub enum ConstraintTarget {
     strum::Display,
     ToSchema,
 )]
-#[serde(rename_all = "camelCase")]
 pub enum MemoryLayer {
     Agent,
     User,
@@ -1134,7 +1114,6 @@ pub struct LayerIdentifiers {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, ToSchema)]
-#[serde(rename_all = "camelCase")]
 pub enum SummaryDepth {
     Sentence,
     Paragraph,
@@ -1223,7 +1202,6 @@ pub struct HindsightNote {
     Display,
     EnumString,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]
 pub enum ReasoningStrategy {
     Exhaustive,
@@ -1327,7 +1305,6 @@ pub fn compute_xxhash64(data: &[u8]) -> String {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, JsonSchema)]
-#[serde(rename_all = "camelCase")]
 pub enum MemoryOperation {
     Add,
     Update,
@@ -1352,7 +1329,6 @@ pub enum MemoryOperation {
     Display,
     EnumString,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]
 pub enum RewardType {
     Helpful,
@@ -1543,7 +1519,6 @@ pub struct KnowledgeQueryResult {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, Default, ToSchema,
 )]
-#[serde(rename_all = "camelCase")]
 pub enum PolicyMode {
     #[default]
     Optional,
@@ -1553,7 +1528,6 @@ pub enum PolicyMode {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, Default, ToSchema,
 )]
-#[serde(rename_all = "camelCase")]
 pub enum RuleMergeStrategy {
     #[default]
     Override,
@@ -1564,7 +1538,6 @@ pub enum RuleMergeStrategy {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, Default, ToSchema,
 )]
-#[serde(rename_all = "camelCase")]
 pub enum RuleType {
     #[default]
     Allow,
@@ -1657,7 +1630,6 @@ pub struct BootstrapStatusSnapshot {
 
 /// Governance event types for auditing and real-time updates
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
 pub enum GovernanceEvent {
     /// New organizational unit created
     UnitCreated {
@@ -4746,7 +4718,6 @@ mod tests {
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, EnumString, Display,
 )]
-#[serde(rename_all = "camelCase")]
 #[strum(ascii_case_insensitive)]
 pub enum GitProviderKind {
     GitHubApp,

--- a/packages/opencode-plugin/package-lock.json
+++ b/packages/opencode-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aeterna-org/opencode-plugin",
-  "version": "0.8.0-rc.5",
+  "version": "0.8.0-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aeterna-org/opencode-plugin",
-      "version": "0.8.0-rc.5",
+      "version": "0.8.0-rc.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencode-ai/plugin": "1.3.6",

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeterna-org/opencode-plugin",
-  "version": "0.8.0-rc.5",
+  "version": "0.8.0-rc.6",
   "description": "OpenCode plugin for Aeterna memory and knowledge integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/storage/migrations/014_grepai_repo_management.sql
+++ b/storage/migrations/014_grepai_repo_management.sql
@@ -141,13 +141,15 @@ SELECT
     current_branch
 FROM codesearch_repositories;
 
+-- Note: tenant_id is not on codesearch_requests; the view is rebuilt with a
+-- JOIN to codesearch_repositories in migration 020. Keep this base view free
+-- of tenant_id so 014 can apply on a fresh DB.
 CREATE OR REPLACE VIEW v_code_search_requests AS
 SELECT
     id,
     repository_id,
     requester_id,
-    status,
-    tenant_id
+    status
 FROM codesearch_requests;
 
 CREATE OR REPLACE VIEW v_code_search_identities AS

--- a/storage/migrations/025_add_app_roles.sql
+++ b/storage/migrations/025_add_app_roles.sql
@@ -123,7 +123,9 @@ TO aeterna_app;
 -- --------------------------------------------------------------------------
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO aeterna_admin;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
+-- Defaults must attach to the table-creating role (aeterna), not whichever
+-- role happens to run this migration (which may be postgres in bootstrap).
+ALTER DEFAULT PRIVILEGES FOR ROLE aeterna IN SCHEMA public
     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO aeterna_admin;
 
 -- --------------------------------------------------------------------------
@@ -131,7 +133,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
 -- --------------------------------------------------------------------------
 
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO aeterna_app, aeterna_admin;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
+ALTER DEFAULT PRIVILEGES FOR ROLE aeterna IN SCHEMA public
     GRANT USAGE, SELECT ON SEQUENCES TO aeterna_app, aeterna_admin;
 
 -- --------------------------------------------------------------------------

--- a/storage/migrations/029_agents_tenant_scope.sql
+++ b/storage/migrations/029_agents_tenant_scope.sql
@@ -112,7 +112,9 @@ END $$;
 
 UPDATE agents a SET tenant_id = sub.tenant_id
 FROM (
-    SELECT a.id AS agent_id, MIN(c.tenant_id) AS tenant_id
+    -- Postgres has no min(uuid) aggregate. Step 2's audit guarantees at most
+-- one distinct tenant per agent, so any element of the array is correct.
+SELECT a.id AS agent_id, (array_agg(c.tenant_id))[1] AS tenant_id
     FROM agents a
     JOIN companies c ON c.deleted_at IS NULL AND (
         c.id = ANY(a.allowed_company_ids)

--- a/storage/src/postgres.rs
+++ b/storage/src/postgres.rs
@@ -3172,11 +3172,21 @@ impl StorageBackend for PostgresBackend {
         &self,
         event: mk_core::types::PersistentEvent,
     ) -> Result<(), Self::Error> {
+        // NOTE: `event.id` is a `String` (UUID v4 stringified by
+        // `PersistentEvent::new`) but the `governance_events.id` column is
+        // `uuid NOT NULL`. Postgres does not implicitly cast text → uuid, so
+        // we make the cast explicit with `$1::uuid`. Without this, every
+        // INSERT (e.g. the post-bootstrap `BootstrapCompleted` emission in
+        // `cli/src/commands/serve.rs::emit_bootstrap_completed`) fails with
+        // `column "id" is of type uuid but expression is of type text` and
+        // the event is silently dropped — `/admin/bootstrap/status` is the
+        // primary readout, so the server keeps running, but the durable
+        // governance trail is incomplete. See rc.6 release notes.
         sqlx::query(
             "INSERT INTO governance_events (id, event_id, idempotency_key, tenant_id, event_type, \
              payload, status, retry_count, max_retries, last_error, created_at, published_at, \
              acknowledged_at, dead_lettered_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, to_timestamp($11), $12, $13, $14)
+             VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8, $9, $10, to_timestamp($11), $12, $13, $14)
              ON CONFLICT (idempotency_key) DO NOTHING",
         )
         .bind(&event.id)

--- a/sync/src/conflict.rs
+++ b/sync/src/conflict.rs
@@ -17,7 +17,6 @@ pub enum ConflictError {
 pub type ConflictResult<T> = Result<T, ConflictError>;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "camelCase")]
 pub enum ConflictStrategy {
     OperationalTransform,
     LastWriteWins,
@@ -33,7 +32,6 @@ impl std::fmt::Display for ConflictStrategy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
 pub enum OperationType {
     Insert,
     Update,

--- a/sync/src/events.rs
+++ b/sync/src/events.rs
@@ -2,7 +2,6 @@ use mk_core::types::{MemoryLayer, SummaryDepth};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
 pub enum SummarySyncEvent {
     Created(SummaryCreated),
     Updated(SummaryUpdated),
@@ -35,7 +34,6 @@ pub struct SummaryUpdated {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
 pub enum SummaryUpdateReason {
     SourceContentChanged,
     ConfigurationChanged,
@@ -56,7 +54,6 @@ pub struct SummaryInvalidated {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
 pub enum InvalidationReason {
     SourceContentChanged {
         previous_hash: String,
@@ -84,7 +81,6 @@ pub struct SummaryDeleted {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
 pub enum DeletionReason {
     SourceDeleted,
     LayerPruned,
@@ -101,7 +97,6 @@ pub struct HindsightSyncEvent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
 pub enum HindsightEventType {
     ErrorSignatureCreated {
         signature_id: String,

--- a/sync/src/live_updates.rs
+++ b/sync/src/live_updates.rs
@@ -48,7 +48,6 @@ pub enum UpdateEvent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
 pub enum KnowledgeChangeType {
     Created,
     Updated,
@@ -57,7 +56,6 @@ pub enum KnowledgeChangeType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
 pub enum PolicyAction {
     Created,
     Updated,

--- a/sync/src/presence.rs
+++ b/sync/src/presence.rs
@@ -24,7 +24,6 @@ pub enum PresenceError {
 pub type PresenceResult<T> = Result<T, PresenceError>;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "camelCase")]
 pub enum PresenceState {
     Online,
     Away,

--- a/tests/tenant_provisioning/scenarios/03-rotate-reference.json
+++ b/tests/tenant_provisioning/scenarios/03-rotate-reference.json
@@ -16,13 +16,13 @@
     "fields": {
       "default_embedding_model": {
         "value": "text-embedding-3-small",
-        "ownership": "tenant"
+        "ownership": "Tenant"
       }
     },
     "secretReferences": {
       "webhook-signing-key": {
         "logicalName": "webhook-signing-key",
-        "ownership": "tenant",
+        "ownership": "Tenant",
         "kind": "k8s",
         "name": "acme-webhook-secrets",
         "key": "signing-key",

--- a/tests/tenant_provisioning/scenarios/04-noop-reapply.json
+++ b/tests/tenant_provisioning/scenarios/04-noop-reapply.json
@@ -16,13 +16,13 @@
     "fields": {
       "default_embedding_model": {
         "value": "text-embedding-3-small",
-        "ownership": "tenant"
+        "ownership": "Tenant"
       }
     },
     "secretReferences": {
       "webhook-signing-key": {
         "logicalName": "webhook-signing-key",
-        "ownership": "tenant",
+        "ownership": "Tenant",
         "kind": "k8s",
         "name": "acme-webhook-secrets",
         "key": "signing-key",

--- a/tests/tenant_provisioning/scenarios/05-prune.json
+++ b/tests/tenant_provisioning/scenarios/05-prune.json
@@ -16,13 +16,13 @@
     "fields": {
       "default_embedding_model": {
         "value": "text-embedding-3-small",
-        "ownership": "tenant"
+        "ownership": "Tenant"
       }
     },
     "secretReferences": {
       "webhook-signing-key": {
         "logicalName": "webhook-signing-key",
-        "ownership": "tenant",
+        "ownership": "Tenant",
         "kind": "k8s",
         "name": "acme-webhook-secrets",
         "key": "signing-key",

--- a/tools/src/knowledge.rs
+++ b/tools/src/knowledge.rs
@@ -314,7 +314,6 @@ pub struct KnowledgeProposal {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub enum KnowledgeProposalStatus {
     Draft,
     Pending,
@@ -337,7 +336,6 @@ pub struct KnowledgeDraft {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub enum KnowledgeDraftStatus {
     Draft,
     Validated,

--- a/tools/src/memory.rs
+++ b/tools/src/memory.rs
@@ -53,7 +53,6 @@ pub struct MemoryDeleteParams {
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
-#[serde(rename_all = "camelCase")]
 pub enum CloseTarget {
     Session,
     Agent,

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "website",
-  "version": "0.8.0-rc.5",
+  "version": "0.8.0-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "website",
-      "version": "0.8.0-rc.5",
+      "version": "0.8.0-rc.6",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.8.0-rc.5",
+  "version": "0.8.0-rc.6",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
# Adopt PascalCase enum convention on the wire (k8s-style)

Fixes a hierarchy-creation regression where `/admin/api/orgs/_taxonomy` returned
empty `companies: []` because the server emitted enum values in camelCase
(`"company"`) while the same code filtered them in PascalCase (`"Company"`).
User-visible symptom: every "Create Organization / Team / Project" form in the
admin UI showed an empty parent dropdown, making hierarchy management impossible
for any deployment that had populated tenants.

## TL;DR

| Layer | Before | After |
|---|---|---|
| Struct fields | camelCase (`#[serde(rename_all = "camelCase")]`) | unchanged — still camelCase |
| Enum variants | camelCase (single-word collapse: `Tenant` → `tenant`, `RequirePullRequest` → `requirePullRequest`) | **PascalCase** (`Tenant`, `RequirePullRequest`) |

Matches Kubernetes `apiVersion: v1, kind: Pod, status: Running` — camelCase keys, PascalCase values.

## Three logical commits

### 1. `fix(storage): cast PersistentEvent.id text→uuid in governance_events insert`

Single-line SQL change in `storage/src/postgres.rs::insert_governance_event`: adds `$1::uuid` cast so the stringified UUID from `PersistentEvent::new` binds correctly to the `governance_events.id uuid NOT NULL` column. Without this, `BootstrapCompleted` events emitted by `cli/src/commands/serve.rs::emit_bootstrap_completed` were silently dropped — masked because `/admin/bootstrap/status` reads from `bootstrap_status`, not the event log.

### 2. `fix(test): hermetic CLI e2e helpers — scrub HOME so tests do not leak dev creds`

Latent test-isolation bug surfaced while validating commit 3. The `aeterna()` test helpers in `cli/tests/{cli_e2e_test, init_command_test, setup_and_codesearch_e2e_test}.rs` did not scrub the parent process environment before spawning the CLI under test. The `aeterna_mock()` variant called `env_clear()` but immediately re-injected the developer's real `HOME`.

Consequence: the spawned `aeterna` binary called `dirs::config_dir()` which on macOS returns `~/Library/Application Support/`, so it discovered the developer's real `credentials.toml` (written by any prior `aeterna auth login`) and used those credentials to make real HTTP calls to whatever server was configured. Tests that asserted on the `server_not_connected` no-config code path then failed with HTTP 401. Roughly 85 e2e tests were affected on any developer mac that had ever logged in.

CI runners were unaffected (fresh runner → no pre-existing config), which is why the bug was latent.

Fix: pin `HOME` to a sentinel path that has no aeterna config under any platform-specific subpath, `env_clear()` everything else (preserving `PATH` and `TMPDIR`). `aeterna_mock()` now layers its mock-server overrides on top of the hermetic base.

### 3. `feat(serde)!: PascalCase enum convention on the wire (k8s-style)`

Drops `#[serde(rename_all = "camelCase")]` from **42 enum derives across 7 source files**:

- `mk_core/src/types.rs` (29 derives — the bulk: roles, ownership, branch policy, credential kind, repository kind, governance status, audit action, etc.)
- `sync/src/conflict.rs` (2)
- `sync/src/events.rs` (5)
- `sync/src/live_updates.rs` (2)
- `sync/src/presence.rs` (1)
- `tools/src/knowledge.rs` (2)
- `tools/src/memory.rs` (1)

Struct field renames (`#[serde(rename_all = "camelCase")]` on `struct` items) are **untouched** — fields stay camelCase.

**Test fixture sweep** (45 substitutions, key-aware regex — only replaces values when paired with the right JSON key, no risk to unrelated `"type"` fields):

- `cli/src/server/manifest_hash.rs` — 2 sub
- `cli/src/server/tenant_api.rs` — 27 sub
- `cli/tests/server_runtime_test.rs` — 10 sub (`role`, `branchPolicy`, `unitType`)
- `tests/tenant_provisioning/scenarios/{03,04,05}*.json` — 6 sub across 3 files

## Verification

| Check | Result |
|---|---|
| `cargo check --workspace` | ✅ clean |
| `cargo test -p aeterna --tests` | ✅ **2,417 passed, 0 failed** |
|   └─ lib unit (978) | ✅ |
|   └─ integration unit (986) | ✅ |
|   └─ cli_e2e_test (309) | ✅ |
|   └─ init_command_test (11) | ✅ |
|   └─ setup_and_codesearch (68) | ✅ |
|   └─ misc (65) | ✅ |
| `cargo fmt --check` | ✅ clean |

## ⚠️ BREAKING CHANGE

Wire format for enum values changes from camelCase to PascalCase.

```diff
  POST /admin/api/orgs
- { "type": "company" }
+ { "type": "Company" }

  POST /admin/api/governance/role
- { "role": "tenantAdmin" }
+ { "role": "TenantAdmin" }

  POST /admin/api/tenant/repo-binding
- { "repository": { "kind": "gitHub" }, "credential": { "kind": "gitHubApp" }, "branch_policy": "requirePullRequest" }
+ { "repository": { "kind": "GitHub" }, "credential": { "kind": "GitHubApp" }, "branch_policy": "RequirePullRequest" }
```

### Migration path

1. **In-tree admin UI** (`aeterna-admin-ui`) — already uses PascalCase in its TS types. The bug was the server emitting camelCase. No UI change needed.
2. **Stored payloads** (cached governance audit entries serialized as JSON, etc.) — either backfill with a key-aware sed or re-fetch.
3. **External SDKs / integrations** — bump version, update docs.
4. **YAML tenant manifests** — update enum values to PascalCase before re-applying.

## Suggested rollout

This is a wire-format breaking change — cut as a new release candidate (e.g.
`v0.8.0-rc.7`) and verify that downstream consumers can wipe & re-bootstrap
before promoting to a stable tag.
