### PR TITLE
fix: resolve 6 runtime bugs from PRs #181/#182/#183 audit

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -102,7 +102,7 @@ jobs:
     # First build after a cold cache is ~30 min (full Rust release build).
     # After post-merge.yml seeds ghcr.io/{repo}-cache:buildcache-master-{arch},
     # subsequent PR builds pull warm layers and finish in <10 min.
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/cli/src/server/lifecycle.rs
+++ b/cli/src/server/lifecycle.rs
@@ -286,7 +286,7 @@ async fn run_retention_purge(state: &AppState) {
     // 4. Purge old governance events past retention (default 180 days)
     let cutoff_secs = i64::from(config.governance_event_days) * 86400;
     let cutoff = chrono::Utc::now().timestamp() - cutoff_secs;
-    match sqlx::query("DELETE FROM governance_events WHERE created_at < $1")
+    match sqlx::query("DELETE FROM governance_events WHERE created_at < to_timestamp($1)")
         .bind(cutoff)
         .execute(state.postgres.pool())
         .await
@@ -307,7 +307,7 @@ async fn run_retention_purge(state: &AppState) {
     // 5. Purge old drift results past retention (default 30 days)
     let cutoff_secs = i64::from(config.drift_result_days) * 86400;
     let cutoff = chrono::Utc::now().timestamp() - cutoff_secs;
-    match sqlx::query("DELETE FROM drift_results WHERE created_at < $1")
+    match sqlx::query("DELETE FROM drift_results WHERE timestamp < $1")
         .bind(cutoff)
         .execute(state.postgres.pool())
         .await

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -903,7 +903,7 @@ impl Default for GraphConfig {
             reader_pool_size: None,
             snapshot_full_interval_secs: default_graph_snapshot_full_interval_secs(),
             snapshot_delta_interval_secs: default_graph_snapshot_delta_interval_secs(),
-            event_sourcing_enabled: true,
+            event_sourcing_enabled: false,
             contention_alerts: ContentionAlertConfig::default(),
         }
     }

--- a/storage/migrations/035_organizational_units_timestamps.sql
+++ b/storage/migrations/035_organizational_units_timestamps.sql
@@ -1,0 +1,40 @@
+-- Migration 035: Align organizational_units timestamp columns with Rust types
+--
+-- The OrganizationalUnit struct uses DateTime<Utc> for created_at / updated_at,
+-- but the inline CREATE TABLE in initialize_schema() originally used BIGINT.
+-- Migration 009 already defines these columns as TIMESTAMPTZ in the referential
+-- DDL, so whichever ran first determined the actual column type.  This migration
+-- normalises any remaining BIGINT columns to TIMESTAMPTZ, converting existing
+-- epoch-seconds data with to_timestamp().
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'organizational_units'
+          AND column_name = 'created_at'
+          AND data_type = 'bigint'
+    ) THEN
+        ALTER TABLE organizational_units
+            ALTER COLUMN created_at TYPE TIMESTAMPTZ
+            USING to_timestamp(created_at);
+        ALTER TABLE organizational_units
+            ALTER COLUMN updated_at TYPE TIMESTAMPTZ
+            USING to_timestamp(updated_at);
+    END IF;
+END $$;
+
+-- Same fix for user_roles.created_at if it is still BIGINT.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'user_roles'
+          AND column_name = 'created_at'
+          AND data_type = 'bigint'
+    ) THEN
+        ALTER TABLE user_roles
+            ALTER COLUMN created_at TYPE TIMESTAMPTZ
+            USING to_timestamp(created_at);
+    END IF;
+END $$;

--- a/storage/src/migrations.rs
+++ b/storage/src/migrations.rs
@@ -192,6 +192,26 @@ pub const MIGRATIONS: &[EmbeddedMigration] = &[
         name: "031_provisioning_idempotency",
         sql: include_str!("../migrations/031_provisioning_idempotency.sql"),
     },
+    EmbeddedMigration {
+        version: 32,
+        name: "032_tenant_delete_cascade",
+        sql: include_str!("../migrations/032_tenant_delete_cascade.sql"),
+    },
+    EmbeddedMigration {
+        version: 33,
+        name: "033_tenant_legal_entity",
+        sql: include_str!("../migrations/033_tenant_legal_entity.sql"),
+    },
+    EmbeddedMigration {
+        version: 34,
+        name: "034_graph_events",
+        sql: include_str!("../migrations/034_graph_events.sql"),
+    },
+    EmbeddedMigration {
+        version: 35,
+        name: "035_organizational_units_timestamps",
+        sql: include_str!("../migrations/035_organizational_units_timestamps.sql"),
+    },
 ];
 
 /// Apply every embedded migration in order, transactionally.

--- a/storage/src/postgres.rs
+++ b/storage/src/postgres.rs
@@ -341,8 +341,8 @@ impl PostgresBackend {
                 parent_id TEXT REFERENCES organizational_units(id),
                 tenant_id TEXT NOT NULL,
                 metadata JSONB DEFAULT '{}',
-                created_at BIGINT NOT NULL,
-                updated_at BIGINT NOT NULL
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
             )",
         )
         .execute(&self.pool)
@@ -354,7 +354,7 @@ impl PostgresBackend {
                 tenant_id TEXT NOT NULL,
                 unit_id TEXT NOT NULL REFERENCES organizational_units(id),
                 role TEXT NOT NULL,
-                created_at BIGINT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 PRIMARY KEY (user_id, tenant_id, unit_id, role)
             )",
         )

--- a/storage/src/retention.rs
+++ b/storage/src/retention.rs
@@ -202,7 +202,7 @@ impl RetentionEnforcer {
         let interval = format!("{days} days");
 
         let result =
-            sqlx::query("DELETE FROM governance_events WHERE timestamp < NOW() - $1::interval")
+            sqlx::query("DELETE FROM governance_events WHERE created_at < NOW() - $1::interval")
                 .bind(&interval)
                 .execute(&self.pool)
                 .await?;
@@ -243,7 +243,7 @@ impl RetentionEnforcer {
         let interval = format!("{days} days");
 
         let result =
-            sqlx::query("DELETE FROM drift_results WHERE created_at < NOW() - $1::interval")
+            sqlx::query("DELETE FROM drift_results WHERE timestamp < EXTRACT(EPOCH FROM NOW() - $1::interval)::bigint")
                 .bind(&interval)
                 .execute(&self.pool)
                 .await?;
@@ -265,7 +265,7 @@ impl RetentionEnforcer {
         let result = sqlx::query(
             "DELETE FROM governance_events \
              WHERE event_type = 'knowledge_promotion_requested' \
-               AND timestamp < NOW() - $1::interval \
+               AND created_at < NOW() - $1::interval \
                AND (status = 'rejected' OR status = 'abandoned' OR status IS NULL)",
         )
         .bind(&interval)


### PR DESCRIPTION
## Summary

Fixes all 6 runtime bugs identified during the comprehensive audit of PRs #181, #182, #183.

- **Register migrations 032–034** in `MIGRATIONS` const — SQL files existed on disk but were never applied
- **Add migration 035** to convert `organizational_units` timestamps from BIGINT to TIMESTAMPTZ, aligning with the `DateTime<Utc>` struct fields introduced in PR #181
- **Update `initialize_schema()`** to use TIMESTAMPTZ for `organizational_units` and `user_roles` tables
- **Fix `lifecycle.rs`** drift_results query (wrong column name) and governance_events query (i64 bound to TIMESTAMPTZ without cast)
- **Fix `retention.rs`** — correct 3 queries using wrong column names for `governance_events` and `drift_results`
- **Align `event_sourcing_enabled`** default to `false` in `config.rs` (was `true`, contradicting `loader.rs`)

Closes #184