### PR TITLE
fix: bind DateTime<Utc> instead of i64 epoch to TIMESTAMPTZ columns

### DIFF
--- a/cli/src/server/auth_middleware.rs
+++ b/cli/src/server/auth_middleware.rs
@@ -542,7 +542,7 @@ mod tests {
         .bind(INSTANCE_SCOPE_TENANT_ID)
         .bind(&root_unit_id)
         .bind("platformadmin")
-        .bind(now)
+        .bind(chrono::Utc::now())
         .execute(backend.pool())
         .await
         .unwrap();

--- a/cli/src/server/bootstrap.rs
+++ b/cli/src/server/bootstrap.rs
@@ -1069,7 +1069,7 @@ async fn seed_platform_admin(
 
     let provider = &cfg.provider;
     let subject = cfg.provider_subject.as_deref().unwrap_or(email.as_str());
-    let now_epoch = chrono::Utc::now().timestamp();
+    let now_ts = chrono::Utc::now();
 
     let mut tx = pool.begin().await.context("begin seed transaction")?;
 
@@ -1080,7 +1080,7 @@ async fn seed_platform_admin(
     )
     .bind(INSTANCE_SCOPE_TENANT_ID)
     .bind("Instance")
-    .bind(now_epoch)
+    .bind(now_ts)
     .execute(&mut *tx)
     .await
     .context("upsert instance-scope organizational unit")?;
@@ -1106,7 +1106,7 @@ async fn seed_platform_admin(
     .bind(company_id)
     .bind("Default")
     .bind(company_id)
-    .bind(now_epoch)
+    .bind(now_ts)
     .execute(&mut *tx)
     .await
     .context("upsert organizational_units company")?;
@@ -1235,7 +1235,7 @@ async fn seed_platform_admin(
     .bind(&user_id_str)
     .bind(INSTANCE_SCOPE_TENANT_ID)
     .bind(INSTANCE_SCOPE_TENANT_ID)
-    .bind(now_epoch)
+    .bind(now_ts)
     .execute(&mut *tx)
     .await
     .context("upsert PlatformAdmin role")?;
@@ -1265,7 +1265,7 @@ async fn seed_k8s_service_account(
         None => return Ok(()),
     };
 
-    let now_epoch = chrono::Utc::now().timestamp();
+    let now_ts_k8s = chrono::Utc::now();
     let synthetic_email = format!("k8s+{}@local", sa_subject.replace([':', '/'], "."));
 
     let mut tx = pool
@@ -1280,7 +1280,7 @@ async fn seed_k8s_service_account(
     )
     .bind(INSTANCE_SCOPE_TENANT_ID)
     .bind("Instance")
-    .bind(now_epoch)
+    .bind(now_ts_k8s)
     .execute(&mut *tx)
     .await
     .context("upsert instance-scope organizational unit for k8s SA")?;
@@ -1312,7 +1312,7 @@ async fn seed_k8s_service_account(
     .bind(user_uuid.to_string())
     .bind(INSTANCE_SCOPE_TENANT_ID)
     .bind(INSTANCE_SCOPE_TENANT_ID)
-    .bind(now_epoch)
+    .bind(now_ts_k8s)
     .execute(&mut *tx)
     .await
     .context("upsert PlatformAdmin role for kubernetes service account")?;

--- a/cli/tests/tenant_provisioning_consistency_cli_test.rs
+++ b/cli/tests/tenant_provisioning_consistency_cli_test.rs
@@ -221,7 +221,7 @@ async fn seed_platform_admin_user(state: &AppState) {
     // Create a unit at INSTANCE_SCOPE_TENANT_ID so the user_roles FK
     // (unit_id → organizational_units.id) is satisfied.
     let root_unit_id = uuid::Uuid::new_v4().to_string();
-    let now = chrono::Utc::now().timestamp();
+    let now = chrono::Utc::now();
     state
         .postgres
         .create_unit(&OrganizationalUnit {

--- a/idp-sync/src/github.rs
+++ b/idp-sync/src/github.rs
@@ -900,7 +900,7 @@ impl GitHubHierarchyMapper {
         external_id: &str,
         slug: &str,
     ) -> IdpSyncResult<Uuid> {
-        let now_epoch = Utc::now().timestamp();
+        let now_ts = Utc::now();
         let new_id = Uuid::new_v4().to_string();
         let tenant_str = self.tenant_id.to_string();
         let parent_str = parent_id.map(|p| p.to_string());
@@ -925,7 +925,7 @@ impl GitHubHierarchyMapper {
         .bind(unit_type)
         .bind(&parent_str)
         .bind(external_id)
-        .bind(now_epoch)
+        .bind(now_ts)
         .bind(slug)
         .fetch_one(&self.db_pool)
         .await
@@ -1031,7 +1031,7 @@ pub async fn bridge_sync_to_governance(
                 team_ou.tenant_id,
                 team_ou.id,
                 m.role,
-                EXTRACT(EPOCH FROM NOW())::BIGINT
+                NOW()
             FROM users u
             JOIN memberships m ON m.user_id = u.id
             JOIN organizational_units team_ou ON team_ou.id = m.team_id::TEXT

--- a/storage/src/postgres.rs
+++ b/storage/src/postgres.rs
@@ -1639,7 +1639,7 @@ impl PostgresBackend {
         .bind(tenant_id.as_str())
         .bind(unit_id)
         .bind(role.to_string().to_lowercase())
-        .bind(chrono::Utc::now().timestamp())
+        .bind(chrono::Utc::now())
         .execute(&mut **tx)
         .await?;
         Ok(())

--- a/storage/tests/postgres_test.rs
+++ b/storage/tests/postgres_test.rs
@@ -370,7 +370,7 @@ async fn test_get_user_roles_for_auth_includes_instance_scope_and_deduplicates()
     let tenant_unit_id = unique_id("company");
     let root_unit_id = unique_id("instance");
     let user_id = unique_id("user");
-    let now = chrono::Utc::now().timestamp();
+    let now = chrono::Utc::now();
 
     backend
         .create_unit(&OrganizationalUnit {


### PR DESCRIPTION
## Summary

Migration 035 converted `organizational_units.created_at/updated_at` and `user_roles.created_at` from `BIGINT` to `TIMESTAMPTZ`, but raw SQL `INSERT` statements that bypass the typed `create_unit()` function still bound `i64` epoch values — causing runtime panics on bootstrap startup.

## Changes

- **`cli/src/server/bootstrap.rs`**: Replace `now_epoch` (i64) with `now_ts` (`DateTime<Utc>`) for all `organizational_units` and `user_roles` inserts in both `seed_platform_admin_user` and `seed_k8s_service_account` functions. Remove now-unused `now_epoch` variables.
- **`storage/src/postgres.rs`**: Fix `assign_role()` to bind `chrono::Utc::now()` instead of `.timestamp()`.
- **`idp-sync/src/github.rs`**: Fix `ensure_unit()` to bind `DateTime<Utc>` and replace `EXTRACT(EPOCH FROM NOW())::BIGINT` with `NOW()` in user_roles inline SQL.
- **`cli/src/server/auth_middleware.rs`**: Fix test helper to bind `chrono::Utc::now()` for user_roles insert.
- **`storage/tests/postgres_test.rs`**: Fix test to use `chrono::Utc::now()` for user_roles inserts.
- **`cli/tests/tenant_provisioning_consistency_cli_test.rs`**: Fix test to use `chrono::Utc::now()` for user_roles insert.

## Verification

- `cargo check` — zero errors, zero warnings
- `cargo check --tests` — zero errors, zero warnings