### PR TITLE
fix: return all unit types from GET /api/v1/org

### DIFF
--- a/cli/src/server/org_api.rs
+++ b/cli/src/server/org_api.rs
@@ -173,7 +173,6 @@ async fn list_orgs(
             return error_response(StatusCode::BAD_REQUEST, "org_list_failed", &err.to_string());
         }
     };
-    units.retain(|unit| unit.unit_type == UnitType::Organization);
     if !ctx.has_known_role(&Role::PlatformAdmin) {
         units.retain(|unit| unit.tenant_id == ctx.tenant_id);
     }
@@ -199,7 +198,6 @@ async fn list_orgs_cross_tenant(
             return error_response(StatusCode::BAD_REQUEST, "org_list_failed", &err.to_string());
         }
     };
-    units.retain(|unit| unit.unit_type == UnitType::Organization);
     if let Some(t) = single_tenant {
         units.retain(|unit| unit.tenant_id.as_str() == t.id.as_str());
     }
@@ -237,7 +235,7 @@ async fn list_orgs_cross_tenant(
                 "id":         unit.id,
                 "name":       unit.name,
                 "parentId":   unit.parent_id,
-                "unitType":   "organization",
+                "unitType":   unit.unit_type,
                 "tenantId":   unit.tenant_id,
                 "tenantSlug": t.map(|t| t.slug.clone()),
                 "tenantName": t.map(|t| t.name.clone()),


### PR DESCRIPTION
## Summary

The `GET /api/v1/org` endpoint filtered results to `UnitType::Organization` only. This caused the admin-ui's "Create Unit" dialog to show "No Company units available" in the parent picker — even when Companies existed — because they were stripped from the response.

## Fix

Remove the `units.retain(|unit| unit.unit_type == UnitType::Organization)` filter from both `list_orgs` and `list_orgs_cross_tenant`. The frontend org tree page already handles all unit types (Company, Organization, Team, Project) and uses client-side filtering for the parent picker.

Also fixed the cross-tenant response to serialize `unitType` from the actual unit type instead of hardcoding `"organization"`.