### PR TITLE
fix(test): align stale test assertions with PascalCase wire format (follow-up to #177)

### DIFF
--- a/cli/src/server/role_grants.rs
+++ b/cli/src/server/role_grants.rs
@@ -445,6 +445,8 @@ mod tests {
 
     #[test]
     fn test_resource_type_serialization() {
+        // Note: ResourceType deliberately uses #[serde(rename_all = "lowercase")] —
+        // a separate convention from the workspace-wide PascalCase enum default.
         let serialized = serde_json::to_string(&ResourceType::Organization).unwrap();
         assert_eq!(serialized, "\"organization\"");
 

--- a/memory/src/reasoning.rs
+++ b/memory/src/reasoning.rs
@@ -93,7 +93,7 @@ mod tests {
     #[tokio::test]
     async fn test_reasoning_logic() {
         let mut mock_llm = MockLlmService::new();
-        let plan_json = "{\"strategy\": \"exhaustive\", \"refined_query\": \"deep search for \
+        let plan_json = "{\"strategy\": \"Exhaustive\", \"refined_query\": \"deep search for \
                          memory-r1 architecture\", \"reasoning\": \"The query is specific and \
                          complex, requiring cross-layer verification.\"}";
         mock_llm.set_response(plan_json).await;

--- a/mk_core/src/types.rs
+++ b/mk_core/src/types.rs
@@ -2552,7 +2552,7 @@ mod tests {
     fn test_knowledge_type_serialization() {
         let adr = KnowledgeType::Adr;
         let json = serde_json::to_string(&adr).unwrap();
-        assert_eq!(json, "\"adr\"");
+        assert_eq!(json, "\"Adr\"");
 
         let deserialized: KnowledgeType = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, KnowledgeType::Adr);
@@ -2562,7 +2562,7 @@ mod tests {
     fn test_knowledge_layer_serialization() {
         let company = KnowledgeLayer::Company;
         let json = serde_json::to_string(&company).unwrap();
-        assert_eq!(json, "\"company\"");
+        assert_eq!(json, "\"Company\"");
 
         let deserialized: KnowledgeLayer = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, KnowledgeLayer::Company);
@@ -2580,7 +2580,7 @@ mod tests {
     fn test_knowledge_status_serialization_includes_rejected() {
         let rejected = KnowledgeStatus::Rejected;
         let json = serde_json::to_string(&rejected).unwrap();
-        assert_eq!(json, "\"rejected\"");
+        assert_eq!(json, "\"Rejected\"");
 
         let deserialized: KnowledgeStatus = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, KnowledgeStatus::Rejected);
@@ -2718,7 +2718,7 @@ mod tests {
     fn test_memory_layer_serialization() {
         let agent = MemoryLayer::Agent;
         let json = serde_json::to_string(&agent).unwrap();
-        assert_eq!(json, "\"agent\"");
+        assert_eq!(json, "\"Agent\"");
 
         let deserialized: MemoryLayer = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, MemoryLayer::Agent);
@@ -2728,7 +2728,7 @@ mod tests {
     fn test_constraint_severity_serialization() {
         let block = ConstraintSeverity::Block;
         let json = serde_json::to_string(&block).unwrap();
-        assert_eq!(json, "\"block\"");
+        assert_eq!(json, "\"Block\"");
 
         let deserialized: ConstraintSeverity = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, ConstraintSeverity::Block);
@@ -2738,7 +2738,7 @@ mod tests {
     fn test_constraint_operator_serialization() {
         let must_use = ConstraintOperator::MustUse;
         let json = serde_json::to_string(&must_use).unwrap();
-        assert_eq!(json, "\"mustUse\"");
+        assert_eq!(json, "\"MustUse\"");
 
         let deserialized: ConstraintOperator = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, ConstraintOperator::MustUse);
@@ -2748,7 +2748,7 @@ mod tests {
     fn test_constraint_target_serialization() {
         let file = ConstraintTarget::File;
         let json = serde_json::to_string(&file).unwrap();
-        assert_eq!(json, "\"file\"");
+        assert_eq!(json, "\"File\"");
 
         let deserialized: ConstraintTarget = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, ConstraintTarget::File);
@@ -3021,7 +3021,7 @@ mod tests {
     fn test_role_serialization() {
         let architect = Role::Architect;
         let json = serde_json::to_string(&architect).unwrap();
-        assert_eq!(json, "\"architect\"");
+        assert_eq!(json, "\"Architect\"");
 
         let deserialized: Role = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, Role::Architect);
@@ -3043,7 +3043,7 @@ mod tests {
     fn test_reasoning_strategy_serialization() {
         let exhaustive = ReasoningStrategy::Exhaustive;
         let json = serde_json::to_string(&exhaustive).unwrap();
-        assert_eq!(json, "\"exhaustive\"");
+        assert_eq!(json, "\"Exhaustive\"");
 
         let deserialized: ReasoningStrategy = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, ReasoningStrategy::Exhaustive);
@@ -3764,26 +3764,26 @@ mod tests {
     fn test_summary_depth_serialization() {
         let sentence = SummaryDepth::Sentence;
         let json = serde_json::to_string(&sentence).unwrap();
-        assert_eq!(json, "\"sentence\"");
+        assert_eq!(json, "\"Sentence\"");
 
         let paragraph = SummaryDepth::Paragraph;
         let json = serde_json::to_string(&paragraph).unwrap();
-        assert_eq!(json, "\"paragraph\"");
+        assert_eq!(json, "\"Paragraph\"");
 
         let detailed = SummaryDepth::Detailed;
         let json = serde_json::to_string(&detailed).unwrap();
-        assert_eq!(json, "\"detailed\"");
+        assert_eq!(json, "\"Detailed\"");
     }
 
     #[test]
     fn test_summary_depth_deserialization() {
-        let sentence: SummaryDepth = serde_json::from_str("\"sentence\"").unwrap();
+        let sentence: SummaryDepth = serde_json::from_str("\"Sentence\"").unwrap();
         assert_eq!(sentence, SummaryDepth::Sentence);
 
-        let paragraph: SummaryDepth = serde_json::from_str("\"paragraph\"").unwrap();
+        let paragraph: SummaryDepth = serde_json::from_str("\"Paragraph\"").unwrap();
         assert_eq!(paragraph, SummaryDepth::Paragraph);
 
-        let detailed: SummaryDepth = serde_json::from_str("\"detailed\"").unwrap();
+        let detailed: SummaryDepth = serde_json::from_str("\"Detailed\"").unwrap();
         assert_eq!(detailed, SummaryDepth::Detailed);
     }
 
@@ -4341,7 +4341,7 @@ mod tests {
     fn test_knowledge_type_hindsight_variant() {
         let hindsight = KnowledgeType::Hindsight;
         let json = serde_json::to_string(&hindsight).unwrap();
-        assert_eq!(json, "\"hindsight\"");
+        assert_eq!(json, "\"Hindsight\"");
 
         let parsed: KnowledgeType = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, KnowledgeType::Hindsight);
@@ -4507,7 +4507,7 @@ mod tests {
         fn test_role_identifier_serde_roundtrip_known_variant_expected() {
             let role = RoleIdentifier::Known(Role::Admin);
             let json = serde_json::to_string(&role).unwrap();
-            assert_eq!(json, "\"admin\"");
+            assert_eq!(json, "\"Admin\"");
 
             let deserialized: RoleIdentifier = serde_json::from_str(&json).unwrap();
             assert_eq!(deserialized, RoleIdentifier::Known(Role::Admin));

--- a/storage/src/redis.rs
+++ b/storage/src/redis.rs
@@ -282,6 +282,9 @@ impl RedisStorage {
         entry_id: &str,
         depth: &mk_core::types::SummaryDepth,
     ) -> String {
+        // Force lowercase on both layer and depth so cache keys stay stable
+        // across the PascalCase wire-format refactor. Cache values are ephemeral
+        // but key collisions across format changes would still flush prematurely.
         format!(
             "summary:{}:{}:{}:{}",
             tenant_id,
@@ -290,6 +293,7 @@ impl RedisStorage {
             serde_json::to_string(depth)
                 .unwrap_or_else(|_| "unknown".to_string())
                 .trim_matches('"')
+                .to_lowercase()
         )
     }
 

--- a/tools/src/governance.rs
+++ b/tools/src/governance.rs
@@ -1815,9 +1815,9 @@ mod tests {
                 "policy": {
                     "id": "pol-1",
                     "name": "Test Policy",
-                    "layer": "team",
-                    "mode": "mandatory",
-                    "merge_strategy": "merge",
+                    "layer": "Team",
+                    "mode": "Mandatory",
+                    "merge_strategy": "Merge",
                     "rules": [],
                     "metadata": {}
                 },

--- a/tools/src/redis_publisher.rs
+++ b/tools/src/redis_publisher.rs
@@ -529,9 +529,9 @@ mod tests {
         };
 
         let json = serde_json::to_string(&event).unwrap();
-        // GovernanceEvent uses rename_all = "camelCase" so it serializes as
-        // "unitCreated"
-        assert!(json.contains("unitCreated"));
+        // GovernanceEvent uses serde default (PascalCase) so it serializes as
+        // "UnitCreated"
+        assert!(json.contains("UnitCreated"));
         assert!(json.contains("test-tenant"));
         assert!(json.contains("unit-1"));
 
@@ -678,8 +678,8 @@ mod tests {
         };
 
         let json = serde_json::to_string(&event).unwrap();
-        // GovernanceEvent uses rename_all = "camelCase"
-        assert!(json.contains("driftDetected"));
+        // GovernanceEvent uses serde default (PascalCase)
+        assert!(json.contains("DriftDetected"));
         assert!(json.contains("project-123"));
         assert!(json.contains("0.75"));
 


### PR DESCRIPTION
# Align stale test assertions with PascalCase wire format

Follow-up to #177 (`feat(serde)!: PascalCase enum convention on the wire`).
Six test files had assertions / fixtures predating the wire-format refactor
and were rejected by `cargo test --workspace --lib`. CI surfaced these on
#177 because the workspace-level `unit-tests` job runs broader than the
`-p aeterna --tests` set used during local validation. The merge of #177
landed with the workspace tests in this red state — this PR makes them green
before we cut `v0.8.0-rc.7`.

## Fixes

| File | Change |
|---|---|
| `mk_core/src/types.rs` | 12 inline `test_*_serialization` tests + `role_identifier_tests` — expected strings updated from camelCase → PascalCase (`agent`/`Agent`, `adr`/`Adr`, `architect`/`Architect`, `exhaustive`/`Exhaustive`, `mustUse`/`MustUse`, `block`/`Block`, `file`/`File`, `company`/`Company`, `rejected`/`Rejected`, `hindsight`/`Hindsight`, `sentence`/`Sentence`, `paragraph`/`Paragraph`, `detailed`/`Detailed`, `admin`/`Admin`). |
| `tools/src/redis_publisher.rs` | 2 tests — `GovernanceEvent` is serde-default so it serializes as `"UnitCreated"` / `"DriftDetected"`, not the camelCase forms the assertions expected. Misleading `// uses rename_all = "camelCase"` comments removed. |
| `tools/src/governance.rs` | `unit_policy.add` JSON fixture — `"layer": "team"`, `"mode": "mandatory"`, `"merge_strategy": "merge"` → PascalCase counterparts. |
| `memory/src/reasoning.rs` | Mock LLM plan fixture in `test_reasoning_logic` — `{"strategy": "exhaustive"}` → `"Exhaustive"`. |
| `storage/src/redis.rs` | `summary_cache_key` — the depth segment now goes through `.to_lowercase()` so cache keys remain stable across the refactor. Without this, `Sentence`/`Paragraph`/`Detailed` would change cache key shape and silently invalidate every cached summary on upgrade. The layer segment was already lowercased; depth now matches. |
| `cli/src/server/role_grants.rs` | Reverted accidental edit — `ResourceType` is deliberately `#[serde(rename_all = "lowercase")]` (a separate convention from the workspace-wide PascalCase default). Test restored to expect `"organization"` / `"session"`. Comment added to flag the intentional divergence. |

## Verification

Local: `cargo test --workspace --lib --no-fail-fast`

```
Suites OK: 19  Suites FAILED: 0
Total passed: 3144  Total failed: 0
```

Was 17 failures across `mk_core`, `tools`, `memory`, `cli` before this commit.

## Why this got missed in #177

During #177 development, local validation used `cargo test -p aeterna --tests`
which excludes `mk_core::tests::*`, `tools::tests::*`, `memory::tests::*`, and
`storage::tests::*` (those run against their owning crates). CI's `unit-tests`
job is workspace-wide and caught all of them. Lesson learned for the post-mortem.
