### PR TITLE
release: v0.8.0-rc.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "adapters"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aeterna"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "adapters",
  "aeterna-backup",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "agent-a2a"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "a2a-types",
  "anyhow",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "anyhow",
  "errors",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "context"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "backoff",
  "chrono",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "cross-tests"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "chrono",
  "memory",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "errors"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "idp-sync"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4806,7 +4806,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memory"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "aisdk",
  "anyhow",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "mk_core"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5407,7 +5407,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opal-fetcher"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8001,7 +8001,7 @@ dependencies = [
 
 [[package]]
 name = "storage"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "adapters",
  "aes-gcm",
@@ -8175,7 +8175,7 @@ dependencies = [
 
 [[package]]
 name = "sync"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8354,7 +8354,7 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8758,7 +8758,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "adapters",
  "anyhow",
@@ -9255,7 +9255,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 # - `.github/workflows/version-consistency.yml` enforces that all those
 #   surfaces agree on every PR and on every tag push.
 [workspace.package]
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 
 [workspace.lints.rust]
 unused_imports = "warn"

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin-ui",
-  "version": "0.8.0-rc.7",
+  "version": "0.8.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-ui",
-      "version": "0.8.0-rc.7",
+      "version": "0.8.0-rc.8",
       "dependencies": {
         "@tanstack/react-query": "^5.62.0",
         "class-variance-authority": "^0.7.1",

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-ui",
   "private": true,
-  "version": "0.8.0-rc.7",
+  "version": "0.8.0-rc.8",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/charts/aeterna-prereqs/Chart.yaml
+++ b/charts/aeterna-prereqs/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   Redis-compatible cache (Dragonfly or Valkey), and vector store (Qdrant)
   for development and testing environments.
 type: application
-version: 0.8.0-rc.7
-appVersion: "0.8.0-rc.7"
+version: 0.8.0-rc.8
+appVersion: "0.8.0-rc.8"
 
 home: https://github.com/kikokikok/aeterna
 sources:

--- a/charts/aeterna/Chart.yaml
+++ b/charts/aeterna/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   stack, and supporting jobs. Requires external PostgreSQL, Redis-compatible
   cache, and vector store. Use the aeterna-prereqs chart for dev/test backends.
 type: application
-version: 0.8.0-rc.7
-appVersion: "0.8.0-rc.7"
+version: 0.8.0-rc.8
+appVersion: "0.8.0-rc.8"
 
 home: https://github.com/kikokikok/aeterna
 icon: https://raw.githubusercontent.com/kikokikok/aeterna/main/docs/logo.png

--- a/deploy/helm/aeterna-opal/Chart.yaml
+++ b/deploy/helm/aeterna-opal/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aeterna-opal
 description: OPAL Authorization Stack for Aeterna Memory-Knowledge System
 type: application
-version: 0.8.0-rc.7
-appVersion: "0.8.0-rc.7"
+version: 0.8.0-rc.8
+appVersion: "0.8.0-rc.8"
 keywords:
   - opal
   - cedar

--- a/packages/opencode-plugin/package-lock.json
+++ b/packages/opencode-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aeterna-org/opencode-plugin",
-  "version": "0.8.0-rc.7",
+  "version": "0.8.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aeterna-org/opencode-plugin",
-      "version": "0.8.0-rc.7",
+      "version": "0.8.0-rc.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencode-ai/plugin": "1.3.6",

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeterna-org/opencode-plugin",
-  "version": "0.8.0-rc.7",
+  "version": "0.8.0-rc.8",
   "description": "OpenCode plugin for Aeterna memory and knowledge integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "website",
-  "version": "0.8.0-rc.7",
+  "version": "0.8.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "website",
-      "version": "0.8.0-rc.7",
+      "version": "0.8.0-rc.8",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.8.0-rc.7",
+  "version": "0.8.0-rc.8",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
Cuts rc.8 with the rc.7 provisioning fix-pack rolled in. See commit message for the full change list. Merging this PR will trigger version-consistency.yml; the v0.8.0-rc.8 tag is pushed immediately after merge.