### PR TITLE
release: 0.8.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "adapters"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aeterna"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "adapters",
  "aeterna-backup",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "agent-a2a"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "a2a-types",
  "anyhow",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "anyhow",
  "errors",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "context"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "backoff",
  "chrono",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "cross-tests"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "chrono",
  "memory",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "errors"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "idp-sync"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4453,7 +4453,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4905,7 +4905,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memory"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "aisdk",
  "anyhow",
@@ -5070,7 +5070,7 @@ dependencies = [
 
 [[package]]
 name = "mk_core"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5432,7 +5432,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5512,7 +5512,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opal-fetcher"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8154,7 +8154,7 @@ dependencies = [
 
 [[package]]
 name = "storage"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "adapters",
  "aes-gcm",
@@ -8333,7 +8333,7 @@ dependencies = [
 
 [[package]]
 name = "sync"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8512,7 +8512,7 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8927,7 +8927,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "adapters",
  "anyhow",
@@ -9424,7 +9424,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 # - `.github/workflows/version-consistency.yml` enforces that all those
 #   surfaces agree on every PR and on every tag push.
 [workspace.package]
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 
 [workspace.lints.rust]
 unused_imports = "warn"

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin-ui",
-  "version": "0.8.0-rc.8",
+  "version": "0.8.0-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-ui",
-      "version": "0.8.0-rc.8",
+      "version": "0.8.0-rc.9",
       "dependencies": {
         "@tanstack/react-query": "^5.62.0",
         "class-variance-authority": "^0.7.1",

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-ui",
   "private": true,
-  "version": "0.8.0-rc.8",
+  "version": "0.8.0-rc.9",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/charts/aeterna-prereqs/Chart.yaml
+++ b/charts/aeterna-prereqs/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   Redis-compatible cache (Dragonfly or Valkey), and vector store (Qdrant)
   for development and testing environments.
 type: application
-version: 0.8.0-rc.8
-appVersion: "0.8.0-rc.8"
+version: 0.8.0-rc.9
+appVersion: "0.8.0-rc.9"
 
 home: https://github.com/kikokikok/aeterna
 sources:

--- a/charts/aeterna/Chart.yaml
+++ b/charts/aeterna/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   stack, and supporting jobs. Requires external PostgreSQL, Redis-compatible
   cache, and vector store. Use the aeterna-prereqs chart for dev/test backends.
 type: application
-version: 0.8.0-rc.8
-appVersion: "0.8.0-rc.8"
+version: 0.8.0-rc.9
+appVersion: "0.8.0-rc.9"
 
 home: https://github.com/kikokikok/aeterna
 icon: https://raw.githubusercontent.com/kikokikok/aeterna/main/docs/logo.png

--- a/deploy/helm/aeterna-opal/Chart.yaml
+++ b/deploy/helm/aeterna-opal/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aeterna-opal
 description: OPAL Authorization Stack for Aeterna Memory-Knowledge System
 type: application
-version: 0.8.0-rc.8
-appVersion: "0.8.0-rc.8"
+version: 0.8.0-rc.9
+appVersion: "0.8.0-rc.9"
 keywords:
   - opal
   - cedar

--- a/packages/opencode-plugin/package-lock.json
+++ b/packages/opencode-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aeterna-org/opencode-plugin",
-  "version": "0.8.0-rc.8",
+  "version": "0.8.0-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aeterna-org/opencode-plugin",
-      "version": "0.8.0-rc.8",
+      "version": "0.8.0-rc.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencode-ai/plugin": "1.3.6",

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeterna-org/opencode-plugin",
-  "version": "0.8.0-rc.8",
+  "version": "0.8.0-rc.9",
   "description": "OpenCode plugin for Aeterna memory and knowledge integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "website",
-  "version": "0.8.0-rc.8",
+  "version": "0.8.0-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "website",
-      "version": "0.8.0-rc.8",
+      "version": "0.8.0-rc.9",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.8.0-rc.8",
+  "version": "0.8.0-rc.9",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
Automated version bump produced by \`.github/workflows/cut-release.yml\`.

## Checklist before merging
- [ ] \`Version Consistency\` check is green
- [ ] \`PR Fast Gate\` is green (unit tests, clippy, fmt, helm lint)
- [ ] \`PR Integration Gate\` is green (multi-arch docker build + shipped-smoke)
- [ ] CHANGELOG / release notes are ready (release.yml auto-generates from commits)

## After merge
\`\`\`
git checkout master && git pull
git tag v0.8.0-rc.9
git push origin v0.8.0-rc.9
\`\`\`
That tag push triggers \`release.yml\` which builds, signs (cosign),
packages helm charts, builds CLI binaries for 4 targets, and opens
the GitHub Release with all assets attached.